### PR TITLE
Add support for region and environments for oauth

### DIFF
--- a/packages/cli/jest.config.js
+++ b/packages/cli/jest.config.js
@@ -3,4 +3,5 @@ module.exports = {
   testEnvironment: 'node',
   verbose: true,
   collectCoverage: true,
+  clearMocks: true
 };

--- a/packages/cli/src/lib/platform/environment.spec.ts
+++ b/packages/cli/src/lib/platform/environment.spec.ts
@@ -1,0 +1,35 @@
+import {platformUrl} from './environment';
+
+describe('platformUrl helper', () => {
+  it('should return https://platform.cloud.coveo.com by default', () => {
+    expect(platformUrl()).toBe('https://platform.cloud.coveo.com');
+  });
+
+  it(`when the environment is prod
+    should not return it in the url e.g. https://platform.cloud.coveo.com`, () => {
+    expect(platformUrl({environment: 'prod'})).toBe(
+      'https://platform.cloud.coveo.com'
+    );
+  });
+
+  it(`when the environment is not prod
+    should return it in the url e.g. https://platformdev.cloud.coveo.com`, () => {
+    expect(platformUrl({environment: 'dev'})).toBe(
+      'https://platformdev.cloud.coveo.com'
+    );
+  });
+
+  it(`when the region is us-east-1
+    should not return it in the url e.g. https://platform.cloud.coveo.com`, () => {
+    expect(platformUrl({region: 'us-east-1'})).toBe(
+      'https://platform.cloud.coveo.com'
+    );
+  });
+
+  it(`when the region is not us-east-1
+    should return it in the url e.g. https://platform-us-west-2.cloud.coveo.com`, () => {
+    expect(platformUrl({region: 'us-west-2'})).toBe(
+      'https://platform-us-west-2.cloud.coveo.com'
+    );
+  });
+});

--- a/packages/cli/src/lib/platform/environment.ts
+++ b/packages/cli/src/lib/platform/environment.ts
@@ -1,0 +1,27 @@
+type PlatformCombination =
+  | {env: 'dev'; region: 'us-east-1' | 'eu-west-1' | 'eu-west-3'}
+  | {env: 'qa'; region: 'us-east-1' | 'eu-west-1' | 'ap-southeast-2'}
+  | {env: 'hipaa'; region: 'us-east-1'}
+  | {env: 'prod'; region: 'us-east-1' | 'us-west-2' | 'eu-west-1'};
+
+export type PlatformEnvironment = PlatformCombination['env'];
+export type PlatformRegion = Extract<
+  PlatformCombination,
+  {env: PlatformEnvironment}
+>['region'];
+
+export function platformUrl<E extends PlatformEnvironment = 'prod'>(options?: {
+  environment?: E;
+  region?: PlatformRegion;
+}) {
+  const urlEnv =
+    !options || !options.environment || options.environment === 'prod'
+      ? ''
+      : options.environment;
+  const urlRegion =
+    !options || !options.region || options.region === 'us-east-1'
+      ? ''
+      : `-${options.region}`;
+
+  return `https://platform${urlEnv}${urlRegion}.cloud.coveo.com`;
+}


### PR DESCRIPTION
The `platformUrl` function could also be used for all commands


https://coveord.atlassian.net/browse/CDX-36