### PR TITLE
fix(cli): ui:create:vue command not invoking @coveo/typescript correctly

### DIFF
--- a/packages/cli/src/commands/ui/create/vue.ts
+++ b/packages/cli/src/commands/ui/create/vue.ts
@@ -72,8 +72,8 @@ export default class Vue extends Command {
     const {providerUsername} = await this.getUserInfo();
 
     const cliArgs = [
-      'invoke',
-      '@coveo/vue-cli-plugin-typescript',
+      'add',
+      '@coveo/typescript',
       '--orgId',
       cfg.organization,
       '--apiKey',


### PR DESCRIPTION
The difference between add and invoke:

- `add [options] <plugin> [pluginOptions]`       install a plugin and invoke its generator in an already created project
- `invoke [options] <plugin> [pluginOptions]`  invoke the generator of a plugin in an already created project

Vue CLI was invoking `@coveo/typescript` before it was added to the project