### PR TITLE
fix(cli): vue Cli does not accept "latest" dependencies in plugin

### DIFF
--- a/packages/vue-cli-plugin-typescript/generator/index.js
+++ b/packages/vue-cli-plugin-typescript/generator/index.js
@@ -6,8 +6,8 @@ module.exports = (api, options, rootOptions) => {
       'start-server': 'node ./scripts/start-server.js',
     },
     dependencies: {
-      '@coveo/headless': '^0',
-      '@coveo/search-token-server': '^0',
+      '@coveo/headless': '*',
+      '@coveo/search-token-server': '*',
       buefy: '^0.9.4',
       concurrently: '^5.3.0',
     },

--- a/packages/vue-cli-plugin-typescript/generator/index.js
+++ b/packages/vue-cli-plugin-typescript/generator/index.js
@@ -6,8 +6,8 @@ module.exports = (api, options, rootOptions) => {
       'start-server': 'node ./scripts/start-server.js',
     },
     dependencies: {
-      '@coveo/headless': 'latest',
-      '@coveo/search-token-server': 'latest',
+      '@coveo/headless': '^0',
+      '@coveo/search-token-server': '^0',
       buefy: '^0.9.4',
       concurrently: '^5.3.0',
     },


### PR DESCRIPTION
The Vue CLI is doing a `semver.validRange` validation on the dependency version that we want to inject.
Since `semver.validRange('latest')` returns `null`, the associated dependencies are never added to the project.
