### PR TITLE
ci(release): change github token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ jobs:
   run-script:
     runs-on: ubuntu-latest
     env:
-      GITHUB_CREDENTIALS: ${{ secrets.COMMIT_TOKEN }}
+      GITHUB_CREDENTIALS: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
Apparently, secrets.COMMIT_TOKEN is only available for private repositories, not public one 🤷 
 
https://coveord.atlassian.net/browse/CDX-134