### PR TITLE
fix(macos): fix app identifier issue on install

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -66,7 +66,7 @@
       "prerun": "./lib/hooks/prerun/prerun"
     },
     "macos": {
-      "identifier": "@coveo/cli"
+      "identifier": "coveo-cli"
     }
   },
   "repository": "coveo/cli",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -66,7 +66,7 @@
       "prerun": "./lib/hooks/prerun/prerun"
     },
     "macos": {
-      "identifier": "coveo-cli"
+      "identifier": "com.coveo.cli"
     }
   },
   "repository": "coveo/cli",


### PR DESCRIPTION
Using an `@coveo` identifier for the app would cause installation problems on osx
https://coveord.atlassian.net/browse/CDX-136