### PR TITLE
test(cli): modify test env to be keyring-compatible

### DIFF
--- a/packages/cli-e2e/docker/Dockerfile
+++ b/packages/cli-e2e/docker/Dockerfile
@@ -52,5 +52,7 @@ RUN chown -R notGroot:notGroot /home/notGroot \
     && chmod -R 600 /home/notGroot/.local/share/keyrings/Default_keyring.keyring \
     && chmod -R 644 /home/notGroot/.local/share/keyrings/default
 
+# Ensure root pwd is set to something known
+RUN echo 'Docker!' | passwd --stdin root 
 # Run everything after as non-privileged user.
 USER notGroot

--- a/packages/cli-e2e/docker/Dockerfile
+++ b/packages/cli-e2e/docker/Dockerfile
@@ -53,6 +53,6 @@ RUN chown -R notGroot:notGroot /home/notGroot \
     && chmod -R 644 /home/notGroot/.local/share/keyrings/default
 
 # Ensure root pwd is set to something known
-RUN echo 'Docker!' | passwd --stdin root 
+RUN echo 'root:Docker!' | chpasswd
 # Run everything after as non-privileged user.
 USER notGroot

--- a/packages/cli-e2e/docker/Dockerfile
+++ b/packages/cli-e2e/docker/Dockerfile
@@ -5,12 +5,16 @@ RUN sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable 
 RUN apt-get update
 
 RUN apt-get install -y google-chrome-stable
-# RUN update-alternatives --set x-www-browser /usr/bin/google-chrome-stable
+RUN update-alternatives --set x-www-browser /usr/bin/google-chrome-stable
+
+# Keyring deps
+RUN apt-get install -y dbus-x11
+RUN apt-get install -y gnome-keyring
 
 # Chrome deps
 RUN apt-get install -yq libgconf-2-4
-RUN apt-get install -y make build-essential libssl-dev zlib1g-dev   
-RUN apt-get install -y libbz2-dev libreadline-dev libsqlite3-dev wget curl llvm 
+RUN apt-get install -y make build-essential libssl-dev zlib1g-dev
+RUN apt-get install -y libbz2-dev libreadline-dev libsqlite3-dev wget curl llvm
 RUN apt-get install -y libncurses5-dev libncursesw5-dev xz-utils tk-dev
 
 # For headless without headless.
@@ -23,3 +27,30 @@ RUN apt-get install -y libsecret-1-dev
 RUN apt-get install -y rsync
 # sudo for running the test as not root while still being root.
 RUN apt-get install -y sudo
+
+# Add user so we don't need --no-sandbox.
+RUN addgroup --system notGroot --force-badname && adduser --system --group notGroot --force-badname \
+    && mkdir -p /home/notGroot/Downloads /app
+
+# Setup the keyring.
+RUN mkdir -p /home/notGroot/.local/share/keyrings
+RUN touch /home/notGroot/.local/share/keyrings/Default_keyring.keyring
+
+
+RUN printf '[keyring]\n\
+display-name=Default keyring\n\
+ctime=1614975180\n\
+mtime=0\n\
+lock-on-idle=false\n\
+lock-after=false\n' > /home/notGroot/.local/share/keyrings/Default_keyring.keyring
+
+RUN printf 'Default_keyring' > /home/notGroot/.local/share/keyrings/default
+
+# Give the file access to the test user.
+RUN chown -R notGroot:notGroot /home/notGroot \
+    && chown -R notGroot:notGroot /app \
+    && chmod -R 600 /home/notGroot/.local/share/keyrings/Default_keyring.keyring \
+    && chmod -R 644 /home/notGroot/.local/share/keyrings/default
+
+# Run everything after as non-privileged user.
+USER notGroot

--- a/packages/cli-e2e/entrypoints/dockerHeadless.sh
+++ b/packages/cli-e2e/entrypoints/dockerHeadless.sh
@@ -3,12 +3,10 @@ Xvfb :1 -screen 0 1024x768x16 & sleep 1
 
 xdg-settings set default-web-browser google-chrome.desktop
 
-useradd -ms /bin/bash notGroot
-rsync -r --exclude="node_modules" /home/cli/* /home/cli-copy
-chmod -R 777 /home/cli-copy
-cd /home/cli-copy
+rsync -r --exclude="node_modules" /home/notGroot/cli/* /home/notGroot/cli-copy/
+cd /home/notGroot/cli-copy
 
-sudo -u notGroot npm run setup
+npm run setup
 cd packages/cli-e2e
-sudo -u notGroot google-chrome --no-first-run --remote-debugging-port=9222 --disable-dev-shm-usage >/dev/null 2>&1 & \
-sudo -u notGroot npm run-script jest
+google-chrome --no-first-run --remote-debugging-port=9222 --disable-dev-shm-usage >/dev/null 2>&1 & \
+npm run-script jest:debug

--- a/packages/cli-e2e/entrypoints/dockerHeadless.sh
+++ b/packages/cli-e2e/entrypoints/dockerHeadless.sh
@@ -9,4 +9,4 @@ cd /home/notGroot/cli-copy
 npm run setup
 cd packages/cli-e2e
 google-chrome --no-first-run --remote-debugging-port=9222 --disable-dev-shm-usage >/dev/null 2>&1 & \
-npm run-script jest:debug
+npm run-script jest

--- a/packages/cli-e2e/entrypoints/dockerX11Entry.sh
+++ b/packages/cli-e2e/entrypoints/dockerX11Entry.sh
@@ -2,12 +2,10 @@ export DISPLAY=host.docker.internal:0.0
 
 xdg-settings set default-web-browser google-chrome.desktop
 
-useradd -ms /bin/bash notGroot
-rsync -r --exclude="node_modules" /home/cli/* /home/cli-copy
-chmod -R 777 /home/cli-copy
-cd /home/cli-copy
+rsync -r --exclude="node_modules" /home/notGroot/cli/* /home/notGroot/cli-copy/
+cd /home/notGroot/cli-copy
 
-sudo -u notGroot npm run setup
+npm run setup
 cd packages/cli-e2e
-sudo -u notGroot google-chrome --no-first-run --remote-debugging-port=9222 --disable-dev-shm-usage >/dev/null 2>&1 & \
-sudo -u notGroot npm run-script jest:debug
+google-chrome --no-first-run --remote-debugging-port=9222 --disable-dev-shm-usage >/dev/null 2>&1 & \
+npm run-script jest:debug

--- a/packages/cli-e2e/entrypoints/dockerX11Entry.sh
+++ b/packages/cli-e2e/entrypoints/dockerX11Entry.sh
@@ -8,4 +8,5 @@ cd /home/notGroot/cli-copy
 npm run setup
 cd packages/cli-e2e
 google-chrome --no-first-run --remote-debugging-port=9222 --disable-dev-shm-usage >/dev/null 2>&1 & \
+
 npm run-script jest:debug

--- a/packages/cli-e2e/entrypoints/entry.js
+++ b/packages/cli-e2e/entrypoints/entry.js
@@ -4,13 +4,13 @@ const {execSync, spawnSync} = require('child_process');
 const DOCKER_IMAGE_NAME = 'coveo-cli-e2e-image';
 const DOCKER_CONTAINER_NAME = 'coveo-cli-e2e-container';
 const repoHostPath = resolve(__dirname, ...new Array(3).fill('..'));
-const repoDockerPath = '/home/cli';
+const repoDockerPath = '/home/notGroot/cli';
 const dockerEntryPoint = (() => {
-  if (process.argv[2] === '--bash') {
+  if (isBash()) {
     return '/bin/bash';
   }
   return join(
-    '/home/cli',
+    repoDockerPath,
     'packages',
     'cli-e2e',
     'entrypoints',
@@ -56,8 +56,8 @@ try {
   execSync(
     `docker run --name=${DOCKER_CONTAINER_NAME} -v "${repoHostPath}:${repoDockerPath}" -p "9229:9229" -${
       process.argv[2] === '--bash' ? 'it' : 'i'
-    } --cap-add=SYS_ADMIN ${DOCKER_IMAGE_NAME} ${dockerEntryPoint}`,
-    {stdio: ['ignore', 'inherit', 'inherit']}
+    } --cap-add=IPC_LOCK --cap-add=SYS_ADMIN ${DOCKER_IMAGE_NAME} ${dockerEntryPoint}`,
+    {stdio: ['inherit', 'inherit', 'inherit']}
   );
 } finally {
   if (!process.env.CI) {
@@ -65,4 +65,7 @@ try {
       stdio: 'ignore',
     });
   }
+}
+function isBash() {
+  return process.argv[2] === '--bash';
 }


### PR DESCRIPTION
This PR modify the docker substantially by making the user being `notGroot` by default (so accessing root will require `sudo` now and not the other way around)

The DockerFile is also augmented with the responsibility of initializing some files for `notGroot` mainly its keychain. By using an unencrypted keychain (i.e. no passphrase) we avoid any GUI prompt from gnome-keychain when trying to write or read from the keychain.

---

https://coveord.atlassian.net/browse/CDX-142