### PR TITLE
fix(cli): add a `--not-git` flag on the command `ui:create:vue`

### DIFF
--- a/packages/cli/src/commands/ui/create/vue.ts
+++ b/packages/cli/src/commands/ui/create/vue.ts
@@ -11,7 +11,7 @@ import {Storage} from '../../../lib/oauth/storage';
 import {platformUrl} from '../../../lib/platform/environment';
 import {spawnProcess} from '../../../lib/utils/process';
 
-interface IprojectOptions {
+interface IProjectOptions {
   preset: {};
   test: boolean;
 }
@@ -98,7 +98,7 @@ export default class Vue extends Command {
     });
   }
 
-  private createProject(name: string, options: IprojectOptions) {
+  private createProject(name: string, options: IProjectOptions) {
     const cliArgs = [
       'create',
       name,

--- a/packages/cli/src/commands/ui/create/vue.ts
+++ b/packages/cli/src/commands/ui/create/vue.ts
@@ -11,11 +11,20 @@ import {Storage} from '../../../lib/oauth/storage';
 import {platformUrl} from '../../../lib/platform/environment';
 import {spawnProcess} from '../../../lib/utils/process';
 
+interface IprojectOptions {
+  preset: {};
+  test: boolean;
+}
 export default class Vue extends Command {
   static description = 'Create a new project powered by vue-cli-service';
 
   static flags = {
     help: flags.help({char: 'h'}),
+    test: flags.boolean({
+      hidden: true,
+      default: false,
+      description: 'For testing only',
+    }),
     preset: flags.string({
       char: 'p',
       helpValue: 'path',
@@ -49,7 +58,7 @@ export default class Vue extends Command {
         this.error('Unable to load preset');
       }
     }
-    await this.createProject(args.name, preset);
+    await this.createProject(args.name, {preset, test: flags.test});
     await this.invokePlugin(args.name);
     await this.config.runHook(
       'analytics',
@@ -89,15 +98,20 @@ export default class Vue extends Command {
     });
   }
 
-  private createProject(name: string, preset: {}) {
-    return this.runVueCliCommand([
+  private createProject(name: string, options: IprojectOptions) {
+    const cliArgs = [
       'create',
       name,
       '--inlinePreset',
-      JSON.stringify(preset),
+      JSON.stringify(options.preset),
       '--skipGetStarted',
       '--bare',
-    ]);
+    ];
+
+    if (options.test) {
+      cliArgs.push('--no-git');
+    }
+    return this.runVueCliCommand(cliArgs);
   }
 
   private runVueCliCommand(args: string[], options = {}) {


### PR DESCRIPTION
This flag is needed to prevent the tests from crashing.

The idea is to have a hidden `--test` flag for each `ui:create:` command. That way, we can adjust the instruction if it is running in test mode.

In the case of Vue.js, the test mode will add the `--no-git` flag, which will prevent the initialization of a git repository during the project creation.

Otherwise, the Vue CLI will return the following error.
```
missing username and email in git config, or failed to sign a commit
```

If you run the E2E tests in your local machines while having uncommitted changes, the Vue Cli will prompt a warning and wait for the user input.
Adding the `--no-git` flag will prevent this scenario