### PR TITLE
ci(githubactions): put pack-command between quotes

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -14,15 +14,15 @@ jobs:
       matrix:
         include:
           - os: macos-latest
-            pack-command: :macos
+            pack-command: ':macos'
             for: 'macos install kit'
             package-targets: 'darwin-x64'
           - os: windows-latest
-            pack-command: :win
+            pack-command: ':win'
             for: 'windows install kit'
             package-targets: 'win32-x64,win32-x86'
           - os: ubuntu-latest
-            pack-command: :deb
+            pack-command: ':deb'
             for: 'linux install kit'
             package-targets: 'linux-x64,linux-arm'
 


### PR DESCRIPTION
I experimented on a fork:
-https://github.com/louis-bompart/cli/blob/master/.github/workflows/beep.yml doesn't work
https://github.com/louis-bompart/cli/blob/master/.github/workflows/boop.yml works
![image](https://user-images.githubusercontent.com/12366410/111663012-cc046500-87e6-11eb-839b-723957ea9065.png)


https://coveord.atlassian.net/browse/CDX-171