### PR TITLE
test(e2e): add screenshots

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,11 +27,9 @@ jobs:
         working-directory: ./packages/cli-e2e
         run: npm run test-e2e
       - name: Check screenshots
-        working-directory: ./packages/cli-e2e
-        run: |
-          ls
-          ls screenshots
+        working-directory: ./packages/cli-e2e/screenshots
+        run: ls
       - uses: actions/upload-artifact@v2
         with:
           name: test-screenshots
-          path: ./screenshots/
+          path: ./packages/cli-e2e/screenshots

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,3 +26,7 @@ jobs:
       - name: End-to-end Tests
         working-directory: ./packages/cli-e2e
         run: npm run test-e2e
+      - uses: actions/upload-artifact@v2
+        with:
+          name: test-screenshots
+          path: packages/cli-e2e/screenshots/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,12 @@ jobs:
       - name: End-to-end Tests
         working-directory: ./packages/cli-e2e
         run: npm run test-e2e
+      - name: Check screenshots
+        working-directory: ./packages/cli-e2e
+        run: |
+          ls
+          ls screenshots
       - uses: actions/upload-artifact@v2
         with:
           name: test-screenshots
-          path: packages/cli-e2e/screenshots/
+          path: ./screenshots/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,9 +26,6 @@ jobs:
       - name: End-to-end Tests
         working-directory: ./packages/cli-e2e
         run: npm run test-e2e
-      - name: Check screenshots
-        working-directory: ./packages/cli-e2e/screenshots
-        run: ls
       - uses: actions/upload-artifact@v2
         with:
           name: test-screenshots

--- a/packages/cli-e2e/.gitignore
+++ b/packages/cli-e2e/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 .env
+screenshots

--- a/packages/cli-e2e/__tests__/auth.specs.ts
+++ b/packages/cli-e2e/__tests__/auth.specs.ts
@@ -10,7 +10,7 @@ import {
   isYesNoPrompt,
   killCliProcess,
 } from '../utils/cli';
-import {connectToChromeBrowser} from '../utils/browser';
+import {captureScreenshots, connectToChromeBrowser} from '../utils/browser';
 
 describe('auth', () => {
   describe('login', () => {
@@ -22,6 +22,7 @@ describe('auth', () => {
     });
 
     afterEach(async () => {
+      await captureScreenshots(browser);
       await killCliProcess(cliProcess);
     }, 5e3);
 

--- a/packages/cli-e2e/__tests__/vue.specs.ts
+++ b/packages/cli-e2e/__tests__/vue.specs.ts
@@ -4,7 +4,7 @@ import type {ChildProcessWithoutNullStreams} from 'child_process';
 import type {HTTPRequest, Browser, Page} from 'puppeteer';
 
 import {setupUIProject, teardownUIProject} from '../utils/cli';
-import {getNewBrowser} from '../utils/browser';
+import {captureScreenshots, getNewBrowser} from '../utils/browser';
 import {isSearchRequest} from '../utils/platform';
 
 describe('ui', () => {
@@ -30,6 +30,11 @@ describe('ui', () => {
       page.on('request', (request: HTTPRequest) => {
         interceptedRequests.push(request);
       });
+    });
+
+    afterEach(async () => {
+      await captureScreenshots(browser);
+      await page.close();
     });
 
     afterAll(async () => {

--- a/packages/cli-e2e/docker/Dockerfile
+++ b/packages/cli-e2e/docker/Dockerfile
@@ -50,6 +50,7 @@ RUN printf 'Default_keyring' > /home/notGroot/.local/share/keyrings/default
 
 # Give the file access to the test user.
 RUN chown -R notGroot:notGroot /home/notGroot \
+    && chmod -R 744 /home/notGroot/ \
     && chown -R notGroot:notGroot /app \
     && chmod -R 600 /home/notGroot/.local/share/keyrings/Default_keyring.keyring \
     && chmod -R 644 /home/notGroot/.local/share/keyrings/default

--- a/packages/cli-e2e/docker/Dockerfile
+++ b/packages/cli-e2e/docker/Dockerfile
@@ -57,6 +57,8 @@ RUN chown -R notGroot:notGroot /home/notGroot \
 
 # Ensure root pwd is set to something known
 RUN echo 'root:Docker!' | chpasswd
+RUN echo 'notGroot:Docker!' | chpasswd
+RUN usermod -aG sudo notGroot
 # Run everything after as non-privileged user.
 USER notGroot
 

--- a/packages/cli-e2e/docker/Dockerfile
+++ b/packages/cli-e2e/docker/Dockerfile
@@ -50,7 +50,7 @@ RUN printf 'Default_keyring' > /home/notGroot/.local/share/keyrings/default
 
 # Give the file access to the test user.
 RUN chown -R notGroot:notGroot /home/notGroot \
-    && chmod -R 744 /home/notGroot/ \
+    && chmod -R 777 /home/notGroot/ \
     && chown -R notGroot:notGroot /app \
     && chmod -R 600 /home/notGroot/.local/share/keyrings/Default_keyring.keyring \
     && chmod -R 644 /home/notGroot/.local/share/keyrings/default

--- a/packages/cli-e2e/entrypoints/common.js
+++ b/packages/cli-e2e/entrypoints/common.js
@@ -77,12 +77,11 @@ const createEnvFile = () => {
 
 const startDockerContainer = () => {
   createEnvFile();
-  mkdirSync('screenshotsHostPath', {recursive: true});
+  mkdirSync(screenshotsHostPath, {recursive: true});
   return execSync(
     `docker run \
     --name=${DOCKER_CONTAINER_NAME} \
     -v "${repoHostPath}:${repoDockerPath}" \
-    -v "${screenshotsHostPath}:${screenshotsDockerPath}" \
     -p "9229:9229" \
     -${process.argv[2] === '--bash' ? 'it' : 'i'} \
     --env-file .env \

--- a/packages/cli-e2e/entrypoints/common.js
+++ b/packages/cli-e2e/entrypoints/common.js
@@ -86,6 +86,7 @@ const startDockerContainer = () => {
     --env-file .env \
     --cap-add=IPC_LOCK \
     --cap-add=SYS_ADMIN \
+    --privileged \
     ${DOCKER_IMAGE_NAME} ${dockerEntryPoint()}`,
     {stdio: ['inherit', 'inherit', 'inherit']}
   );

--- a/packages/cli-e2e/entrypoints/common.js
+++ b/packages/cli-e2e/entrypoints/common.js
@@ -6,7 +6,6 @@ const DOCKER_IMAGE_NAME = 'coveo-cli-e2e-image';
 const DOCKER_CONTAINER_NAME = 'coveo-cli-e2e-container';
 const repoHostPath = resolve(__dirname, ...new Array(3).fill('..'));
 const repoDockerPath = '/home/notGroot/cli';
-const screenshotsDockerPath = '/home/notGroot/screenshots';
 const screenshotsHostPath = resolve(__dirname, '..', 'screenshots');
 const dockerFilePath = resolve(repoHostPath, 'packages', 'cli-e2e', 'docker');
 
@@ -79,7 +78,7 @@ const startDockerContainer = () => {
   createEnvFile();
   mkdirSync(screenshotsHostPath, {recursive: true});
   return execSync(
-    `docker run \
+    `${process.env.CI ? 'sudo ' : ''}docker run \
     --name=${DOCKER_CONTAINER_NAME} \
     -v "${repoHostPath}:${repoDockerPath}" \
     -p "9229:9229" \

--- a/packages/cli-e2e/entrypoints/common.js
+++ b/packages/cli-e2e/entrypoints/common.js
@@ -1,11 +1,13 @@
 const {resolve, join} = require('path');
 const {execSync, spawnSync} = require('child_process');
-const {existsSync, writeFileSync} = require('fs');
+const {existsSync, mkdirSync, writeFileSync} = require('fs');
 
 const DOCKER_IMAGE_NAME = 'coveo-cli-e2e-image';
 const DOCKER_CONTAINER_NAME = 'coveo-cli-e2e-container';
 const repoHostPath = resolve(__dirname, ...new Array(3).fill('..'));
 const repoDockerPath = '/home/notGroot/cli';
+const screenshotsDockerPath = '/home/notGroot/screenshots';
+const screenshotsHostPath = resolve(__dirname, '..', 'screenshots');
 const dockerFilePath = resolve(repoHostPath, 'packages', 'cli-e2e', 'docker');
 
 const dockerEntryPoint = () => {
@@ -75,10 +77,18 @@ const createEnvFile = () => {
 
 const startDockerContainer = () => {
   createEnvFile();
+  mkdirSync('screenshotsHostPath', {recursive: true});
   return execSync(
-    `docker run --name=${DOCKER_CONTAINER_NAME} -v "${repoHostPath}:${repoDockerPath}" -p "9229:9229" -${
-      process.argv[2] === '--bash' ? 'it' : 'i'
-    } --env-file .env --cap-add=IPC_LOCK --cap-add=SYS_ADMIN ${DOCKER_IMAGE_NAME} ${dockerEntryPoint()}`,
+    `docker run \
+    --name=${DOCKER_CONTAINER_NAME} \
+    -v "${repoHostPath}:${repoDockerPath}" \
+    -v "${screenshotsHostPath}:${screenshotsDockerPath}" \
+    -p "9229:9229" \
+    -${process.argv[2] === '--bash' ? 'it' : 'i'} \
+    --env-file .env \
+    --cap-add=IPC_LOCK \
+    --cap-add=SYS_ADMIN \
+    ${DOCKER_IMAGE_NAME} ${dockerEntryPoint()}`,
     {stdio: ['inherit', 'inherit', 'inherit']}
   );
 };

--- a/packages/cli-e2e/entrypoints/dockerHeadless.sh
+++ b/packages/cli-e2e/entrypoints/dockerHeadless.sh
@@ -10,3 +10,5 @@ npm run setup
 cd packages/cli-e2e
 google-chrome --no-first-run --remote-debugging-port=9222 --disable-dev-shm-usage >/dev/null 2>&1 & \
 npm run-script jest
+
+rsync -r /home/notGroot/cli-copy/packages/cli-e2e/screenshots* /home/notGroot/cli/packages/cli-e2e/screenshots

--- a/packages/cli-e2e/entrypoints/dockerHeadless.sh
+++ b/packages/cli-e2e/entrypoints/dockerHeadless.sh
@@ -11,4 +11,4 @@ cd packages/cli-e2e
 google-chrome --no-first-run --remote-debugging-port=9222 --disable-dev-shm-usage >/dev/null 2>&1 & \
 npm run-script jest
 
-rsync -r /home/notGroot/cli-copy/packages/cli-e2e/screenshots* /home/notGroot/cli/packages/cli-e2e/screenshots
+sudo rsync -r /home/notGroot/cli-copy/packages/cli-e2e/screenshots/* /home/notGroot/cli/packages/cli-e2e/screenshots

--- a/packages/cli-e2e/entrypoints/dockerHeadless.sh
+++ b/packages/cli-e2e/entrypoints/dockerHeadless.sh
@@ -11,4 +11,4 @@ cd packages/cli-e2e
 google-chrome --no-first-run --remote-debugging-port=9222 --disable-dev-shm-usage >/dev/null 2>&1 & \
 npm run-script jest
 
-sudo rsync -r /home/notGroot/cli-copy/packages/cli-e2e/screenshots/* /home/notGroot/cli/packages/cli-e2e/screenshots
+echo "Docker!\n" | sudo -S rsync -r /home/notGroot/cli-copy/packages/cli-e2e/screenshots/* /home/notGroot/cli/packages/cli-e2e/screenshots

--- a/packages/cli-e2e/setup.ts
+++ b/packages/cli-e2e/setup.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-namespace */
 import {ChildProcessWithoutNullStreams} from 'child_process';
 import type {Browser} from 'puppeteer';
-import {connectToChromeBrowser} from './utils/browser';
+import {captureScreenshots, connectToChromeBrowser} from './utils/browser';
 import {clearKeychain, loginWithOffice} from './utils/login';
 
 declare global {
@@ -28,6 +28,11 @@ export default async function () {
   const browser = await connectToChromeBrowser();
   await clearChromeBrowsingData(browser);
   await clearKeychain();
-  global.loginProcess = await loginWithOffice();
+  try {
+    global.loginProcess = await loginWithOffice();
+  } catch (e) {
+    await captureScreenshots(browser, 'jestSetup');
+    throw e;
+  }
   await clearChromeBrowsingData(browser);
 }

--- a/packages/cli-e2e/setup.ts
+++ b/packages/cli-e2e/setup.ts
@@ -1,7 +1,12 @@
 /* eslint-disable @typescript-eslint/no-namespace */
 import {ChildProcessWithoutNullStreams} from 'child_process';
+import {mkdirSync} from 'fs';
 import type {Browser} from 'puppeteer';
-import {captureScreenshots, connectToChromeBrowser} from './utils/browser';
+import {
+  captureScreenshots,
+  connectToChromeBrowser,
+  SCREENSHOTS_PATH,
+} from './utils/browser';
 import {clearKeychain, loginWithOffice} from './utils/login';
 
 declare global {
@@ -25,6 +30,7 @@ async function clearChromeBrowsingData(browser: Browser) {
 }
 
 export default async function () {
+  mkdirSync(SCREENSHOTS_PATH, {recursive: true});
   const browser = await connectToChromeBrowser();
   await clearChromeBrowsingData(browser);
   await clearKeychain();

--- a/packages/cli-e2e/utils/browser.ts
+++ b/packages/cli-e2e/utils/browser.ts
@@ -65,6 +65,7 @@ export async function captureScreenshots(browser: Browser): Promise<void> {
       });
     } catch (error) {
       console.warn('Failed to record screenshot.');
+      console.warn(error);
     }
   }
 }

--- a/packages/cli-e2e/utils/browser.ts
+++ b/packages/cli-e2e/utils/browser.ts
@@ -61,11 +61,10 @@ export async function captureScreenshots(browser: Browser): Promise<void> {
       await page.screenshot({
         fullPage: true,
         type: 'png',
-        path:
-          resolve(
-            SCREENSHOTS_PATH,
-            expect.getState().currentTestName.trim().replace(/ /g, '_')
-          ) + '.png',
+        path: resolve(
+          SCREENSHOTS_PATH,
+          expect.getState().currentTestName.trim().replace(/ /g, '_') + '.png'
+        ),
       });
     } catch (error) {
       console.warn('Failed to record screenshot.');

--- a/packages/cli-e2e/utils/browser.ts
+++ b/packages/cli-e2e/utils/browser.ts
@@ -1,4 +1,6 @@
 import axios from 'axios';
+import {resolve} from 'path';
+import {mkdirSync} from 'fs';
 
 import puppeteer from 'puppeteer';
 import type {Browser, Page} from 'puppeteer';
@@ -7,6 +9,8 @@ const CHROME_JSON_DEBUG_URL = 'http://localhost:9222/json/version';
 interface JsonVersionFile {
   webSocketDebuggerUrl: string;
 }
+
+const SCREENSHOTS_PATH = '/home/notGroot/screenshots';
 
 /**
  * Closes all pages of the targeted browser instance.
@@ -48,6 +52,21 @@ export async function getNewBrowser(): Promise<Browser> {
     headless: false,
     args: getChromeDefaultOptions(),
   });
+}
+
+export async function captureScreenshots(browser: Browser): Promise<void> {
+  mkdirSync(SCREENSHOTS_PATH, {recursive: true});
+  for (const page of await browser.pages()) {
+    try {
+      await page.screenshot({
+        fullPage: true,
+        type: 'png',
+        path: resolve(SCREENSHOTS_PATH, expect.getState.name),
+      });
+    } catch (error) {
+      console.warn('Failed to record screenshot.');
+    }
+  }
 }
 
 /**

--- a/packages/cli-e2e/utils/browser.ts
+++ b/packages/cli-e2e/utils/browser.ts
@@ -10,7 +10,7 @@ interface JsonVersionFile {
 }
 
 export const SCREENSHOTS_PATH =
-  '/home/notGroot/cli/packages/cli-e2e/screenshots';
+  '/home/notGroot/cli-copy/packages/cli-e2e/screenshots';
 
 /**
  * Closes all pages of the targeted browser instance.

--- a/packages/cli-e2e/utils/browser.ts
+++ b/packages/cli-e2e/utils/browser.ts
@@ -1,6 +1,5 @@
 import axios from 'axios';
 import {resolve} from 'path';
-import {mkdirSync} from 'fs';
 
 import puppeteer from 'puppeteer';
 import type {Browser, Page} from 'puppeteer';
@@ -10,7 +9,8 @@ interface JsonVersionFile {
   webSocketDebuggerUrl: string;
 }
 
-const SCREENSHOTS_PATH = '/home/notGroot/cli/packages/cli-e2e/screenshots';
+export const SCREENSHOTS_PATH =
+  '/home/notGroot/cli/packages/cli-e2e/screenshots';
 
 /**
  * Closes all pages of the targeted browser instance.
@@ -58,7 +58,6 @@ export async function captureScreenshots(
   browser: Browser,
   screenshotName?: string
 ): Promise<void> {
-  mkdirSync(SCREENSHOTS_PATH, {recursive: true});
   for (const page of await browser.pages()) {
     page.url;
     try {

--- a/packages/cli-e2e/utils/browser.ts
+++ b/packages/cli-e2e/utils/browser.ts
@@ -61,7 +61,11 @@ export async function captureScreenshots(browser: Browser): Promise<void> {
       await page.screenshot({
         fullPage: true,
         type: 'png',
-        path: resolve(SCREENSHOTS_PATH, expect.getState().currentTestName),
+        path: resolve(
+          SCREENSHOTS_PATH,
+          expect.getState().currentTestName.trim().replace(/ /g, '_'),
+          '.png'
+        ),
       });
     } catch (error) {
       console.warn('Failed to record screenshot.');

--- a/packages/cli-e2e/utils/browser.ts
+++ b/packages/cli-e2e/utils/browser.ts
@@ -63,7 +63,7 @@ export async function captureScreenshots(browser: Browser): Promise<void> {
         type: 'png',
         path: resolve(
           SCREENSHOTS_PATH,
-          expect.getState().currentTestName.trim().replace(/ /g, '_') + '.png'
+          expect.getState().currentTestName.trim().replace(/\W/g, '_') + '.png'
         ),
       });
     } catch (error) {

--- a/packages/cli-e2e/utils/browser.ts
+++ b/packages/cli-e2e/utils/browser.ts
@@ -61,7 +61,7 @@ export async function captureScreenshots(browser: Browser): Promise<void> {
       await page.screenshot({
         fullPage: true,
         type: 'png',
-        path: resolve(SCREENSHOTS_PATH, expect.getState.name),
+        path: resolve(SCREENSHOTS_PATH, expect.getState().currentTestName),
       });
     } catch (error) {
       console.warn('Failed to record screenshot.');

--- a/packages/cli-e2e/utils/browser.ts
+++ b/packages/cli-e2e/utils/browser.ts
@@ -61,11 +61,11 @@ export async function captureScreenshots(browser: Browser): Promise<void> {
       await page.screenshot({
         fullPage: true,
         type: 'png',
-        path: resolve(
-          SCREENSHOTS_PATH,
-          expect.getState().currentTestName.trim().replace(/ /g, '_'),
-          '.png'
-        ),
+        path:
+          resolve(
+            SCREENSHOTS_PATH,
+            expect.getState().currentTestName.trim().replace(/ /g, '_')
+          ) + '.png',
       });
     } catch (error) {
       console.warn('Failed to record screenshot.');

--- a/packages/cli-e2e/utils/browser.ts
+++ b/packages/cli-e2e/utils/browser.ts
@@ -10,7 +10,7 @@ interface JsonVersionFile {
   webSocketDebuggerUrl: string;
 }
 
-const SCREENSHOTS_PATH = '/home/notGroot/screenshots';
+const SCREENSHOTS_PATH = '/home/notGroot/cli/packages/cli-e2e/screenshots';
 
 /**
  * Closes all pages of the targeted browser instance.
@@ -54,16 +54,22 @@ export async function getNewBrowser(): Promise<Browser> {
   });
 }
 
-export async function captureScreenshots(browser: Browser): Promise<void> {
+export async function captureScreenshots(
+  browser: Browser,
+  screenshotName?: string
+): Promise<void> {
   mkdirSync(SCREENSHOTS_PATH, {recursive: true});
   for (const page of await browser.pages()) {
+    page.url;
     try {
       await page.screenshot({
         fullPage: true,
         type: 'png',
         path: resolve(
           SCREENSHOTS_PATH,
-          expect.getState().currentTestName.trim().replace(/\W/g, '_') + '.png'
+          (screenshotName ??
+            expect.getState().currentTestName.trim().replace(/\W/g, '_')) +
+            '.png'
         ),
       });
     } catch (error) {

--- a/packages/cli/package-lock.json
+++ b/packages/cli/package-lock.json
@@ -114,22 +114,6 @@
         }
       }
     },
-    "@angular/cdk": {
-      "version": "11.2.4",
-      "resolved": "https://registry.npmjs.org/@angular/cdk/-/cdk-11.2.4.tgz",
-      "integrity": "sha512-BcMHRaKZxkpK+dPwmjqktAzWUnywbyHyrORGlF4OMtbE88IvbI8tQ+0xANfBm0cPaAm+na5AlGKyH2ptzedyRQ==",
-      "requires": {
-        "parse5": "^5.0.0",
-        "tslib": "^2.0.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
-          "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A=="
-        }
-      }
-    },
     "@angular/cli": {
       "version": "11.1.4",
       "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-11.1.4.tgz",
@@ -1322,82 +1306,6 @@
         "exec-sh": "^0.3.2",
         "minimist": "^1.2.0"
       }
-    },
-    "@coveo/angular": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@coveo/angular/-/angular-0.5.0.tgz",
-      "integrity": "sha512-rzDpcadT4cd8VwUTTp27eSYBXohLUNoIRfuU8rmaJmjCEWNa9dpuumr+3WT+ddR/JV//mRWp07bIzOEqU1I/WA==",
-      "requires": {
-        "@angular-devkit/core": "^11.1.2",
-        "@angular-devkit/schematics": "^11.1.2",
-        "@angular/cdk": "^11.1.1",
-        "@angular/cli": "^11.1.2",
-        "@coveo/search-token-server": "^0.5.0",
-        "@schematics/angular": "^11.1.2",
-        "typescript": "~4.1.2"
-      },
-      "dependencies": {
-        "typescript": {
-          "version": "4.1.5",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.5.tgz",
-          "integrity": "sha512-6OSu9PTIzmn9TCDiovULTnET6BgXtDYL4Gg4szY+cGsc3JP1dQL8qvE8kShTRx1NIw4Q9IBHlwODjkjWEtMUyA=="
-        }
-      }
-    },
-    "@coveo/cra-template": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@coveo/cra-template/-/cra-template-0.5.0.tgz",
-      "integrity": "sha512-BcykpSB2oOMYD9AQQh+xNs3I1wKaFQNDiiF/VCngSY6XA/DA68wupt3KdN32SzWl7Yl+56X1/1hca4WjCKD7Tg==",
-      "dev": true
-    },
-    "@coveo/search-token-server": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@coveo/search-token-server/-/search-token-server-0.5.0.tgz",
-      "integrity": "sha512-RSpXDoY7A2ocyb6+B8y47TNUhVjF9D5qrff37IOl7rMkCTx7BX/LJOZJIM9eB7KosrRmSq2HlxxgNxTvOMkgmw==",
-      "requires": {
-        "@coveord/platform-client": "^11.0.0",
-        "abortcontroller-polyfill": "^1.7.1",
-        "dotenv": "^8.2.0",
-        "express": "^4.17.1",
-        "isomorphic-fetch": "^3.0.0",
-        "ts-node": "^9.1.1",
-        "typescript": "^4.1.5"
-      },
-      "dependencies": {
-        "@coveord/platform-client": {
-          "version": "11.3.0",
-          "resolved": "https://registry.npmjs.org/@coveord/platform-client/-/platform-client-11.3.0.tgz",
-          "integrity": "sha512-BCVXK7KYWLnVADPv6ecyjcPV8vwpRUft+iOZFJa7zCBYQo5UwLX1GP7ihrilNYBuSkPh3Lcqr6aha/8zcvESvA==",
-          "requires": {
-            "exponential-backoff": "^3.1.0",
-            "form-data": "^3.0.0",
-            "query-string": "^6.13.1"
-          }
-        },
-        "ts-node": {
-          "version": "9.1.1",
-          "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-9.1.1.tgz",
-          "integrity": "sha512-hPlt7ZACERQGf03M253ytLY3dHbGNGrAq9qIHWUY9XHYl1z7wYngSr3OQ5xmui8o2AaxsONxIzjafLUiWBo1Fg==",
-          "requires": {
-            "arg": "^4.1.0",
-            "create-require": "^1.1.0",
-            "diff": "^4.0.1",
-            "make-error": "^1.1.1",
-            "source-map-support": "^0.5.17",
-            "yn": "3.1.1"
-          }
-        },
-        "typescript": {
-          "version": "4.2.3",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.2.3.tgz",
-          "integrity": "sha512-qOcYwxaByStAWrBf4x0fibwZvMRG+r4cQoTjbPtUlrWjBHbmCAww1i448U0GJ+3cNNEtebDteo/cHOR3xJ4wEw=="
-        }
-      }
-    },
-    "@coveo/vue-cli-plugin-typescript": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@coveo/vue-cli-plugin-typescript/-/vue-cli-plugin-typescript-0.5.0.tgz",
-      "integrity": "sha512-/fJmWIfS/Gu7QZTwP1KAn4xN+KYGsiURm74Lg8Wcf4QAYwCcdgrZ5WU3YCtdEeTKeWuqHabUL3uvtqqVVR5Q3g=="
     },
     "@coveord/platform-client": {
       "version": "9.29.0",
@@ -6848,11 +6756,6 @@
         }
       }
     },
-    "create-require": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
-      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ=="
-    },
     "cross-spawn": {
       "version": "6.0.5",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
@@ -7312,11 +7215,6 @@
       "requires": {
         "streamsearch": "0.1.2"
       }
-    },
-    "diff": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A=="
     },
     "diff-sequences": {
       "version": "26.6.2",
@@ -12920,7 +12818,8 @@
     "parse5": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.1.tgz",
-      "integrity": "sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug=="
+      "integrity": "sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug==",
+      "dev": true
     },
     "parseurl": {
       "version": "1.3.3",


### PR DESCRIPTION
With that, we should have screenshot artifacts on the tests.

Jest has been quite disappointing here.  you cannot get nice/good information on what the current test is (name, status, etc).

So either I was taking the screenshot every time, or I was adding complexity for the screenshots.
Well, we're not charged for the artifact loading, so I chose the first option.