### PR TITLE
feat(login): improve feedback message on sucessful login 

### DIFF
--- a/packages/cli/src/commands/auth/login.spec.ts
+++ b/packages/cli/src/commands/auth/login.spec.ts
@@ -4,17 +4,45 @@ jest.mock('../../lib/config/config');
 jest.mock('keytar');
 jest.mock('../../hooks/analytics/analytics');
 jest.mock('../../hooks/prerun/prerun');
+jest.mock('../../lib/platform/authenticatedClient');
+jest.mock('@coveord/platform-client');
 import {test} from '@oclif/test';
 import {mocked} from 'ts-jest/utils';
 import {Config} from '../../lib/config/config';
 import {OAuth} from '../../lib/oauth/oauth';
 import {Storage} from '../../lib/oauth/storage';
+import {AuthenticatedClient} from '../../lib/platform/authenticatedClient';
+import {PlatformClient} from '@coveord/platform-client';
 const mockedOAuth = mocked(OAuth, true);
 const mockedStorage = mocked(Storage, true);
 const mockedConfig = mocked(Config, true);
+const mockedAuthenticatedClient = mocked(AuthenticatedClient);
+const mockedPlatformClient = mocked(PlatformClient);
 
 describe('auth:login', () => {
+  const mockConfigSet = jest.fn();
+  const mockListOrgs = jest.fn();
+
   beforeEach(() => {
+    mockListOrgs.mockReturnValue(Promise.resolve([{id: 'foo'}]));
+    mockedPlatformClient.mockImplementation(
+      () =>
+        ({
+          organization: {list: mockListOrgs} as unknown,
+        } as PlatformClient)
+    );
+    mockedAuthenticatedClient.mockImplementation(
+      () =>
+        ({
+          getClient: () =>
+            Promise.resolve(
+              mockedPlatformClient.getMockImplementation()!({
+                accessToken: 'theToken',
+                organizationId: 'foo',
+              })
+            ),
+        } as AuthenticatedClient)
+    );
     mockedOAuth.mockImplementationOnce(
       () =>
         ({
@@ -24,6 +52,23 @@ describe('auth:login', () => {
             }),
         } as OAuth)
     );
+
+    mockedConfig.mockImplementation(
+      () =>
+        (({
+          get: () =>
+            Promise.resolve({
+              region: 'us-east-1',
+              organization: 'foo',
+              environment: 'prod',
+            }),
+          set: mockConfigSet,
+        } as unknown) as Config)
+    );
+  });
+
+  afterEach(() => {
+    mockConfigSet.mockClear();
   });
 
   test
@@ -44,7 +89,7 @@ describe('auth:login', () => {
         `passes the -e=${environment} flag to oauth and configuration`,
         () => {
           expect(mockedOAuth.mock.calls[0][0]?.environment).toBe(environment);
-          expect(mockedConfig.mock.instances[0].set).toHaveBeenCalledWith(
+          expect(mockConfigSet).toHaveBeenCalledWith(
             'environment',
             environment
           );
@@ -64,10 +109,7 @@ describe('auth:login', () => {
       .command(['auth:login', '-r', region, '-o', 'foo'])
       .it(`passes the -e=${region} flag to oauth and configuration`, () => {
         expect(mockedOAuth.mock.calls[0][0]?.region).toBe(region);
-        expect(mockedConfig.mock.instances[0].set).toHaveBeenCalledWith(
-          'region',
-          region
-        );
+        expect(mockConfigSet).toHaveBeenCalledWith('region', region);
       });
   });
 
@@ -88,4 +130,28 @@ describe('auth:login', () => {
         );
       });
   });
+
+  test
+    .stdout()
+    .command(['auth:login', '-o', 'this_is_not_a_valid_org'])
+    .exit(2)
+    .it('fails when organization flag is invalid');
+
+  test
+    .do(() => {
+      mockListOrgs.mockReturnValueOnce(Promise.resolve([]));
+    })
+    .stdout()
+    .command(['auth:login'])
+    .exit(2)
+    .it(
+      'fails when no organization flag is passed and the user has access to no organization'
+    );
+
+  test
+    .stdout()
+    .command(['auth:login', '-o', 'foo'])
+    .it('succeed when organization flag is valid', (ctx) => {
+      expect(ctx.stdout).toContain('Success');
+    });
 });

--- a/packages/cli/src/commands/auth/login.ts
+++ b/packages/cli/src/commands/auth/login.ts
@@ -140,7 +140,6 @@ export default class Login extends Command {
   private async verifyOrganization() {
     const flags = this.flags;
     const orgs = await this.getAllOrgsUserHasAccessTo();
-    console.log(flags);
 
     if (flags.organization) {
       const found = orgs.find((o) => o.id === flags.organization);

--- a/packages/cli/src/commands/auth/login.ts
+++ b/packages/cli/src/commands/auth/login.ts
@@ -114,10 +114,8 @@ export default class Login extends Command {
   }
 
   private async pickFirstAvailableOrganization() {
-    const orgs = await (
-      await new AuthenticatedClient().getClient()
-    ).organization.list();
-    return ((orgs as unknown) as OrganizationModel[])[0]?.id;
+    const orgs = await this.getAllOrgsUserHasAccessTo();
+    return orgs[0]?.id;
   }
 
   private get flags() {
@@ -150,7 +148,11 @@ export default class Login extends Command {
     }
 
     if (orgs.length === 0) {
-      this.error('You do not have access to any Coveo organization.');
+      this.error(`
+      You do not have access to any Coveo organization in this region and environment.
+      Please make sure to you have access to at least one Coveo Organization, and that you are targeting the correct region and environment.
+      Run auth:login --help to see available options to log into a different organization, region or environment.
+      `);
     }
   }
 }

--- a/packages/cli/src/commands/auth/login.ts
+++ b/packages/cli/src/commands/auth/login.ts
@@ -76,7 +76,6 @@ export default class Login extends Command {
     Environment: ${cfg.environment}
     Run auth:login --help to see available options to log into a different organization, region or environment.
     `);
-    this.config.runHook('analytics', buildAnalyticsSuccessHook(this, flags));
   }
 
   private async loginAndPersistToken() {

--- a/packages/cli/src/commands/auth/login.ts
+++ b/packages/cli/src/commands/auth/login.ts
@@ -50,7 +50,7 @@ export default class Login extends Command {
     await this.loginAndPersistToken();
     await this.persistRegionAndEnvironment();
     await this.persistOrganization();
-
+    await this.feedbackOnSuccessfulLogin();
     this.config.runHook('analytics', buildAnalyticsSuccessHook(this, flags));
   }
 
@@ -61,6 +61,21 @@ export default class Login extends Command {
       buildAnalyticsFailureHook(this, flags, err)
     );
     throw err;
+  }
+
+  private async feedbackOnSuccessfulLogin() {
+    const cfg = await this.configuration.get();
+    this.log(`
+    Successfully logged in !
+    Close your browser to continue
+
+    You are currently logged in:
+    Organization: ${cfg.organization}
+    Region: ${cfg.region}
+    Environment: ${cfg.environment}
+    Run auth:login --help to see available options to log into a different organization, region or environment.
+    `);
+    this.config.runHook('analytics', buildAnalyticsSuccessHook(this, flags));
   }
 
   private async loginAndPersistToken() {
@@ -92,9 +107,6 @@ export default class Login extends Command {
     const firstOrgAvailable = await this.pickFirstAvailableOrganization();
     if (firstOrgAvailable) {
       await cfg.set('organization', firstOrgAvailable as string);
-      this.log(
-        `No organization specified.\nYou are currently logged in ${firstOrgAvailable}.\nIf you wish to specify an organization, use the --organization parameter.`
-      );
       return;
     }
 


### PR DESCRIPTION
Improve the "login message" on success, which displays current org, region, and environment.

Also add a check on "does the user has access to the org he specified" during login. 

Otherwise they will most probably get cryptic errors for other subsequent commands, when trying to generate an API key for an org that does not exists, or for which their user does not have access to, when they try to run the ui:* commands.

+ Some UTs


https://coveord.atlassian.net/browse/CDX-182