### PR TITLE
fix(cli): missing await in authentication decorator

### DIFF
--- a/packages/cli/src/lib/decorators/authenticationRequired.ts
+++ b/packages/cli/src/lib/decorators/authenticationRequired.ts
@@ -35,7 +35,7 @@ export default function AuthenticationRequired() {
         );
       }
 
-      originalRunCommand.apply(this);
+      await originalRunCommand.apply(this);
     };
   };
 }


### PR DESCRIPTION
This missing await was making it so we were bypassing the standard error handling of oclif, for all commands needing authentication, since all commands are async.

https://coveord.atlassian.net/browse/CDX-181