### PR TITLE
ci(angular): add prepublish hook

### DIFF
--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -7,6 +7,7 @@
     "build": "tsc -p tsconfig.json",
     "prebuild": "node ./scripts/clean.js",
     "postbuild": "node ./scripts/setup.js",
+    "prepublishOnly": "npm run build",
     "npm:publish": "npm publish --access public"
   },
   "keywords": [


### PR DESCRIPTION
The `dist` folder needs to be built before publishing the schematic.
Otherwise, pulling the schematic will not use the latest code and can cause [issues](https://github.com/coveo/cli/pull/106#discussion_r600638651).