### PR TITLE
fix(angular): fix search-token-server path

### DIFF
--- a/packages/angular/src/search-token-server/rules/templates.ts
+++ b/packages/angular/src/search-token-server/rules/templates.ts
@@ -3,9 +3,9 @@ import {CoveoSchema} from '../../schema';
 import {dirname} from 'path';
 
 export function createServerDirectory(options: CoveoSchema) {
-  const searchTokenServeTemplate = dirname(
+  const searchTokenServeTemplate = `file://${dirname(
     require.resolve('@coveo/search-token-server')
-  );
+  )}`;
 
   return createFiles(options, './server', searchTokenServeTemplate);
 }


### PR DESCRIPTION
See the issue here: https://github.com/angular/angular-cli/issues/17921
Tho, the `files://` did work for me.

I invite you to checkout the branch and test to ensures it still works in an UNIX environment (no reason why tho, the `files://` is supposed to works everywhere :tm:.

----
https://coveord.atlassian.net/browse/CDX-192