### PR TITLE
test(cli): fix unit tests to work on windows too

### DIFF
--- a/packages/cli/src/lib/config/config.spec.ts
+++ b/packages/cli/src/lib/config/config.spec.ts
@@ -1,4 +1,5 @@
 import {pathExists, createFile, writeJSON, readJSON} from 'fs-extra';
+import {join} from 'path';
 import {mocked} from 'ts-jest/utils';
 import {Config} from './config';
 jest.mock('fs-extra');
@@ -11,17 +12,22 @@ describe('config', () => {
   beforeEach(() => {
     mockedReadJSON.mockImplementation(() => Promise.resolve({}));
   });
+
   it('should ensure config file exists', async () => {
     await new Config('foo/bar').get();
-    expect(mockedPathExists).toHaveBeenCalledWith('foo/bar/config.json');
+    expect(mockedPathExists).toHaveBeenCalledWith(
+      join('foo', 'bar', 'config.json')
+    );
   });
 
   it('should create config file when it does not exists', async () => {
     mockedPathExists.mockImplementationOnce(() => Promise.resolve(false));
     await new Config('foo/bar').get();
-    expect(mockedCreateFile).toHaveBeenCalledWith('foo/bar/config.json');
+    expect(mockedCreateFile).toHaveBeenCalledWith(
+      join('foo', 'bar', 'config.json')
+    );
     expect(mockedWriteJSON).toHaveBeenCalledWith(
-      'foo/bar/config.json',
+      join('foo', 'bar', 'config.json'),
       expect.objectContaining({})
     );
   });
@@ -49,7 +55,7 @@ describe('config', () => {
       mockedReadJSON.mockImplementationOnce(() => Promise.reject('oh noes'));
       await new Config('foo/bar').get();
       expect(mockedWriteJSON).toHaveBeenCalledWith(
-        'foo/bar/config.json',
+        join('foo', 'bar', 'config.json'),
         expect.objectContaining({})
       );
     });
@@ -63,7 +69,7 @@ describe('config', () => {
       };
       await new Config('foo/bar').replace(theNewConfig);
       expect(mockedWriteJSON).toHaveBeenCalledWith(
-        'foo/bar/config.json',
+        join('foo', 'bar', 'config.json'),
         theNewConfig
       );
     });
@@ -72,7 +78,7 @@ describe('config', () => {
       mockedReadJSON.mockImplementationOnce(() => ({hello: 'world'}));
       await new Config('foo/bar').set('environment', 'dev');
       expect(mockedWriteJSON).toHaveBeenCalledWith(
-        'foo/bar/config.json',
+        join('foo', 'bar', 'config.json'),
         expect.objectContaining({
           hello: 'world',
           environment: 'dev',


### PR DESCRIPTION
I chose to uses join instead of a predefined path because otherwise I would just recode `join` and I think it's fine to rely on the core node dependency in our UT.

----

https://coveord.atlassian.net/browse/CDX-95