### PR TITLE
feat(vue): add precheck for node version on `ui:create:vue`

### DIFF
--- a/packages/cli/src/commands/ui/create/vue.ts
+++ b/packages/cli/src/commands/ui/create/vue.ts
@@ -8,6 +8,7 @@ import {Config} from '../../../lib/config/config';
 import {
   Preconditions,
   IsAuthenticated,
+  IsNodeVersionAbove,
 } from '../../../lib/decorators/preconditions';
 import {AuthenticatedClient} from '../../../lib/platform/authenticatedClient';
 import {platformUrl} from '../../../lib/platform/environment';
@@ -16,7 +17,7 @@ import {getPackageVersion} from '../../../lib/utils/misc';
 
 export default class Vue extends Command {
   static templateName = '@coveo/vue-cli-plugin-typescript';
-
+  static requiredNodeVersion = '12.21.0';
   static description =
     'Create a Coveo Headless-powered search page with the Vue.js web framework. See https://docs.coveo.com/en/headless and https://vuejs.org/';
 
@@ -47,7 +48,7 @@ export default class Vue extends Command {
     {name: 'name', description: 'The target application name.', required: true},
   ];
 
-  @Preconditions(IsAuthenticated())
+  @Preconditions(IsAuthenticated(), IsNodeVersionAbove(Vue.requiredNodeVersion))
   async run() {
     const {args, flags} = this.parse(Vue);
 

--- a/packages/cli/src/commands/ui/create/vue.ts
+++ b/packages/cli/src/commands/ui/create/vue.ts
@@ -17,6 +17,11 @@ import {getPackageVersion} from '../../../lib/utils/misc';
 
 export default class Vue extends Command {
   static templateName = '@coveo/vue-cli-plugin-typescript';
+  /**
+   * Refer to the Vue-CLI's changelog to be forthcoming with which version of Node.JS to support.
+   * (i.e. if a Node version is about to get dropped in an upcoming version of the CLI, better drop it now)
+   * @see https://github.com/vuejs/vue-cli/blob/dev/CHANGELOG.md
+   */ 
   static requiredNodeVersion = '12.21.0';
   static description =
     'Create a Coveo Headless-powered search page with the Vue.js web framework. See https://docs.coveo.com/en/headless and https://vuejs.org/';

--- a/packages/cli/src/commands/ui/create/vue.ts
+++ b/packages/cli/src/commands/ui/create/vue.ts
@@ -21,7 +21,7 @@ export default class Vue extends Command {
    * Refer to the Vue-CLI's changelog to be forthcoming with which version of Node.JS to support.
    * (i.e. if a Node version is about to get dropped in an upcoming version of the CLI, better drop it now)
    * @see https://github.com/vuejs/vue-cli/blob/dev/CHANGELOG.md
-   */ 
+   */
   static requiredNodeVersion = '12.21.0';
   static description =
     'Create a Coveo Headless-powered search page with the Vue.js web framework. See https://docs.coveo.com/en/headless and https://vuejs.org/';


### PR DESCRIPTION
Implementation of the refacto from #122.

Only decision made here was where to put the line on the Node version.
Vue does support as low as 8.x for Node.JS ([source](https://cli.vuejs.org/guide/installation.html))
However, their alpha version has already dropped it, and also dropped 10.x ([source](https://github.com/vuejs/vue-cli/blob/dev/CHANGELOG.md#500-alpha5-2021-02-23))

Therefore, Node 12 seems OK till next year. (all non LTS has been dropped by Vue in v5 too)


----

CDX-198