### PR TITLE
docs(cli): add topics description for different commands

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -69,7 +69,19 @@
     ],
     "topics": {
       "auth": {
-        "description": "Manage authentification against the Coveo platform"
+        "description": "manage authentification against the Coveo platform"
+      },
+      "config": {
+        "description": "manage coveo CLI configuration"
+      },
+      "org": {
+        "description": "manage Coveo organizations"
+      },
+      "ui": {
+        "description": "manage user interface deployments"
+      },
+      "ui:create": {
+        "description": "create a user interface powered by different front end frameworks with Coveo Headless"
       }
     },
     "hooks": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -72,7 +72,7 @@
         "description": "manage authentification against the Coveo platform"
       },
       "config": {
-        "description": "manage coveo CLI configuration"
+        "description": "manage Coveo CLI configuration"
       },
       "org": {
         "description": "manage Coveo organizations"
@@ -81,7 +81,7 @@
         "description": "manage user interface deployments"
       },
       "ui:create": {
-        "description": "create a user interface powered by different front end frameworks with Coveo Headless"
+        "description": "create a user interface powered by different front end frameworks and Coveo Headless"
       }
     },
     "hooks": {

--- a/packages/cli/src/commands/ui/create/angular.ts
+++ b/packages/cli/src/commands/ui/create/angular.ts
@@ -17,7 +17,7 @@ export default class Angular extends Command {
   static templateName = '@coveo/angular';
 
   static description =
-    'Create a Coveo Headless-powered search page with the Angular web framework. See https://docs.coveo.com/en/headless and https://angular.io/.';
+    'Create a Coveo Headless-powered search page with the Angular web framework. See https://docs.coveo.com/headless and https://angular.io/.';
 
   static flags = {
     version: flags.string({

--- a/packages/cli/src/commands/ui/create/react.ts
+++ b/packages/cli/src/commands/ui/create/react.ts
@@ -25,7 +25,7 @@ export default class React extends Command {
   static requiredNodeVersion = '10.16.0';
 
   static description =
-    'Create a Coveo Headless-powered search page with the React web framework.';
+    'Create a Coveo Headless-powered search page with the React web framework. See https://docs.coveo.com/headless and https://reactjs.org/.';
 
   static examples = [
     '$ coveo ui:create:react myapp',

--- a/packages/cli/src/commands/ui/create/vue.ts
+++ b/packages/cli/src/commands/ui/create/vue.ts
@@ -18,7 +18,7 @@ export default class Vue extends Command {
   static templateName = '@coveo/vue-cli-plugin-typescript';
 
   static description =
-    'Create a Coveo Headless-powered search page with the Vue.js web framework. See https://docs.coveo.com/en/headless and https://vuejs.org/';
+    'Create a Coveo Headless-powered search page with the Vue.js web framework. See https://docs.coveo.com/headless and https://vuejs.org/';
 
   static flags = {
     help: flags.help({char: 'h'}),


### PR DESCRIPTION
In package.json > oclif > topics > description , we can control what will appear when you do `coveo help`, or `coveo ui:create` etc.

 The topic description will appear that inform the user what they can expect to see if they drill down in that section of the cli "command tree".

examples: 

![image](https://user-images.githubusercontent.com/1591893/113163385-1dace680-920e-11eb-9abe-6f56e8da7f78.png)


![image](https://user-images.githubusercontent.com/1591893/113163456-31584d00-920e-11eb-8d09-00e27151556a.png)



https://coveord.atlassian.net/browse/CDX-213