### PR TITLE
fix(angular): prevent d.ts files from being copied to project

### DIFF
--- a/packages/angular/src/ng-add-setup-project/rules/ng-module.ts
+++ b/packages/angular/src/ng-add-setup-project/rules/ng-module.ts
@@ -72,8 +72,11 @@ function getDefaultAppModuleContent() {
 }
 
 function isTypeScriptSourceFile(action: Action) {
-  const splitted = action.path.split('.');
-  return splitted.indexOf('ts') !== -1 && splitted.indexOf('spec') === -1;
+  return (
+    action.path.endsWith('.ts') &&
+    !action.path.endsWith('.d.ts') &&
+    !action.path.endsWith('.spec.ts')
+  );
 }
 
 function isCreateAction(action: Action) {


### PR DESCRIPTION
This only happens when testing the schematic locally without going through the one published in npm.

https://coveord.atlassian.net/browse/CDX-221