### PR TITLE
ci(snyk): sanitize project name and use directory instead of filename

### DIFF
--- a/.deployment.config.json
+++ b/.deployment.config.json
@@ -27,28 +27,28 @@
     "no_container_images": true,
     "configurations": [
       {
-        "project_name": "coveo/cli:package.json",
+        "project_name": "cli-root",
         "file": "package.json"
       },
       {
-        "project_name": "coveo/cli:packages/cli/package.json",
-        "file": "packages/cli/package.json"
+        "project_name": "cli",
+        "directory": "packages/cli"
       },
       {
-        "project_name": "coveo/cli:packages/angular/package.json",
-        "file": "packages/angular/package.json"
+        "project_name": "angular",
+        "directory": "packages/angular"
       },
       {
-        "project_name": "coveo/cli:packages/cra-template/package.json",
-        "file": "packages/cra-template/package.json"
+        "project_name": "cra-template",
+        "directory": "packages/cra-template"
       },
       {
-        "project_name": "coveo/cli:packages/search-token-server/package.json",
-        "file": "packages/search-token-server/package.json"
+        "project_name": "search-token-server",
+        "directory": "packages/search-token-server"
       },
       {
-        "project_name": "coveo/cli:packages/vue-cli-plugin-typescript/package.json",
-        "file": "packages/vue-cli-plugin-typescript/package.json"
+        "project_name": "vue-cli-plugin",
+        "directory": "packages/vue-cli-plugin-typescript"
       }
     ]
   },


### PR DESCRIPTION
Long story, short. the snyk certifier does not like to have `/` in the project name and cannot target the project made with the Snyk- Github integration.

---
https://coveord.atlassian.net/browse/CDX-202