### PR TITLE
fix(cli): allow update to run without the analytics setting being set

### DIFF
--- a/packages/cli/src/hooks/prerun/prerun.spec.ts
+++ b/packages/cli/src/hooks/prerun/prerun.spec.ts
@@ -33,14 +33,33 @@ describe('hooks:prerun', () => {
 
   test
     .do(() => {
-      mockGet.mockReturnValueOnce(Promise.resolve({analyticsEnabled: false}));
+      mockGet.mockReturnValueOnce(
+        Promise.resolve({analyticsEnabled: undefined})
+      );
     })
+    .stub(cli, 'confirm', () => async () => true)
+    .stdout()
+    .hook('prerun', {id: 'update'})
+    .it(
+      'does modify config when #analytics have not been configured and the command being run is update',
+      () => {
+        expect(mockSet).not.toHaveBeenCalled();
+      }
+    );
+
+  test
+    .do(() => {
+      mockGet.mockReturnValueOnce(
+        Promise.resolve({analyticsEnabled: undefined})
+      );
+    })
+    .stub(cli, 'confirm', () => async () => true)
     .stdout()
     .hook('prerun')
     .it(
-      'does not modify config or prompt the user if analytics are disabled in config',
+      'does modify config when #analytics have not been configured and the users answer #true',
       () => {
-        expect(mockSet).not.toHaveBeenCalled();
+        expect(mockSet).toHaveBeenCalledWith('analyticsEnabled', true);
       }
     );
 

--- a/packages/cli/src/hooks/prerun/prerun.spec.ts
+++ b/packages/cli/src/hooks/prerun/prerun.spec.ts
@@ -39,7 +39,7 @@ describe('hooks:prerun', () => {
     })
     .stub(cli, 'confirm', () => async () => true)
     .stdout()
-    .hook('prerun', {id: 'update'})
+    .hook('prerun', {Command: {id: 'update'}})
     .it(
       'does modify config when #analytics have not been configured and the command being run is update',
       () => {

--- a/packages/cli/src/hooks/prerun/prerun.ts
+++ b/packages/cli/src/hooks/prerun/prerun.ts
@@ -17,7 +17,7 @@ const hook: Hook<'prerun'> = async function (options) {
   if (
     configuration.analyticsEnabled === true ||
     configuration.analyticsEnabled === false ||
-    options.Command.id === 'update'
+    options?.Command?.id === 'update'
   ) {
     return;
   }

--- a/packages/cli/src/hooks/prerun/prerun.ts
+++ b/packages/cli/src/hooks/prerun/prerun.ts
@@ -11,12 +11,13 @@ You can decide to opt in or opt out at any moment by using the config:set comman
 Read more at https://github.com/coveo/cli/tree/master/packages/cli/PRIVACY.md\n
 Do you wish to enable analytics and telemetry tracking ? (y/n)`;
 
-const hook: Hook<'prerun'> = async function () {
+const hook: Hook<'prerun'> = async function (options) {
   const cfg = new Config(global.config.configDir);
   const configuration = await cfg.get();
   if (
     configuration.analyticsEnabled === true ||
-    configuration.analyticsEnabled === false
+    configuration.analyticsEnabled === false ||
+    options.Command.id === 'update'
   ) {
     return;
   }


### PR DESCRIPTION
This was blocking the auto-update on the first run 😢 

---

https://coveord.atlassian.net/browse/CDX-243