### PR TITLE
ci(release): ensure release commit includes proper package-lock.json

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,18 +30,22 @@ jobs:
         if: ${{ github.event.inputs.version == ''}}
       - name: Manually bump version
         if: ${{ github.event.inputs.version != ''}}
-        run: node_modules/.bin/lerna publish ${{ github.event.inputs.version }} ---conventional-commits --force-publish -y --no-push
+        run: node_modules/.bin/lerna publish ${{ github.event.inputs.version }} ---conventional-commits --force-publish -y --no-push --no-tag
       - name: Semantically bump version
         if: ${{ github.event.inputs.version == ''}}
-        run: node_modules/.bin/lerna publish ---conventional-commits -y --no-push
+        run: node_modules/.bin/lerna publish ---conventional-commits -y --no-push --no-tag
       - run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > ~/.npmrc
-      - run: npm run npm:publish
+      - name: Publish on NPM
+        run: npm run npm:publish
+      - name: Get version number
+        run: node ./scripts/get-version.js
       - name: Wait for NPM cache to be updated
         run: node ./scripts/wait-for-packages.js
       - name: Update package-lock.json
         run: |
           npm run npm:genPkgLock
           git commit --amend --no-edit
+          git tag ${{ env.tag }}
       - name: Push commit & tag
         run: |
           git push

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,10 +30,19 @@ jobs:
         if: ${{ github.event.inputs.version == ''}}
       - name: Manually bump version
         if: ${{ github.event.inputs.version != ''}}
-        run: node_modules/.bin/lerna version ${{ github.event.inputs.version }} ---conventional-commits --force-publish -y
+        run: node_modules/.bin/lerna publish ${{ github.event.inputs.version }} ---conventional-commits --force-publish -y --no-push
       - name: Semantically bump version
         if: ${{ github.event.inputs.version == ''}}
-        run: node_modules/.bin/lerna version ---conventional-commits -y
-      - run: npm run release:changelog
+        run: node_modules/.bin/lerna publish ---conventional-commits -y --no-push
       - run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > ~/.npmrc
       - run: npm run npm:publish
+      - name: Wait for NPM cache to be updated
+        run: ./scripts/wait-for-packages.js
+      - name: Update package-lock.json
+        run: npm run npm:genPkgLock
+      - name: Push commit & tag
+        run: |
+          git push
+          git push --tags
+      - name: Create GitHub release.
+        run: npm run release:changelog

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
       - run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > ~/.npmrc
       - run: npm run npm:publish
       - name: Wait for NPM cache to be updated
-        run: ./scripts/wait-for-packages.js
+        run: node ./scripts/wait-for-packages.js
       - name: Update package-lock.json
         run: npm run npm:genPkgLock
       - name: Push commit & tag

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,8 +24,11 @@ jobs:
         with:
           node-version: '14'
       - run: npm run setup
-      - run: git config --global user.email action@github.com
-      - run: git config --global user.name GitHub Action
+      - name: Setup credentials
+      - run: |
+          git config --global user.email action@github.com
+          git config --global user.name GitHub Action
+          echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > ~/.npmrc
       - run: node_modules/.bin/lerna changed
         if: ${{ github.event.inputs.version == ''}}
       - name: Manually bump version
@@ -34,9 +37,6 @@ jobs:
       - name: Semantically bump version
         if: ${{ github.event.inputs.version == ''}}
         run: node_modules/.bin/lerna publish ---conventional-commits -y --no-push --no-tag
-      - run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > ~/.npmrc
-      - name: Publish on NPM
-        run: npm run npm:publish
       - name: Wait for NPM cache to be updated
         run: node ./scripts/wait-for-packages.js
       - name: Update package-lock.json

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
         run: node ./scripts/wait-for-packages.js
       - name: Update package-lock.json
         run: |
-          npm run npm:genPkgLock
+          npm run npm:pkglock
           git commit --amend --no-edit
       - name: Tag the version
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,9 @@ jobs:
       - name: Wait for NPM cache to be updated
         run: node ./scripts/wait-for-packages.js
       - name: Update package-lock.json
-        run: npm run npm:genPkgLock
+        run: |
+          npm run npm:genPkgLock
+          git commit --amend --no-edit
       - name: Push commit & tag
         run: |
           git push

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,14 +37,15 @@ jobs:
       - run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > ~/.npmrc
       - name: Publish on NPM
         run: npm run npm:publish
-      - name: Get version number
-        run: node ./scripts/get-version.js
       - name: Wait for NPM cache to be updated
         run: node ./scripts/wait-for-packages.js
       - name: Update package-lock.json
         run: |
           npm run npm:genPkgLock
           git commit --amend --no-edit
+      - name: Tag the version
+        run: |
+          node ./scripts/get-version.js
           git tag ${{ env.tag }}
       - name: Push commit & tag
         run: |

--- a/package-lock.json
+++ b/package-lock.json
@@ -2866,6 +2866,15 @@
       "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
       "dev": true
     },
+    "async-retry": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.1.tgz",
+      "integrity": "sha512-aiieFW/7h3hY0Bq5d+ktDBejxuwR78vRu9hDUdR8rNhSaQ29VzPL4AoIRG7D/c7tdenwOcKvgPM6tIxB3cB6HA==",
+      "dev": true,
+      "requires": {
+        "retry": "0.12.0"
+      }
+    },
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -2895,6 +2904,15 @@
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz",
       "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==",
       "dev": true
+    },
+    "axios": {
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
+      "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
+      "dev": true,
+      "requires": {
+        "follow-redirects": "^1.10.0"
+      }
     },
     "balanced-match": {
       "version": "1.0.0",
@@ -5338,6 +5356,12 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.1.1.tgz",
       "integrity": "sha512-zAoAQiudy+r5SvnSw3KJy5os/oRJYHzrzja/tBDqrZtNhUw8bt6y8OBzMWcjWr+8liV8Eb6yOhw8WZ7VFZ5ZzA==",
+      "dev": true
+    },
+    "follow-redirects": {
+      "version": "1.13.3",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.3.tgz",
+      "integrity": "sha512-DUgl6+HDzB0iEptNQEXLx/KhTmDb8tZUHSeLqpnjpknR70H0nC2t9N73BK6fN4hOvJ84pKlIQVQ4k5FFlBedKA==",
       "dev": true
     },
     "for-in": {

--- a/package.json
+++ b/package.json
@@ -78,6 +78,6 @@
     "release:changelog": "node ./scripts/release-changelog.js",
     "npm:publish:template": "lerna run --no-bail npm:publish:template",
     "npm:bump:template": "lerna run --no-bail npm:bump:template",
-    "npm:genPkgLock": "lerna run --no-bail npm:genPkgLock"
+    "npm:genPkgLock": "lerna exec npm i"
   }
 }

--- a/package.json
+++ b/package.json
@@ -19,6 +19,8 @@
     "@types/node": "^10",
     "@typescript-eslint/eslint-plugin": "^4.14.0",
     "@typescript-eslint/parser": "^4.14.0",
+    "async-retry": "^1.3.1",
+    "axios": "^0.21.1",
     "cz-conventional-changelog": "^3.3.0",
     "eslint": "^7.18.0",
     "eslint-config-prettier": "^7.2.0",
@@ -74,8 +76,8 @@
     "commit": "git-cz",
     "pr:report": "node ./scripts/pr-bot.js",
     "release:changelog": "node ./scripts/release-changelog.js",
-    "npm:publish": "lerna run --no-bail npm:publish",
     "npm:publish:template": "lerna run --no-bail npm:publish:template",
-    "npm:bump:template": "lerna run --no-bail npm:bump:template"
+    "npm:bump:template": "lerna run --no-bail npm:bump:template",
+    "npm:genPkgLock": "lerna run --no-bail npm:genPkgLock"
   }
 }

--- a/package.json
+++ b/package.json
@@ -78,6 +78,6 @@
     "release:changelog": "node ./scripts/release-changelog.js",
     "npm:publish:template": "lerna run --no-bail npm:publish:template",
     "npm:bump:template": "lerna run --no-bail npm:bump:template",
-    "npm:genPkgLock": "lerna exec npm i"
+    "npm:pkglock": "lerna exec npm i"
   }
 }

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -10,8 +10,7 @@
     "postbuild": "node ./scripts/setup.js",
     "prepublishOnly": "npm run build",
     "npm:bump:template": "npm --no-git-tag-version version",
-    "npm:publish:template": "npm publish --access public --tag ci-test",
-    "npm:genPkgLock": "npm i --package-lock-only"
+    "npm:publish:template": "npm publish --access public --tag ci-test"
   },
   "keywords": [
     "schematics",

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -9,9 +9,9 @@
     "prebuild": "node ./scripts/clean.js",
     "postbuild": "node ./scripts/setup.js",
     "prepublishOnly": "npm run build",
-    "npm:publish": "npm publish --access public",
+    "npm:bump:template": "npm --no-git-tag-version version",
     "npm:publish:template": "npm publish --access public --tag ci-test",
-    "npm:bump:template": "npm --no-git-tag-version version"
+    "npm:genPkgLock": "npm i --package-lock-only"
   },
   "keywords": [
     "schematics",
@@ -44,5 +44,8 @@
     "@types/node": "^12.11.1",
     "fs-extra": "^9.1.0",
     "jasmine": "^3.5.0"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/cra-template/package.json
+++ b/packages/cra-template/package.json
@@ -2,10 +2,10 @@
   "name": "@coveo/cra-template",
   "version": "1.0.1",
   "scripts": {
-    "npm:publish": "npm publish --access public",
-    "npm:publish:template": "npm publish --access public --tag ci-test",
+    "lint": "prettier --check . && eslint .",
     "npm:bump:template": "npm --no-git-tag-version version",
-    "lint": "prettier --check . && eslint ."
+    "npm:publish:template": "npm publish --access public --tag ci-test",
+    "npm:genPkgLock": "npm i --package-lock-only"
   },
   "keywords": [
     "react",
@@ -41,5 +41,8 @@
     "prettier": "^2.2.1",
     "react-dom": "^17.0.1",
     "react-router-dom": "^5.2.0"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/cra-template/package.json
+++ b/packages/cra-template/package.json
@@ -4,8 +4,7 @@
   "scripts": {
     "lint": "prettier --check . && eslint .",
     "npm:bump:template": "npm --no-git-tag-version version",
-    "npm:publish:template": "npm publish --access public --tag ci-test",
-    "npm:genPkgLock": "npm i --package-lock-only"
+    "npm:publish:template": "npm publish --access public --tag ci-test"
   },
   "keywords": [
     "react",

--- a/packages/search-token-server/package.json
+++ b/packages/search-token-server/package.json
@@ -13,8 +13,7 @@
     "typescript": "^4.1.5"
   },
   "scripts": {
-    "start": "ts-node server.ts",
-    "npm:genPkgLock": "npm i --package-lock-only"
+    "start": "ts-node server.ts"
   },
   "devDependencies": {
     "@types/express": "^4.17.11",

--- a/packages/search-token-server/package.json
+++ b/packages/search-token-server/package.json
@@ -14,10 +14,13 @@
   },
   "scripts": {
     "start": "ts-node server.ts",
-    "npm:publish": "npm publish --access public"
+    "npm:genPkgLock": "npm i --package-lock-only"
   },
   "devDependencies": {
     "@types/express": "^4.17.11",
     "gts": "^3.1.0"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/vue-cli-plugin-typescript/package.json
+++ b/packages/vue-cli-plugin-typescript/package.json
@@ -11,8 +11,7 @@
   "scripts": {
     "lint": "prettier --check . && eslint .",
     "npm:bump:template": "npm --no-git-tag-version version",
-    "npm:publish:template": "npm publish --access public --tag ci-test",
-    "npm:genPkgLock": "npm i --package-lock-only"
+    "npm:publish:template": "npm publish --access public --tag ci-test"
   },
   "devDependencies": {
     "@coveo/headless": "^0.8.0",

--- a/packages/vue-cli-plugin-typescript/package.json
+++ b/packages/vue-cli-plugin-typescript/package.json
@@ -9,10 +9,10 @@
   },
   "license": "Apache-2.0",
   "scripts": {
-    "npm:publish": "npm publish --access public",
-    "npm:publish:template": "npm publish --access public --tag ci-test",
+    "lint": "prettier --check . && eslint .",
     "npm:bump:template": "npm --no-git-tag-version version",
-    "lint": "prettier --check . && eslint ."
+    "npm:publish:template": "npm publish --access public --tag ci-test",
+    "npm:genPkgLock": "npm i --package-lock-only"
   },
   "devDependencies": {
     "@coveo/headless": "^0.8.0",
@@ -20,5 +20,8 @@
     "vue": "^2.6.12",
     "vue-property-decorator": "^9.1.2",
     "vue-router": "^3.5.1"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/scripts/get-version.js
+++ b/scripts/get-version.js
@@ -1,0 +1,11 @@
+const core = require('@actions/core');
+const {readFileSync} = require('fs');
+
+(async () => {
+  try {
+    const tag = JSON.parse(readFileSync('lerna.json', 'utf8'))['version'];
+    core.exportVariable('tag', tag);
+  } catch (error) {
+    core.setFailed(error.message);
+  }
+})();

--- a/scripts/wait-for-package.js
+++ b/scripts/wait-for-package.js
@@ -1,0 +1,35 @@
+// https://registry.npmjs.org/@coveo%2fcra-template
+const {get} = require('axios');
+const {readFileSync} = require('fs');
+const retry = require('async-retry');
+
+const publicPackages = [
+  '@coveo/search-token-server',
+  '@coveo/angular',
+  '@coveo/cra-template',
+  '@coveo/vue-cli-plugin-typescript',
+];
+
+function getExpectedVersion() {
+  const lernaJson = JSON.parse(readFileSync('lerna.json', {encoding: 'utf8'}));
+  return lernaJson.version;
+}
+
+const expectedVersion = getExpectedVersion();
+
+publicPackages.map(async (packageName) => {
+  await retry(
+    async (_bail) => {
+      // if anything throws, we retry
+      const res = await get(`https://registry.npmjs.org/${packageName}`);
+      const latestVersion = res['dist-tags']['latest'];
+      if (latestVersion !== expectedVersion) {
+        throw `Not the good version yet. Got ${latestVersion}. Expected ${expectedVersion}`;
+      }
+    },
+    {
+      maxRetryTime: 10 * 60e3,
+      minTimeout: 30e3,
+    }
+  );
+});


### PR DESCRIPTION
Lerna usually symlinks leaf repositories and thus does not 'install' them per se. So for example, this is why there's no `@coveo/search-token-server` in the `@coveo/angular` package, despite the former being a dependency of the latter.

This causes issues for Snyk because it expect a package-lock.json coherent with the package.json

This PR satisfies this need by ensuring that the release commit is made after an `npm i` is done in every leaf packages that needs it (so far `angular` et `cli`).


----


CDX-248