### PR TITLE
ci(lerna): fix no tag option, add files after pkglock

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,10 +33,10 @@ jobs:
         if: ${{ github.event.inputs.version == ''}}
       - name: Manually bump version
         if: ${{ github.event.inputs.version != ''}}
-        run: node_modules/.bin/lerna publish ${{ github.event.inputs.version }} ---conventional-commits --force-publish -y --no-push --no-tag
+        run: node_modules/.bin/lerna publish ${{ github.event.inputs.version }} ---conventional-commits --force-publish -y --no-push --no-git-tag-version
       - name: Semantically bump version
         if: ${{ github.event.inputs.version == ''}}
-        run: node_modules/.bin/lerna publish ---conventional-commits -y --no-push --no-tag
+        run: node_modules/.bin/lerna publish ---conventional-commits -y --no-push --no-git-tag-version
       - name: Wait for NPM cache to be updated
         run: node ./scripts/wait-for-packages.js
       - name: Update package-lock.json

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,14 +42,13 @@ jobs:
       - name: Update package-lock.json
         run: |
           npm run npm:pkglock
-          git commit --amend --no-edit
+          git commit --amend --no-edit --all
       - name: Tag the version
         run: |
           node ./scripts/get-version.js
           git tag ${{ env.tag }}
       - name: Push commit & tag
         run: |
-          git add .
           git push
           git push --tags
       - name: Create GitHub release.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,6 +49,7 @@ jobs:
           git tag ${{ env.tag }}
       - name: Push commit & tag
         run: |
+          git add .
           git push
           git push --tags
       - name: Create GitHub release.


### PR DESCRIPTION
### Issue 1: Bad flag for lerna publish

> 'lerna publish supports all of the options provided by lerna version [...]'

from https://github.com/lerna/lerna/tree/main/commands/publish#options

> By default, lerna version will commit changes to package.json files and tag the release. Pass --no-git-tag-version to disable the behavior.
>
>This option is analogous to the npm version option --git-tag-version, just inverted.

from https://github.com/lerna/lerna/tree/main/commands/version#--no-git-tag-version

### Issue 2: Files not added to the release commit

Fixed by adding a `--all` to the git commit command see:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---all

---
https://coveord.atlassian.net/browse/CDX-253