### PR TITLE
ci(e2e): scope cli-e2e

### DIFF
--- a/packages/cli-e2e/package.json
+++ b/packages/cli-e2e/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "cli-e2e",
+  "name": "@coveo/cli-e2e",
   "version": "1.0.0",
   "description": "End-to-End test of Coveo's CLI",
   "author": "Coveo",


### PR DESCRIPTION
>If this field is set for a package without a scope, it will fail.

https://github.com/lerna/lerna/tree/main/commands/publish#publishconfigaccess

:feelsgood: 

----

https://coveord.atlassian.net/browse/CDX-262