### PR TITLE
ci(release): ignore lerna&changelog for version bump

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
         run: node ./scripts/get-version.js
       - name: Commit changes, tag and push
         run: |
-          git commit --all -m "[Version bump] chore(release): publish v${{ env.tag }}"
+          git commit --all -m "[Version bump] chore(release): publish v${{ env.tag }}\nlerna.json\n\nCHANGELOG.md\n**/CHANGELOG.md"
           git tag "v${{ env.tag }}"
           git push
           git push --tags


### PR DESCRIPTION
The QA Certifier does not want to ignore the version bump commit due to those files.
(readmes, package-lock.json, and package.json are already included)
See: https://coveord.atlassian.net/wiki/spaces/CM/pages/1786708612/Package+Rollout+Certifier

https://coveord.atlassian.net/browse/CDX-272