### PR TITLE
fix(cli): include patches when packing

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -48,6 +48,7 @@
   "files": [
     "/bin",
     "/lib",
+    "/patches",
     "/npm-shrinkwrap.json",
     "/oclif.manifest.json"
   ],


### PR DESCRIPTION
TL;DR: Do as the cool kidz do https://github.com/salesforcecli/sfdx-cli/blob/main/package.json
Long answer: not documented (or at least ain't found the doc), but all files matching the globs in "files" will be copied when packin'

Tested locally for Windows ✔️

Confirmed fix for CDX-214

----

https://coveord.atlassian.net/browse/CDX-108