### PR TITLE
doc(cli): redo installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@ Linux:
 - http://static.cloud.coveo.com/cli/coveo-latest_amd64.deb
 - http://static.cloud.coveo.com/cli/coveo-latest_armel.deb
 
-These executables install the latest available version. Afterwards, run `coveo update` to update to the latest version.
+These executables install the latest available version. Afterwards, anytime you run `coveo update`, your CLI installation will update to the latest version.
 
-In practice, you'll then typically want to [`login`](https://github.com/coveo/cli/tree/master/packages/cli#coveo-authlogin) to your Coveo Organization, [`configure`](https://github.com/coveo/cli/tree/master/packages/cli#coveo-configset) the CLI to connect to this organization, and finally create a search page (see [`coveo ui:create:angular NAME`](https://github.com/coveo/cli/tree/master/packages/cli#coveo-uicreateangular-name), [`coveo ui:create:react NAME`](https://github.com/coveo/cli/tree/master/packages/cli#coveo-uicreatereact-name) and [`coveo ui:create:vue NAME`](https://github.com/coveo/cli/tree/master/packages/cli#coveo-uicreatevue-name)).
+In practice, you'll typically want to [`login`](https://github.com/coveo/cli/tree/master/packages/cli#coveo-authlogin) to your Coveo Organization, [`configure`](https://github.com/coveo/cli/tree/master/packages/cli#coveo-configset) the CLI to connect to this organization, and finally create a search page (see [`coveo ui:create:angular NAME`](https://github.com/coveo/cli/tree/master/packages/cli#coveo-uicreateangular-name), [`coveo ui:create:react NAME`](https://github.com/coveo/cli/tree/master/packages/cli#coveo-uicreatereact-name) and [`coveo ui:create:vue NAME`](https://github.com/coveo/cli/tree/master/packages/cli#coveo-uicreatevue-name)).
 
 The project is still under heavy development and more features are coming, stay tuned!
 

--- a/README.md
+++ b/README.md
@@ -8,15 +8,24 @@ Coveo CLI is a command line interface to interact with the Coveo platform. It al
 
 ## Usage
 
-Install via npm:
+Installation links:
 
-```sh-session
-$ npm install -g @coveo/cli
-```
+Mac:
+- http://static.cloud.coveo.com/cli/coveo-latest.pkg
 
-In practice, you'll typically want to [`login`](https://github.com/coveo/cli/tree/master/packages/cli#coveo-authlogin) to your Coveo Organization, [`configure`](https://github.com/coveo/cli/tree/master/packages/cli#coveo-configset) the CLI to connect to this organization, and finally create a search page (see [`coveo ui:create:angular NAME`](https://github.com/coveo/cli/tree/master/packages/cli#coveo-uicreateangular-name), [`coveo ui:create:react NAME`](https://github.com/coveo/cli/tree/master/packages/cli#coveo-uicreatereact-name) and [`coveo ui:create:vue NAME`](https://github.com/coveo/cli/tree/master/packages/cli#coveo-uicreatevue-name)).
+Windows:
+- http://static.cloud.coveo.com/cli/coveo-latest-x64.exe
+- http://static.cloud.coveo.com/cli/coveo-latest-x32.exe
 
-The project is still under heavy development, stay tuned!
+Linux:
+- http://static.cloud.coveo.com/cli/coveo-latest_amd64.deb
+- http://static.cloud.coveo.com/cli/coveo-latest_armel.deb
+
+These executables install the latest available version. Afterwards, run `coveo update` to update to the latest version.
+
+In practice, you'll then typically want to [`login`](https://github.com/coveo/cli/tree/master/packages/cli#coveo-authlogin) to your Coveo Organization, [`configure`](https://github.com/coveo/cli/tree/master/packages/cli#coveo-configset) the CLI to connect to this organization, and finally create a search page (see [`coveo ui:create:angular NAME`](https://github.com/coveo/cli/tree/master/packages/cli#coveo-uicreateangular-name), [`coveo ui:create:react NAME`](https://github.com/coveo/cli/tree/master/packages/cli#coveo-uicreatereact-name) and [`coveo ui:create:vue NAME`](https://github.com/coveo/cli/tree/master/packages/cli#coveo-uicreatevue-name)).
+
+The project is still under heavy development and more features are coming, stay tuned!
 
 ## Local Setup to Contribute
 


### PR DESCRIPTION
removed mention of npm, since it's not supported yet, and replaced by static installation links.