### PR TITLE
ci(release): fix release commit message

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
         run: node ./scripts/get-version.js
       - name: Commit changes, tag and push
         run: |
-          git commit --all -m "[Version bump] chore(release): publish v${{ env.tag }}\nlerna.json\n\nCHANGELOG.md\n**/CHANGELOG.md"
+          echo -e "[Version bump] chore(release): publish v${{ env.tag }}\nlerna.json\nCHANGELOG.md\n**/CHANGELOG.md\n**/README.md" | git commit --all --file -
           git tag "v${{ env.tag }}"
           git push
           git push --tags


### PR DESCRIPTION
Git commit does not interpret back-slashed escaped characters nor does it has an option for this.
However, you can use stdin for the message using `--file` flag with `-` for value

Echo allows back-slash interpretation with `-e`.
Thus: echo the message, pipe the echo in the git commit with `--file -` 🎉

Relevant links:
 - [Git-SCM commit documentation](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--Fltfilegt)
 - [Bash documentation](https://ss64.com/bash/echo.html)
-------

https://coveord.atlassian.net/browse/CDX-276