### PR TITLE
use winpty always + catch err

### DIFF
--- a/packages/cli/src/commands/ui/create/react.ts
+++ b/packages/cli/src/commands/ui/create/react.ts
@@ -78,7 +78,7 @@ export default class React extends Command {
     throw err;
   }
 
-  private createProject(name: string) {
+  private async createProject(name: string) {
     const flags = this.flags;
     const templateVersion =
       flags.version || getPackageVersion(React.templateName);
@@ -86,7 +86,13 @@ export default class React extends Command {
       name,
       '--template',
       `${React.templateName}@${templateVersion}`,
-    ]);
+    ]).catch((_e) =>
+      Promise.reject(
+        new Error(
+          'create-react-app is not able to create the project. See the logs above for more information.'
+        )
+      )
+    );
   }
 
   private async setupEnvironmentVariables(name: string) {
@@ -151,7 +157,7 @@ export default class React extends Command {
   }
 
   private async runReactCliCommand(commandArgs: string[], options = {}) {
-    return new Promise<string>((resolve) => {
+    return new Promise<string>((resolve, reject) => {
       const child = spawnProcessPTY(
         appendCmdIfWindows`npx`,
         ['create-react-app'].concat([...commandArgs]),
@@ -174,7 +180,10 @@ export default class React extends Command {
         }
       });
 
-      child.onExit(() => {
+      child.onExit((exitCode) => {
+        if (exitCode) {
+          reject();
+        }
         resolve(remainingString);
       });
     });

--- a/packages/cli/src/commands/ui/create/react.ts
+++ b/packages/cli/src/commands/ui/create/react.ts
@@ -180,7 +180,7 @@ export default class React extends Command {
         }
       });
 
-      child.onExit((exitCode) => {
+      child.onExit(({exitCode}) => {
         if (exitCode) {
           reject();
         }

--- a/packages/cli/src/lib/utils/process.ts
+++ b/packages/cli/src/lib/utils/process.ts
@@ -1,5 +1,5 @@
 import {spawn, SpawnOptions} from 'child_process';
-import {spawn as ptySpawn} from 'node-pty';
+import {spawn as ptySpawn, IWindowsPtyForkOptions} from 'node-pty';
 
 /**
  *
@@ -78,13 +78,14 @@ export async function spawnProcessOutput(
 export function spawnProcessPTY(
   command: string,
   args: string[],
-  options: SpawnOptions = {}
+  options: IWindowsPtyForkOptions = {}
 ) {
   const ptyProcess = ptySpawn(command, args, {
     name: 'xterm-color',
     cols: process.stdout.columns,
     rows: process.stdout.rows,
     cwd: options.cwd ?? process.cwd(),
+    useConpty: false,
   });
 
   return ptyProcess;


### PR DESCRIPTION
For Windows, it seems that `conPty` is not very stable yet, enforcing the usage of `winPty` fixes the console not being released.

We need to handle the rejection of the pty with the code (no stderr: () and process it properly for all OSes.
