### PR TITLE
ci(release): extract fragment of release notes for github release

### DIFF
--- a/scripts/release-changelog.js
+++ b/scripts/release-changelog.js
@@ -7,7 +7,9 @@ const fs = require('fs');
 async function main() {
   const tag = await getLatestTag();
   const changelog = fs.readFileSync('CHANGELOG.md', 'utf8');
-  await createOrUpdateReleaseDescription(tag, changelog);
+  const changelogVersioned = changelog.split(/^#{1,2} .*$/gm); //Lines starting with one or two `#` are separator
+  const changelogLastVersion = changelogVersioned[2].trim(); // Third paragraph because: 0 is before the header (empty str), 1 is just after `# changelog` (all notable changes etc), 2 is the latest release
+  await createOrUpdateReleaseDescription(tag, changelogLastVersion);
 }
 
 main();


### PR DESCRIPTION
## Proposed changes

Split the changelog using a regex matching all `h1` and `h2` and extract the changeset on top.
Then, use the same process as before for publishing.

## Testing

Tested on my machine by altering the changelog.md and running the script (logging instead of publishing, ofc). I also checked what the RegExp was doing here: https://regex101.com/r/UitWby/1.


-----
CDX-185