### PR TITLE
fix(angular): fix Coveo headless error on application run

### DIFF
--- a/packages/angular/src/ng-add-setup-project/index.ts
+++ b/packages/angular/src/ng-add-setup-project/index.ts
@@ -10,6 +10,7 @@ import {
 } from '../common-rules/dependencies';
 import {updateNgModule} from './rules/ng-module';
 import {addMaterialAngular, addToPackageJson} from './rules/dependencies';
+import {updateTsConfig} from './rules/tsconfig';
 
 export default function (options: CoveoSchema): Rule {
   return async (tree: Tree) => {
@@ -20,6 +21,7 @@ export default function (options: CoveoSchema): Rule {
       addMaterialAngular(options),
       createFiles(options),
       updateNgModule(options, project),
+      updateTsConfig(options),
     ]);
   };
 }

--- a/packages/angular/src/ng-add-setup-project/rules/tsconfig.ts
+++ b/packages/angular/src/ng-add-setup-project/rules/tsconfig.ts
@@ -1,0 +1,32 @@
+import {Rule, SchematicContext, Tree} from '@angular-devkit/schematics';
+import {normalize} from '@angular-devkit/core';
+import {CoveoSchema} from '../../schema';
+import {EOL} from 'os';
+
+export function updateTsConfig(_options: CoveoSchema): Rule {
+  return (tree: Tree, _context: SchematicContext) => {
+    const tsconfigBuffer = tree.read(normalize('./tsconfig.json'));
+    if (tsconfigBuffer === null) {
+      return;
+    }
+    try {
+      const fileArray = tsconfigBuffer.toString().split(EOL);
+      const tsconfigcomment = fileArray[0];
+      const tsConfig = JSON.parse(fileArray.slice(1).join(EOL));
+
+      tsConfig.compilerOptions.allowSyntheticDefaultImports = true;
+
+      tree.overwrite(
+        normalize('./tsconfig.json'),
+        `${tsconfigcomment}
+${JSON.stringify(tsConfig, null, 4)}`
+      );
+    } catch (error) {
+      console.error(
+        `Unable to update the Angular tsconfig.json file by adding the "allowSyntheticDefaultImports" flag.
+Make sure to add this flag to your tsconfig.json. Otherwise, you might experience errors when running the app`,
+        error
+      );
+    }
+  };
+}

--- a/packages/angular/src/ng-add-setup-project/rules/tsconfig.ts
+++ b/packages/angular/src/ng-add-setup-project/rules/tsconfig.ts
@@ -14,7 +14,7 @@ export function updateTsConfig(_options: CoveoSchema): Rule {
       const tsconfigcomment = fileArray[0];
       const tsConfig = JSON.parse(fileArray.slice(1).join(EOL));
 
-      tsConfig.compilerOptions.allowSyntheticDefaultImports = true;
+      tsConfig.compilerOptions.skipLibCheck = true;
 
       tree.overwrite(
         normalize('./tsconfig.json'),


### PR DESCRIPTION
https://coveord.atlassian.net/browse/CDX-280

## Proposed changes

I updated the angular `tsconfig.json` file to include the `allowSyntheticDefaultImports` flag. Otherwise the `npm start` command leads to an error (see image). 
![image](https://user-images.githubusercontent.com/12199712/116814310-459dab80-ab26-11eb-8078-648b7bd6ea24.png)

### Note:
All other templates (React and Vue) have the `allowSyntheticDefaultImports` flag in their `tsconfig.json`.

## Testing

This is already covered by current E2E tests.

-----
CDX-280

