### PR TITLE
fix(angular): fix angular modifier to works with windows

### DIFF
--- a/packages/angular/src/ng-add-setup-project/rules/tsconfig.ts
+++ b/packages/angular/src/ng-add-setup-project/rules/tsconfig.ts
@@ -1,7 +1,8 @@
 import {Rule, SchematicContext, Tree} from '@angular-devkit/schematics';
 import {normalize} from '@angular-devkit/core';
 import {CoveoSchema} from '../../schema';
-import {EOL} from 'os';
+
+const commentRegExp = /\/\*.*\*\//;
 
 export function updateTsConfig(_options: CoveoSchema): Rule {
   return (tree: Tree, _context: SchematicContext) => {
@@ -10,15 +11,17 @@ export function updateTsConfig(_options: CoveoSchema): Rule {
       return;
     }
     try {
-      const fileArray = tsconfigBuffer.toString().split(EOL);
-      const tsconfigcomment = fileArray[0];
-      const tsConfig = JSON.parse(fileArray.slice(1).join(EOL));
+      const originalTsConfig = tsconfigBuffer.toString();
+      const tsConfigComment =
+        originalTsConfig.match(commentRegExp)?.[0]?.trim() ?? '';
+      const tsConfig = JSON.parse(
+        originalTsConfig.replace(commentRegExp, '').trim()
+      );
 
       tsConfig.compilerOptions.skipLibCheck = true;
-
       tree.overwrite(
         normalize('./tsconfig.json'),
-        `${tsconfigcomment}
+        `${tsConfigComment}
 ${JSON.stringify(tsConfig, null, 4)}`
       );
     } catch (error) {


### PR DESCRIPTION
## Proposed changes

Replace the logic for the original tsConfig parsing to not depend in anyway to EOL characters by using native function (`.trim()`) to deal with it and a little RegExp to select the comment line. at the beginning of the tsconfig.

## Testing

- [] Unit Tests: Not UT-able.
- [] Functionnal Tests: Cant do: Need Windows FT setup 😿 
- [x] Manual Tests: Spin up Verdaccio and published the template in it then run the coveo CLI 1.1.0 (bin) to try it out.

-----
CDX-287