### PR TITLE
test(e2e): bump up filewatcher

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,11 +12,14 @@ jobs:
       PLATFORM_USER_NAME: ${{ secrets.PLATFORM_USER_NAME }}
       PLATFORM_USER_PASSWORD: ${{ secrets.PLATFORM_USER_PASSWORD }}
     steps:
+      - name: Setup runner
+        # Ensure we can use as many file watcher as we want. see https://github.com/facebook/create-react-app/blob/master/docusaurus/docs/troubleshooting.md#npm-start-fail-due-to-watch-error
+        run: echo fs.inotify.max_user_watches=524288 | tee -a /etc/sysctl.conf && sysctl -p
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
           node-version: '14'
-      - name: Setup
+      - name: Setup repo
         run: npm run setup
       - name: Check linting
         run: npm run lint

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - name: Setup runner
         # Ensure we can use as many file watcher as we want. see https://github.com/facebook/create-react-app/blob/master/docusaurus/docs/troubleshooting.md#npm-start-fail-due-to-watch-error
-        run: echo fs.inotify.max_user_watches=524288 | tee -a /etc/sysctl.conf && sysctl -p
+        run: echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:


### PR DESCRIPTION
## Proposed changes

Increase the limit of filewatcher as recommended by Create-React-App see [here](https://github.com/facebook/create-react-app/blob/master/docusaurus/docs/troubleshooting.md#npm-start-fail-due-to-watch-error).

I elected to not use `CHOKIDAR_USEPOLLING=true` which is another recommendation that's made for using CRA in VM environment for two reasons:
1. Mainly meant to be used for networking issue, which are more likely to occur when the watched file are shared between the host and the container, which is not our case.
2. The option is potentially more CPU intensive, see [here](https://github.com/paulmillr/chokidar#performance). And I'd like to avoid straining the CPU of the GitHub runners.

However, if the proposed change ain't enough, that'll probably be the next step.

## Testing

Modifs are all in CI, so, I'll do a bunch of runs and see what gives.

-----
CDX-290