### PR TITLE
test(cli): add timestamps in log files

### DIFF
--- a/packages/cli-e2e/utils/filelogger.ts
+++ b/packages/cli-e2e/utils/filelogger.ts
@@ -12,4 +12,17 @@ export class FileLogger {
     this.stdout = createWriteStream(join(dir, 'stdout'));
     this.stderr = createWriteStream(join(dir, 'stderr'));
   }
+
+  private formatTime(hours: number, minutes: number, seconds: number): string {
+    const formatter = (n: number) => `0${n}`.slice(-2);
+    return [hours, minutes, seconds].map(formatter).join(':');
+  }
+
+  public getTimestamp() {
+    const now = new Date();
+    const hours = now.getHours();
+    const minutes = now.getMinutes();
+    const seconds = now.getSeconds();
+    return this.formatTime(hours, minutes, seconds);
+  }
 }

--- a/packages/cli-e2e/utils/filelogger.ts
+++ b/packages/cli-e2e/utils/filelogger.ts
@@ -15,7 +15,8 @@ export class FileLogger {
 
   private formatTime(hours: number, minutes: number, seconds: number): string {
     const formatter = (n: number) => `0${n}`.slice(-2);
-    return [hours, minutes, seconds].map(formatter).join(':');
+    const time = [hours, minutes, seconds].map(formatter).join(':');
+    return `[${time}] `;
   }
 
   public getTimestamp() {

--- a/packages/cli-e2e/utils/terminal/terminal.ts
+++ b/packages/cli-e2e/utils/terminal/terminal.ts
@@ -8,7 +8,7 @@ import type {When} from './when';
 import {ProcessManager} from '../processManager';
 import {Orchestrator} from './orchestrator';
 import {FileLogger} from '../filelogger';
-import {WriteStream} from 'node:fs';
+import {WriteStream} from 'fs';
 
 /**
  * An helper class to manipulate processes that interact with a TTY.

--- a/packages/cli-e2e/utils/terminal/terminal.ts
+++ b/packages/cli-e2e/utils/terminal/terminal.ts
@@ -42,11 +42,11 @@ export class Terminal {
   }
 
   private logIntoFile(fileLogger: FileLogger) {
-    const addTimestampToFile = (stream: WriteStream) => () =>
+    const appendTimestamp = (stream: WriteStream) => () =>
       stream.write(fileLogger.getTimestamp());
 
-    this.childProcess.stdout.on('data', addTimestampToFile(fileLogger.stdout));
-    this.childProcess.stderr.on('data', addTimestampToFile(fileLogger.stderr));
+    this.childProcess.stdout.on('data', appendTimestamp(fileLogger.stdout));
+    this.childProcess.stderr.on('data', appendTimestamp(fileLogger.stderr));
 
     this.childProcess.stdout.pipe(fileLogger.stdout, {end: true});
     this.childProcess.stderr.pipe(fileLogger.stderr, {end: true});


### PR DESCRIPTION
https://coveord.atlassian.net/browse/CDX-300

## Proposed changes

Prepend a timestamp on every line that is added to the artifacts.
This will help knowing how long each spawn process takes
![image](https://user-images.githubusercontent.com/12199712/117350638-cb00c300-ae7a-11eb-8dcc-54897de6be58.png)

-----
CDX-300
