### PR TITLE
test(cli): increase E2E timetout for angular

### DIFF
--- a/packages/cli-e2e/__tests__/angular.specs.ts
+++ b/packages/cli-e2e/__tests__/angular.specs.ts
@@ -77,7 +77,7 @@ describe('ui:create:angular', () => {
     browser = await getNewBrowser();
     await buildApplication(buildProcessManager);
     await buildProcessManager.killAllProcesses();
-  }, 15 * 60e3);
+  }, 20 * 60e3);
 
   beforeEach(async () => {
     jest.resetModules();
@@ -107,7 +107,7 @@ describe('ui:create:angular', () => {
       serverProcessManager = new ProcessManager();
       processManagers.push(serverProcessManager);
       await startApplication(serverProcessManager);
-    }, 5 * 60e3);
+    }, 15 * 60e3);
 
     beforeEach(async () => {
       consoleInterceptor = new BrowserConsoleInterceptor(page, projectName);
@@ -190,7 +190,7 @@ describe('ui:create:angular', () => {
       processManagers.push(serverProcessManager);
       await deactivateEnvironmentFile(projectName);
       await startApplication(serverProcessManager);
-    }, 5 * 60e3);
+    }, 15 * 60e3);
 
     afterAll(async () => {
       await restoreEnvironmentFile(projectName);


### PR DESCRIPTION
https://coveord.atlassian.net/browse/CDX-299

## Proposed changes

The angular E2E tests sometime fail and I suspect a timeout issue. In this PR, we simply give a couple more minutes to the angular setup phase.

Once #205 is merged, we will be able to confirm if the errors are caused by an insufficient timeout by inspecting the log timestamps.

-----
CDX-299

