### PR TITLE
chore(commitlint): update commitlint dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -147,33 +147,56 @@
       }
     },
     "@commitlint/config-conventional": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/config-conventional/-/config-conventional-11.0.0.tgz",
-      "integrity": "sha512-SNDRsb5gLuDd2PL83yCOQX6pE7gevC79UPFx+GLbLfw6jGnnbO9/tlL76MLD8MOViqGbo7ZicjChO9Gn+7tHhA==",
+      "version": "12.1.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/config-conventional/-/config-conventional-12.1.1.tgz",
+      "integrity": "sha512-15CqbXMsQiEb0qbzjEHe2OkzaXPYSp7RxaS6KoSVk/4W0QiigquavQ+M0huBZze92h0lMS6Pxoq4AJ5CQ3D+iQ==",
       "dev": true,
       "requires": {
         "conventional-changelog-conventionalcommits": "^4.3.1"
       }
     },
     "@commitlint/config-lerna-scopes": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/config-lerna-scopes/-/config-lerna-scopes-11.0.0.tgz",
-      "integrity": "sha512-/PjLKefMlnG+Sk27MY3MZo+T/9/PrgDcLk1YCSPVHNkXibXiS2Hb5NEMuNHzPxwts4IvJo0WIOb0YOBx5GBsdA==",
+      "version": "12.1.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/config-lerna-scopes/-/config-lerna-scopes-12.1.1.tgz",
+      "integrity": "sha512-j5u3UHbd4nccBTz0DVraO5cJDVdMgEh7sfuW9BH9SPxlI2F0LmLUIssrUuyCNL1bk+VIH2pdAWonlIlAAfJ4Nw==",
       "dev": true,
       "requires": {
+        "globby": "^11.0.1",
         "import-from": "3.0.0",
         "resolve-pkg": "2.0.0",
-        "semver": "7.3.2"
+        "semver": "7.3.5"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "7.3.5",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        }
       }
     },
     "@commitlint/ensure": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/ensure/-/ensure-11.0.0.tgz",
-      "integrity": "sha512-/T4tjseSwlirKZdnx4AuICMNNlFvRyPQimbZIOYujp9DSO6XRtOy9NrmvWujwHsq9F5Wb80QWi4WMW6HMaENug==",
+      "version": "12.1.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/ensure/-/ensure-12.1.1.tgz",
+      "integrity": "sha512-XEUQvUjzBVQM7Uv8vYz+c7PDukFvx0AvQEyX/V+PaTkCK/xPvexu7FLbFwvypjSt9BPMf+T/rhB1hVmldkd6lw==",
       "dev": true,
       "requires": {
-        "@commitlint/types": "^11.0.0",
+        "@commitlint/types": "^12.1.1",
         "lodash": "^4.17.19"
+      },
+      "dependencies": {
+        "@commitlint/types": {
+          "version": "12.1.1",
+          "resolved": "https://registry.npmjs.org/@commitlint/types/-/types-12.1.1.tgz",
+          "integrity": "sha512-+qGH+s2Lo6qwacV2X3/ZypZwaAI84ift+1HBjXdXtI/q0F5NtmXucV3lcQOTviMTNiJhq4qWON2fjci2NItASw==",
+          "dev": true,
+          "requires": {
+            "chalk": "^4.0.0"
+          }
+        }
       }
     },
     "@commitlint/execute-rule": {
@@ -184,25 +207,56 @@
       "optional": true
     },
     "@commitlint/is-ignored": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/is-ignored/-/is-ignored-11.0.0.tgz",
-      "integrity": "sha512-VLHOUBN+sOlkYC4tGuzE41yNPO2w09sQnOpfS+pSPnBFkNUUHawEuA44PLHtDvQgVuYrMAmSWFQpWabMoP5/Xg==",
+      "version": "12.1.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/is-ignored/-/is-ignored-12.1.1.tgz",
+      "integrity": "sha512-Sn4fsnWX+wLAJOD/UZeoVruB98te1TyPYRiDEq0MhRJAQIrP+7jE/O3/ass68AAMq00HvH3OK9kt4UBXggcGjA==",
       "dev": true,
       "requires": {
-        "@commitlint/types": "^11.0.0",
-        "semver": "7.3.2"
+        "@commitlint/types": "^12.1.1",
+        "semver": "7.3.5"
+      },
+      "dependencies": {
+        "@commitlint/types": {
+          "version": "12.1.1",
+          "resolved": "https://registry.npmjs.org/@commitlint/types/-/types-12.1.1.tgz",
+          "integrity": "sha512-+qGH+s2Lo6qwacV2X3/ZypZwaAI84ift+1HBjXdXtI/q0F5NtmXucV3lcQOTviMTNiJhq4qWON2fjci2NItASw==",
+          "dev": true,
+          "requires": {
+            "chalk": "^4.0.0"
+          }
+        },
+        "semver": {
+          "version": "7.3.5",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        }
       }
     },
     "@commitlint/lint": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/lint/-/lint-11.0.0.tgz",
-      "integrity": "sha512-Q8IIqGIHfwKr8ecVZyYh6NtXFmKw4YSEWEr2GJTB/fTZXgaOGtGFZDWOesCZllQ63f1s/oWJYtVv5RAEuwN8BQ==",
+      "version": "12.1.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/lint/-/lint-12.1.1.tgz",
+      "integrity": "sha512-FFFPpku/E0svL1jaUVqosuZJDDWiNWYBlUw5ZEljh3MwWRcoaWtMIX5bseX+IvHpFZsCTAiBs1kCgNulCi0UvA==",
       "dev": true,
       "requires": {
-        "@commitlint/is-ignored": "^11.0.0",
-        "@commitlint/parse": "^11.0.0",
-        "@commitlint/rules": "^11.0.0",
-        "@commitlint/types": "^11.0.0"
+        "@commitlint/is-ignored": "^12.1.1",
+        "@commitlint/parse": "^12.1.1",
+        "@commitlint/rules": "^12.1.1",
+        "@commitlint/types": "^12.1.1"
+      },
+      "dependencies": {
+        "@commitlint/types": {
+          "version": "12.1.1",
+          "resolved": "https://registry.npmjs.org/@commitlint/types/-/types-12.1.1.tgz",
+          "integrity": "sha512-+qGH+s2Lo6qwacV2X3/ZypZwaAI84ift+1HBjXdXtI/q0F5NtmXucV3lcQOTviMTNiJhq4qWON2fjci2NItASw==",
+          "dev": true,
+          "requires": {
+            "chalk": "^4.0.0"
+          }
+        }
       }
     },
     "@commitlint/load": {
@@ -231,19 +285,31 @@
       }
     },
     "@commitlint/message": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/message/-/message-11.0.0.tgz",
-      "integrity": "sha512-01ObK/18JL7PEIE3dBRtoMmU6S3ecPYDTQWWhcO+ErA3Ai0KDYqV5VWWEijdcVafNpdeUNrEMigRkxXHQLbyJA==",
+      "version": "12.1.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/message/-/message-12.1.1.tgz",
+      "integrity": "sha512-RakDSLAiOligXjhbLahV8HowF4K75pZIcs0+Ii9Q8Gz5H3DWf1Ngit7alFTWfcbf/+DTjSzVPov5HiwQZPIBUg==",
       "dev": true
     },
     "@commitlint/parse": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/parse/-/parse-11.0.0.tgz",
-      "integrity": "sha512-DekKQAIYWAXIcyAZ6/PDBJylWJ1BROTfDIzr9PMVxZRxBPc1gW2TG8fLgjZfBP5mc0cuthPkVi91KQQKGri/7A==",
+      "version": "12.1.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/parse/-/parse-12.1.1.tgz",
+      "integrity": "sha512-nuljIvAbBDr93DgL0wCArftEIhjSghawAwhvrKNV9FFcqAJqfVqitwMxJrNDCQ5pgUMCSKULLOEv+dA0bLlTEQ==",
       "dev": true,
       "requires": {
-        "conventional-changelog-angular": "^5.0.0",
+        "@commitlint/types": "^12.1.1",
+        "conventional-changelog-angular": "^5.0.11",
         "conventional-commits-parser": "^3.0.0"
+      },
+      "dependencies": {
+        "@commitlint/types": {
+          "version": "12.1.1",
+          "resolved": "https://registry.npmjs.org/@commitlint/types/-/types-12.1.1.tgz",
+          "integrity": "sha512-+qGH+s2Lo6qwacV2X3/ZypZwaAI84ift+1HBjXdXtI/q0F5NtmXucV3lcQOTviMTNiJhq4qWON2fjci2NItASw==",
+          "dev": true,
+          "requires": {
+            "chalk": "^4.0.0"
+          }
+        }
       }
     },
     "@commitlint/resolve-extends": {
@@ -269,28 +335,40 @@
       }
     },
     "@commitlint/rules": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/rules/-/rules-11.0.0.tgz",
-      "integrity": "sha512-2hD9y9Ep5ZfoNxDDPkQadd2jJeocrwC4vJ98I0g8pNYn/W8hS9+/FuNpolREHN8PhmexXbkjrwyQrWbuC0DVaA==",
+      "version": "12.1.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/rules/-/rules-12.1.1.tgz",
+      "integrity": "sha512-oCcLF/ykcJfhM2DeeaDyrgdaiuKsqIPNocugdPj2WEyhSYqmx1/u18CV96LAtW+WyyiOLCCeiZwiQutx3T5nXg==",
       "dev": true,
       "requires": {
-        "@commitlint/ensure": "^11.0.0",
-        "@commitlint/message": "^11.0.0",
-        "@commitlint/to-lines": "^11.0.0",
-        "@commitlint/types": "^11.0.0"
+        "@commitlint/ensure": "^12.1.1",
+        "@commitlint/message": "^12.1.1",
+        "@commitlint/to-lines": "^12.1.1",
+        "@commitlint/types": "^12.1.1"
+      },
+      "dependencies": {
+        "@commitlint/types": {
+          "version": "12.1.1",
+          "resolved": "https://registry.npmjs.org/@commitlint/types/-/types-12.1.1.tgz",
+          "integrity": "sha512-+qGH+s2Lo6qwacV2X3/ZypZwaAI84ift+1HBjXdXtI/q0F5NtmXucV3lcQOTviMTNiJhq4qWON2fjci2NItASw==",
+          "dev": true,
+          "requires": {
+            "chalk": "^4.0.0"
+          }
+        }
       }
     },
     "@commitlint/to-lines": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/to-lines/-/to-lines-11.0.0.tgz",
-      "integrity": "sha512-TIDTB0Y23jlCNubDROUVokbJk6860idYB5cZkLWcRS9tlb6YSoeLn1NLafPlrhhkkkZzTYnlKYzCVrBNVes1iw==",
+      "version": "12.1.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/to-lines/-/to-lines-12.1.1.tgz",
+      "integrity": "sha512-W23AH2XF5rI27MOAPSSr0TUDoRe7ZbFoRtYhFnPu2MBmcuDA9Tmfd9N5sM2tBXtdE26uq3SazwKqGt1OoGAilQ==",
       "dev": true
     },
     "@commitlint/types": {
       "version": "11.0.0",
       "resolved": "https://registry.npmjs.org/@commitlint/types/-/types-11.0.0.tgz",
       "integrity": "sha512-VoNqai1vR5anRF5Tuh/+SWDFk7xi7oMwHrHrbm1BprYXjB2RJsWLhUrStMssDxEl5lW/z3EUdg8RvH/IUBccSQ==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "@eslint/eslintrc": {
       "version": "0.3.0",
@@ -3938,9 +4016,9 @@
       }
     },
     "conventional-changelog-conventionalcommits": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-4.5.0.tgz",
-      "integrity": "sha512-buge9xDvjjOxJlyxUnar/+6i/aVEVGA7EEh4OafBCXPlLUQPGbRUBhBUveWRxzvR8TEjhKEP4BdepnpG2FSZXw==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-4.6.0.tgz",
+      "integrity": "sha512-sj9tj3z5cnHaSJCYObA9nISf7eq/YjscLPoq6nmew4SiOjxqL2KRpK20fjnjVbpNDjJ2HR3MoVcWKXwbVvzS0A==",
       "dev": true,
       "requires": {
         "compare-func": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -12,9 +12,9 @@
   "devDependencies": {
     "@actions/core": "^1.2.6",
     "@actions/github": "^4.0.0",
-    "@commitlint/config-conventional": "^11.0.0",
-    "@commitlint/config-lerna-scopes": "^11.0.0",
-    "@commitlint/lint": "^11.0.0",
+    "@commitlint/config-conventional": "^12.1.1",
+    "@commitlint/config-lerna-scopes": "^12.1.1",
+    "@commitlint/lint": "^12.1.1",
     "@oclif/dev-cli": "^1.26.0",
     "@types/node": "^10",
     "@typescript-eslint/eslint-plugin": "^4.14.0",


### PR DESCRIPTION
Updated commitlint dependencies to 12.x.
The only breaking change was a change in how `extends` resolve things. However, the only time we use extends is with a an array of a single element, therefore, this won't impact us.

[Commitlint Changelog](https://github.com/conventional-changelog/commitlint/blob/master/CHANGELOG.md#1200-2021-01-18)

-----
CDX-227