### PR TITLE
test(e2e): replace 'linestart' instead of eol

### DIFF
--- a/packages/cli-e2e/utils/timeStamper.ts
+++ b/packages/cli-e2e/utils/timeStamper.ts
@@ -5,7 +5,7 @@ export class TimeStamper extends Transform {
     super({
       transform(chunk, _encoding, callback) {
         this.push(
-          chunk.toString().replace(/\n/gm, `[${TimeStamper.getTimestamp()}]\n`)
+          chunk.toString().replace(/^/gm, `[${TimeStamper.getTimestamp()}]`)
         );
         callback();
       },


### PR DESCRIPTION
## Proposed changes

Ensure the timestamp is:
 - At the beginning of the lines
 - And also at the beginning of the first line
 
To do so, I replaced `\n` by `^`.
It 'match' every line start, including the first one, but does not capture anything (which is nice for our use-case)

You can see it in action [here](
https://www.typescriptlang.org/play?#code/MYewdgzgLgBFCm0DKUBOBLMBzGBeGABgGYggBGAhqgFCUBeRFd1R6ddZAru9TH3CCghqBANzVQkEABt4AOmkgsACgTI0mLHNTwADtIrB4ygPQAdMCawBbADSEA2gA0XAXQsEAlJ4ngIM+UUVNSgUDGxtPQMjUwsrO0ILZzcvH0l-WQUlVURQjQidfUNjEwA9eNsAcmSnV0rvIA).

## Testing

Run the E2E, see logs in CI artifacts ;) 

-----
CDX-324