### PR TITLE
test(e2e): strengthen chrome logic

### DIFF
--- a/packages/cli-e2e/entrypoints/dockerHeadless.sh
+++ b/packages/cli-e2e/entrypoints/dockerHeadless.sh
@@ -28,6 +28,9 @@ node scripts/wait-for-published-packages.js
 
 cd packages/cli-e2e
 
+# Wait for Chrome to be up'n'running.
+while ! timeout 1 bash -c "echo > /dev/tcp/localhost/9222"; do sleep 10; done
+
 if npm run-script jest
 then
     echo "Docker!" | sudo -S rsync -r /home/notGroot/cli-copy/packages/cli-e2e/artifacts/* /home/notGroot/cli/packages/cli-e2e/artifacts

--- a/packages/cli-e2e/entrypoints/dockerX11Entry.sh
+++ b/packages/cli-e2e/entrypoints/dockerX11Entry.sh
@@ -22,4 +22,8 @@ node scripts/wait-for-published-packages.js
 
 cd packages/cli-e2e
 export COVEO_CLI_E2E_DEBUG=true;
+
+# Wait for Chrome to be up'n'running.
+while ! timeout 1 bash -c "echo > /dev/tcp/localhost/9222"; do sleep 10; done
+
 npm run-script jest:debug

--- a/packages/cli-e2e/utils/login.ts
+++ b/packages/cli-e2e/utils/login.ts
@@ -112,6 +112,10 @@ async function startLoginFlow(browser: Browser) {
 
   await retry(async () => strictEqual(await isLoggedin(), true));
 
+  if ((await browser.pages()).length < 2) {
+    await browser.newPage();
+  }
+
   await page.close();
 }
 


### PR DESCRIPTION
## Proposed changes
 - Tests can start before Chrome is up and running. The changes in the shell scripts fix that by ensuring a `fd` is open on TCP localhost:9222 with some bash voodoo thingies (could have used `netcat`, but would require to add a new pkg, so I elected to use this instead because it's still pretty readable IMO.
 
 - Initial login may close the last tab of `notGroot` Chrome (so not the puppeteer chromium, but our instance of the 'user browser', used to test login.). To fix that I open a page if there's just one opened, and this before closing the 'logged-in' page.

## Testing

CI, expected to fail due to Angular errors from CDX-323.

-----
CDX-325
