### PR TITLE
fix(angular): lock-on @angular/material to 11.x

### DIFF
--- a/packages/angular/src/ng-add-setup-project/index.ts
+++ b/packages/angular/src/ng-add-setup-project/index.ts
@@ -29,7 +29,7 @@ export default function (options: CoveoSchema): Rule {
 export function setupDependencies(_options: CoveoSchema): Rule {
   return () =>
     chain([
-      addToPackageJson('@angular/material'),
+      addToPackageJson('@angular/material', '^11.2.11'),
       addToPackageJson('@coveo/headless'),
       addToPackageJson('@coveo/search-token-server'),
       addToPackageJson('concurrently'),

--- a/packages/angular/src/ng-add-setup-project/rules/dependencies.ts
+++ b/packages/angular/src/ng-add-setup-project/rules/dependencies.ts
@@ -11,12 +11,15 @@ import {
 } from '@schematics/angular/utility/dependencies';
 import {CoveoSchema} from '../../schema';
 
-export function addToPackageJson(packageName: string): Rule {
+export function addToPackageJson(
+  packageName: string,
+  version = 'latest'
+): Rule {
   return (tree: Tree, _context: SchematicContext) => {
     const packageToAdd: NodeDependency = {
       type: NodeDependencyType.Default,
       name: packageName,
-      version: 'latest',
+      version,
       overwrite: true,
     };
 


### PR DESCRIPTION
## Proposed changes

Angular released v12 yesterday. It breaks the project generation with angular because we're compatible with Angular v11 but did not test with 12.
Because we we're always installing `latest` angular material, we lost control on this one and drop the ball.

To fix it, install the version that we want.

## Testing
- CI
- FT: covered by existing tests.
- Manual: ensured that switching back to v11 was working by 'replacing' the dep in the package.json post generation, installing, and starting the project

-----
CDX-323