### PR TITLE
build(cli): add public access for the package

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -109,5 +109,8 @@
     "version": "oclif-dev readme && git add README.md",
     "postinstall": "patch-package"
   },
-  "types": "lib/index.d.ts"
+  "types": "lib/index.d.ts",
+  "publishConfig": {
+    "access": "public"
+  }
 }


### PR DESCRIPTION
## Proposed changes

Add the `publishConfig.access: public` to the `package.json` of the CLI.
This made the release fail: https://github.com/coveo/cli/runs/2579919788?check_suite_focus=true :|

Documentation: https://docs.npmjs.com/cli/v7/using-npm/config#access
It default to _restricted_ on scoped package (i.e. that are prepend by `@acme/`). Restricted aka private packages need bona fide authentication, not just a token (or at the very least the token in the CI ain't got right for that.). So npm derp and refuse to proceed.

## Testing

Tested with Verdaccio, but the true test can only be done against npm 😅 

-----
CDX-327