### PR TITLE
test(pptr): small improvements on puppeteer

### DIFF
--- a/packages/cli-e2e/setup.ts
+++ b/packages/cli-e2e/setup.ts
@@ -10,15 +10,14 @@ import {clearAccessTokenFromConfig, loginWithOffice} from './utils/login';
 import {ProcessManager} from './utils/processManager';
 
 async function clearChromeBrowsingData(browser: Browser) {
-  const pages = await browser.pages();
+  const client = await browser.target().createCDPSession();
 
-  const pageClearDataPromise = [];
-  for (const page of pages) {
-    const client = await page.target().createCDPSession();
-    pageClearDataPromise.push(client.send('Network.clearBrowserCookies'));
-    pageClearDataPromise.push(client.send('Network.clearBrowserCache'));
-  }
-  return Promise.all(pageClearDataPromise);
+  const browserClearDataPromises = [
+    client.send('Network.clearBrowserCookies'),
+    client.send('Network.clearBrowserCache'),
+  ];
+
+  return Promise.all(browserClearDataPromises);
 }
 
 export default async function () {

--- a/packages/cli-e2e/setup.ts
+++ b/packages/cli-e2e/setup.ts
@@ -10,14 +10,17 @@ import {clearAccessTokenFromConfig, loginWithOffice} from './utils/login';
 import {ProcessManager} from './utils/processManager';
 
 async function clearChromeBrowsingData(browser: Browser) {
-  const client = await browser.target().createCDPSession();
+  const page = await browser.newPage();
+  const client = await page.target().createCDPSession();
 
   const browserClearDataPromises = [
     client.send('Network.clearBrowserCookies'),
     client.send('Network.clearBrowserCache'),
   ];
 
-  return Promise.all(browserClearDataPromises);
+  await Promise.all(browserClearDataPromises);
+  await client.detach();
+  await page.close();
 }
 
 export default async function () {

--- a/packages/cli-e2e/utils/browserConsoleInterceptor.ts
+++ b/packages/cli-e2e/utils/browserConsoleInterceptor.ts
@@ -58,6 +58,8 @@ export class BrowserConsoleInterceptor {
   public async endSession() {
     const client = await this.getClient();
     client.removeAllListeners('Runtime.consoleAPICalled');
+    await client.detach();
+    this._client = null;
     this.interceptedMessages = [];
   }
 }

--- a/packages/cli-e2e/utils/login.ts
+++ b/packages/cli-e2e/utils/login.ts
@@ -1,5 +1,5 @@
 import retry from 'async-retry';
-import {Browser, BrowserContextEmittedEvents, Page, Target} from 'puppeteer';
+import type {Browser, Page, Target} from 'puppeteer';
 import {
   answerPrompt,
   CLI_EXEC_PATH,
@@ -28,15 +28,12 @@ export async function isLoggedin() {
 
 function waitForLoginPage(browser: Browser) {
   return new Promise<Page>((resolve) => {
-    browser.on(
-      BrowserContextEmittedEvents.TargetChanged,
-      async (target: Target) => {
-        const page = await target.page();
-        if (page && isLoginPage(page)) {
-          resolve(page);
-        }
+    browser.on('targetchanged', async (target: Target) => {
+      const page = await target.page();
+      if (page && isLoginPage(page)) {
+        resolve(page);
       }
-    );
+    });
   });
 }
 

--- a/packages/cli-e2e/utils/login.ts
+++ b/packages/cli-e2e/utils/login.ts
@@ -1,5 +1,5 @@
 import retry from 'async-retry';
-import type {Browser, Page, Target} from 'puppeteer';
+import {Browser, BrowserContextEmittedEvents, Page, Target} from 'puppeteer';
 import {
   answerPrompt,
   CLI_EXEC_PATH,
@@ -28,12 +28,15 @@ export async function isLoggedin() {
 
 function waitForLoginPage(browser: Browser) {
   return new Promise<Page>((resolve) => {
-    browser.on('targetchanged', async (target: Target) => {
-      const page = await target.page();
-      if (page && isLoginPage(page)) {
-        resolve(page);
+    browser.on(
+      BrowserContextEmittedEvents.TargetChanged,
+      async (target: Target) => {
+        const page = await target.page();
+        if (page && isLoginPage(page)) {
+          resolve(page);
+        }
       }
-    });
+    );
   });
 }
 


### PR DESCRIPTION
## Proposed changes
 - Use the `browser.target` for browser specific CDP method.
   - I think (no proof) that `browser.target` will be more reliable than `page.target`
   - It reduces the number of CDP call from `2n` (with `n` being the number of page) to 2.
 - Some code cleaning (comments, used a map to streamline the code).
 - `Promise.all` to allow concurrency on the screenshots.
 - Hard-ref to the browser event name. (i.e. no magic string when possible)

## Testing
 - Ran FT
 - CI
 
-----
CDX-338