### PR TITLE
test(e2e): find the open handles

### DIFF
--- a/packages/cli-e2e/package.json
+++ b/packages/cli-e2e/package.json
@@ -21,7 +21,7 @@
     "test:headless": "node ./entrypoints/entry.js",
     "test:debug": "node ./entrypoints/entry.js --debug",
     "test:bash": "node ./entrypoints/entry.js --bash",
-    "jest": "jest --verbose --runInBand",
+    "jest": "jest --verbose --runInBand --detectOpenHandles",
     "jest:debug": "node --inspect=0.0.0.0:9229 node_modules/.bin/jest --runInBand"
   },
   "bugs": {


### PR DESCRIPTION
I would like to enable this on the whole repo for the time being to figure out the handles that are opened when the test ends.

Con: test length gonna take a hit