### PR TITLE
test(e2e): enable forceExit

### DIFF
--- a/packages/cli-e2e/package.json
+++ b/packages/cli-e2e/package.json
@@ -21,7 +21,7 @@
     "test:headless": "node ./entrypoints/entry.js",
     "test:debug": "node ./entrypoints/entry.js --debug",
     "test:bash": "node ./entrypoints/entry.js --bash",
-    "jest": "jest --verbose --runInBand --detectOpenHandles",
+    "jest": "jest --verbose --runInBand --detectOpenHandles --forceExit",
     "jest:debug": "node --inspect=0.0.0.0:9229 node_modules/.bin/jest --runInBand"
   },
   "bugs": {


### PR DESCRIPTION
## Proposed changes

The processes and 'handles' handling in Windows is fuzzy at best right now, and it makes the tests timeout despite them working properly.

Let's say at Jest to just shut everything down for now. However, we should revisit that in the future because it's problematic for some tests involving unresolved timeout and promises.

-----
CDX-393