### PR TITLE
feat(ui): support for Headless v1

### DIFF
--- a/packages/angular/package-lock.json
+++ b/packages/angular/package-lock.json
@@ -149,31 +149,31 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.14.5.tgz",
-      "integrity": "sha512-121rumjddw9c3NCQ55KGkyE1h/nzWhU/owjhw0l4mQrkzz4x9SGS1X8gFLraHwX7td3Yo4QTL+qj0NcIzN87BA==",
+      "version": "7.14.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.14.6.tgz",
+      "integrity": "sha512-/PCB2uJ7oM44tz8YhC4Z/6PeOKXp4K588f+5M3clr1M4zbqztlo0XEfJ2LEzj/FgwfgGcIdl8n7YYjTCI0BYwg==",
       "dev": true,
       "requires": {
         "regenerator-runtime": "^0.13.4"
       }
     },
     "@coveo/bueno": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/@coveo/bueno/-/bueno-0.16.0.tgz",
-      "integrity": "sha512-5NAWWHDtv05B+2ow9CGYrr3bVUleREfemXtTRve8GC2EOFBTcer3J1MWaWUYGsBfuZCXMg/n/x0ezHlWJCrBJQ==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@coveo/bueno/-/bueno-0.28.0.tgz",
+      "integrity": "sha512-2XOKaL8mVCntmF7nGttKuwhnJJunlXFqp4OmEQXn6tA+sDRUvx6S/hzNHYxv1/l434c3OKgHIUbOjl0a6kTIUg==",
       "dev": true
     },
     "@coveo/headless": {
-      "version": "0.16.2",
-      "resolved": "https://registry.npmjs.org/@coveo/headless/-/headless-0.16.2.tgz",
-      "integrity": "sha512-Tl0JCFlMqkwFvlbPKHiqz49Dz8g98sZMSW2fjAHj7BkpZH8HY7Oq/ZFPnoAXtEqtAC5wxqpdeYaFl2oyqAFmIQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@coveo/headless/-/headless-0.28.1.tgz",
+      "integrity": "sha512-xqk1EJQ8GqfJMrr6iwu6IS8DDI8Qz6jFsY9+6Hdm5b8JECk6BtySMvx7zj1RR4j1ugK0UOxNJl0UAe3FgRwQFg==",
       "dev": true,
       "requires": {
-        "@coveo/bueno": "^0.16.0",
+        "@coveo/bueno": "^0.28.0",
         "@reduxjs/toolkit": "^1.5.0",
         "@types/pino": "^6.3.4",
         "@types/redux-mock-store": "^1.0.2",
-        "coveo.analytics": "^2.18.19",
+        "coveo.analytics": "^2.18.27",
         "cross-fetch": "^3.0.6",
         "dayjs": "^1.9.6",
         "exponential-backoff": "^3.1.0",
@@ -1001,9 +1001,9 @@
       }
     },
     "coveo.analytics": {
-      "version": "2.18.25",
-      "resolved": "https://registry.npmjs.org/coveo.analytics/-/coveo.analytics-2.18.25.tgz",
-      "integrity": "sha512-F4PGDaj4qSVS+j0/uTY+C3RZkN6WHOwuLJFo8ZXJwvREVu4WAOOhLo9Weh8BI8abrPXMubcXQRphXQb41Xb97w==",
+      "version": "2.18.28",
+      "resolved": "https://registry.npmjs.org/coveo.analytics/-/coveo.analytics-2.18.28.tgz",
+      "integrity": "sha512-JQqMqknmhJDPOyqmrXG9b4590Mf2uEbsnEbl25/725K0GOGXb/lTlggnUkb3sKRWbOVY4d+xK9jUZwGpsWU8NQ==",
       "dev": true,
       "requires": {
         "@react-native-async-storage/async-storage": "^1.13.3",

--- a/packages/angular/src/ng-add-setup-project/files/src/app/engine.service.ts
+++ b/packages/angular/src/ng-add-setup-project/files/src/app/engine.service.ts
@@ -8,9 +8,9 @@ import {environment} from '../environments/environment';
 export class EngineService {
   private engine!: SearchEngine;
 
-  constructor() {}
+  public constructor() {}
 
-  init(accessToken: string) {
+  public init(accessToken: string) {
     this.engine = buildSearchEngine({
       configuration: {
         platformUrl: environment.platformUrl,

--- a/packages/angular/src/ng-add-setup-project/files/src/app/engine.service.ts
+++ b/packages/angular/src/ng-add-setup-project/files/src/app/engine.service.ts
@@ -1,17 +1,17 @@
 import {Injectable} from '@angular/core';
-import {HeadlessEngine, searchAppReducers} from '@coveo/headless';
+import {buildSearchEngine, SearchEngine} from '@coveo/headless';
 import {environment} from '../environments/environment';
 
 @Injectable({
   providedIn: 'root',
 })
 export class EngineService {
-  private engine!: HeadlessEngine<typeof searchAppReducers>;
+  private engine!: SearchEngine;
 
-  public constructor() {}
+  constructor() {}
 
-  public init(accessToken: string) {
-    this.engine = new HeadlessEngine({
+  init(accessToken: string) {
+    this.engine = buildSearchEngine({
       configuration: {
         platformUrl: environment.platformUrl,
         organizationId: environment.organizationId,
@@ -22,7 +22,6 @@ export class EngineService {
           return token;
         },
       },
-      reducers: searchAppReducers,
     });
   }
 

--- a/packages/angular/src/ng-add-setup-project/files/src/app/search-box/search-box.component.ts
+++ b/packages/angular/src/ng-add-setup-project/files/src/app/search-box/search-box.component.ts
@@ -33,7 +33,6 @@ export class SearchBoxComponent implements OnInit {
   public search() {
     if (!this.headlessSearchBox.state.isLoading) {
       this.headlessSearchBox.submit();
-      this.headlessSearchBox.hideSuggestions();
     }
   }
 

--- a/packages/angular/src/ng-add-setup-project/files/src/app/search-page/search-page.component.ts
+++ b/packages/angular/src/ng-add-setup-project/files/src/app/search-page/search-page.component.ts
@@ -1,5 +1,4 @@
 import {Component, AfterViewInit} from '@angular/core';
-import {AnalyticsActions, SearchActions} from '@coveo/headless';
 import {EngineService} from '../engine.service';
 
 @Component({
@@ -11,11 +10,7 @@ export class SearchPageComponent implements AfterViewInit {
   public constructor(private engineService: EngineService) {}
 
   public executeSearch() {
-    const {dispatch} = this.engineService.get();
-    const action = SearchActions.executeSearch(
-      AnalyticsActions.logInterfaceLoad()
-    );
-    dispatch(action);
+    this.engineService.get().executeFirstSearch();
   }
 
   public ngAfterViewInit(): void {

--- a/packages/cli/package-lock.json
+++ b/packages/cli/package-lock.json
@@ -43,24 +43,6 @@
         "rxjs": "6.6.3"
       }
     },
-    "@angular/cdk": {
-      "version": "11.2.13",
-      "resolved": "https://registry.npmjs.org/@angular/cdk/-/cdk-11.2.13.tgz",
-      "integrity": "sha512-FkE4iCwoLbQxLDUOjV1I7M/6hmpyb7erAjEdWgch7nGRNxF1hqX5Bqf1lvLFKPNCbx5NRI5K7YVAdIUQUR8vug==",
-      "dev": true,
-      "requires": {
-        "parse5": "^5.0.0",
-        "tslib": "^2.0.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
-          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==",
-          "dev": true
-        }
-      }
-    },
     "@angular/cli": {
       "version": "11.2.12",
       "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-11.2.12.tgz",
@@ -1304,96 +1286,6 @@
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
-      "dev": true
-    },
-    "@coveo/angular": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@coveo/angular/-/angular-1.3.0.tgz",
-      "integrity": "sha512-7Jebg2MgxTNPEF3JHZvStuBz+Qc3boilArO6B6rbhp5mEsLmB/Q0QsrJzDUpJNsM36tswqBrU2SFfw9mtP7YaQ==",
-      "dev": true,
-      "requires": {
-        "@angular-devkit/core": "^11.1.2",
-        "@angular-devkit/schematics": "^11.1.2",
-        "@angular/cdk": "^11.1.1",
-        "@angular/cli": "^11.1.2",
-        "@coveo/search-token-server": "^1.3.0",
-        "@schematics/angular": "^11.1.2",
-        "typescript": "~4.1.2"
-      },
-      "dependencies": {
-        "typescript": {
-          "version": "4.1.5",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.5.tgz",
-          "integrity": "sha512-6OSu9PTIzmn9TCDiovULTnET6BgXtDYL4Gg4szY+cGsc3JP1dQL8qvE8kShTRx1NIw4Q9IBHlwODjkjWEtMUyA==",
-          "dev": true
-        }
-      }
-    },
-    "@coveo/cra-template": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@coveo/cra-template/-/cra-template-1.3.0.tgz",
-      "integrity": "sha512-9H9KMDCJ1QJmejFoyeVHKh2uUkyhCIa0/W0BRqaVG9MmaTIPq40sAvuOji7U0IvMZkXh+mCEVOUYaqIoIH4j1A==",
-      "dev": true
-    },
-    "@coveo/search-token-server": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@coveo/search-token-server/-/search-token-server-1.3.0.tgz",
-      "integrity": "sha512-8N1aMrHNu5iFmFNNs40ihhzdL3HU1zydOwx20NmkhVig+lz6hSWrA6/1EoWvV4qKaE9fufYBtiD+34NYcHkIMg==",
-      "dev": true,
-      "requires": {
-        "@coveord/platform-client": "^11.0.0",
-        "@types/express": "^4.17.11",
-        "abortcontroller-polyfill": "^1.7.1",
-        "cors": "^2.8.5",
-        "dotenv": "^8.2.0",
-        "express": "^4.17.1",
-        "isomorphic-fetch": "^3.0.0",
-        "ts-node": "^9.1.1",
-        "typescript": "^4.1.5"
-      },
-      "dependencies": {
-        "@coveord/platform-client": {
-          "version": "11.3.0",
-          "resolved": "https://registry.npmjs.org/@coveord/platform-client/-/platform-client-11.3.0.tgz",
-          "integrity": "sha512-BCVXK7KYWLnVADPv6ecyjcPV8vwpRUft+iOZFJa7zCBYQo5UwLX1GP7ihrilNYBuSkPh3Lcqr6aha/8zcvESvA==",
-          "dev": true,
-          "requires": {
-            "exponential-backoff": "^3.1.0",
-            "form-data": "^3.0.0",
-            "query-string": "^6.13.1"
-          }
-        },
-        "form-data": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
-          "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
-          "dev": true,
-          "requires": {
-            "asynckit": "^0.4.0",
-            "combined-stream": "^1.0.8",
-            "mime-types": "^2.1.12"
-          }
-        },
-        "ts-node": {
-          "version": "9.1.1",
-          "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-9.1.1.tgz",
-          "integrity": "sha512-hPlt7ZACERQGf03M253ytLY3dHbGNGrAq9qIHWUY9XHYl1z7wYngSr3OQ5xmui8o2AaxsONxIzjafLUiWBo1Fg==",
-          "dev": true,
-          "requires": {
-            "arg": "^4.1.0",
-            "create-require": "^1.1.0",
-            "diff": "^4.0.1",
-            "make-error": "^1.1.1",
-            "source-map-support": "^0.5.17",
-            "yn": "3.1.1"
-          }
-        }
-      }
-    },
-    "@coveo/vue-cli-plugin-typescript": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@coveo/vue-cli-plugin-typescript/-/vue-cli-plugin-typescript-1.3.0.tgz",
-      "integrity": "sha512-jBrlBV8TcntWxBbNyzDL9Tudonbp+2UApB2/OEvPttRgyrGBcCHcaz4TEyEWizMyI0DqUZmKiUi25XdVX+JZ9g==",
       "dev": true
     },
     "@coveord/platform-client": {
@@ -5850,12 +5742,6 @@
         }
       }
     },
-    "create-require": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
-      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
-      "dev": true
-    },
     "cross-spawn": {
       "version": "6.0.5",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
@@ -6276,12 +6162,6 @@
           "dev": true
         }
       }
-    },
-    "dotenv": {
-      "version": "8.6.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.6.0.tgz",
-      "integrity": "sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==",
-      "dev": true
     },
     "download": {
       "version": "7.1.0",
@@ -11151,13 +11031,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
       "integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY="
-    },
-    "parse5": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.1.tgz",
-      "integrity": "sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug==",
-      "dev": true,
-      "optional": true
     },
     "parseurl": {
       "version": "1.3.3",

--- a/packages/cra-template/package-lock.json
+++ b/packages/cra-template/package-lock.json
@@ -102,22 +102,22 @@
       }
     },
     "@coveo/bueno": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/@coveo/bueno/-/bueno-0.16.0.tgz",
-      "integrity": "sha512-5NAWWHDtv05B+2ow9CGYrr3bVUleREfemXtTRve8GC2EOFBTcer3J1MWaWUYGsBfuZCXMg/n/x0ezHlWJCrBJQ==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@coveo/bueno/-/bueno-0.28.0.tgz",
+      "integrity": "sha512-2XOKaL8mVCntmF7nGttKuwhnJJunlXFqp4OmEQXn6tA+sDRUvx6S/hzNHYxv1/l434c3OKgHIUbOjl0a6kTIUg==",
       "dev": true
     },
     "@coveo/headless": {
-      "version": "0.16.2",
-      "resolved": "https://registry.npmjs.org/@coveo/headless/-/headless-0.16.2.tgz",
-      "integrity": "sha512-Tl0JCFlMqkwFvlbPKHiqz49Dz8g98sZMSW2fjAHj7BkpZH8HY7Oq/ZFPnoAXtEqtAC5wxqpdeYaFl2oyqAFmIQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@coveo/headless/-/headless-0.28.1.tgz",
+      "integrity": "sha512-xqk1EJQ8GqfJMrr6iwu6IS8DDI8Qz6jFsY9+6Hdm5b8JECk6BtySMvx7zj1RR4j1ugK0UOxNJl0UAe3FgRwQFg==",
       "dev": true,
       "requires": {
-        "@coveo/bueno": "^0.16.0",
+        "@coveo/bueno": "^0.28.0",
         "@reduxjs/toolkit": "^1.5.0",
         "@types/pino": "^6.3.4",
         "@types/redux-mock-store": "^1.0.2",
-        "coveo.analytics": "^2.18.19",
+        "coveo.analytics": "^2.18.27",
         "cross-fetch": "^3.0.6",
         "dayjs": "^1.9.6",
         "exponential-backoff": "^3.1.0",
@@ -716,9 +716,9 @@
       "dev": true
     },
     "coveo.analytics": {
-      "version": "2.18.25",
-      "resolved": "https://registry.npmjs.org/coveo.analytics/-/coveo.analytics-2.18.25.tgz",
-      "integrity": "sha512-F4PGDaj4qSVS+j0/uTY+C3RZkN6WHOwuLJFo8ZXJwvREVu4WAOOhLo9Weh8BI8abrPXMubcXQRphXQb41Xb97w==",
+      "version": "2.18.28",
+      "resolved": "https://registry.npmjs.org/coveo.analytics/-/coveo.analytics-2.18.28.tgz",
+      "integrity": "sha512-JQqMqknmhJDPOyqmrXG9b4590Mf2uEbsnEbl25/725K0GOGXb/lTlggnUkb3sKRWbOVY4d+xK9jUZwGpsWU8NQ==",
       "dev": true,
       "requires": {
         "@react-native-async-storage/async-storage": "^1.13.3",

--- a/packages/cra-template/template/src/App.tsx
+++ b/packages/cra-template/template/src/App.tsx
@@ -6,7 +6,7 @@ import coveologo from './coveologo.svg';
 import {BrowserRouter as Router, Route} from 'react-router-dom';
 import {Grid, Typography, Box} from '@material-ui/core';
 import {initializeHeadlessEngine} from './common/Engine';
-import {Engine} from '@coveo/headless';
+import {SearchEngine} from '@coveo/headless';
 
 export default function App() {
   return (
@@ -36,7 +36,7 @@ const GuardedRoute = () => {
 };
 
 const Home = () => {
-  const [engine, setEngine] = React.useState<Engine | null>(null);
+  const [engine, setEngine] = React.useState<SearchEngine | null>(null);
 
   useEffect(() => {
     initializeHeadlessEngine().then((engine) => {

--- a/packages/cra-template/template/src/Components/SearchPage.tsx
+++ b/packages/cra-template/template/src/Components/SearchPage.tsx
@@ -9,21 +9,17 @@ import Pager from './Pager';
 import Sort from './Sort';
 import FacetList from './FacetList';
 import ResultsPerPage from './ResultsPerPage';
-import {AnalyticsActions, SearchActions, Engine} from '@coveo/headless';
+import {SearchEngine} from '@coveo/headless';
 import {EngineProvider} from '../common/engineContext';
 
 interface ISearchPageProps {
-  engine: Engine;
+  engine: SearchEngine;
 }
 
 const SearchPage: React.FunctionComponent<ISearchPageProps> = (props) => {
   const {engine} = props;
   useEffect(() => {
-    const {dispatch} = engine;
-    const action = SearchActions.executeSearch(
-      AnalyticsActions.logInterfaceLoad()
-    );
-    dispatch(action);
+    engine.executeFirstSearch();
   }, [engine]);
 
   return (

--- a/packages/cra-template/template/src/common/Engine.tsx
+++ b/packages/cra-template/template/src/common/Engine.tsx
@@ -1,4 +1,4 @@
-import {HeadlessEngine, searchAppReducers} from '@coveo/headless';
+import {buildSearchEngine} from '@coveo/headless';
 
 const getEndpointToLocalServer = () => {
   if (!process.env.REACT_APP_SERVER_PORT) {
@@ -20,13 +20,12 @@ export async function getSearchToken() {
 }
 
 export async function initializeHeadlessEngine() {
-  return new HeadlessEngine({
+  return buildSearchEngine({
     configuration: {
       platformUrl: process.env.REACT_APP_PLATFORM_URL,
       organizationId: process.env.REACT_APP_ORGANIZATION_ID!,
       accessToken: await getSearchToken(),
       renewAccessToken: getSearchToken,
     },
-    reducers: searchAppReducers,
   });
 }

--- a/packages/cra-template/template/src/common/engineContext.ts
+++ b/packages/cra-template/template/src/common/engineContext.ts
@@ -1,7 +1,7 @@
-import {Engine} from '@coveo/headless';
+import {SearchEngine} from '@coveo/headless';
 import {createContext} from 'react';
 
-const EngineContext = createContext<Engine | null>(null);
+const EngineContext = createContext<SearchEngine | null>(null);
 
 export const EngineProvider = EngineContext.Provider;
 

--- a/packages/vue-cli-plugin-typescript/generator/template/src/EngineService.ts
+++ b/packages/vue-cli-plugin-typescript/generator/template/src/EngineService.ts
@@ -1,9 +1,7 @@
-import {HeadlessEngine, searchAppReducers} from '@coveo/headless';
+import {buildSearchEngine, SearchEngine} from '@coveo/headless';
 import {getTokenEndpoint, isEnvValid} from './utils/envUtils';
 
-export function getEngine(
-  token: string
-): HeadlessEngine<typeof searchAppReducers> {
+export function getEngine(token: string): SearchEngine {
   if (!isEnvValid(process.env)) {
     throw new Error(`
     You should have a valid <code>.env</code> file at the root of this \
@@ -14,7 +12,7 @@ export function getEngine(
     Refer to the project README file for more information.
     `);
   } else {
-    return new HeadlessEngine({
+    return buildSearchEngine({
       configuration: {
         platformUrl: process.env.VUE_APP_PLATFORM_URL,
         organizationId: process.env.VUE_APP_ORGANIZATION_ID,
@@ -25,7 +23,6 @@ export function getEngine(
           return token;
         },
       },
-      reducers: searchAppReducers,
     });
   }
 }

--- a/packages/vue-cli-plugin-typescript/generator/template/src/components/Pager.vue
+++ b/packages/vue-cli-plugin-typescript/generator/template/src/components/Pager.vue
@@ -10,7 +10,7 @@
 </template>
 <script lang="ts">
 import Vue from 'vue';
-import {buildPager, Engine} from '@coveo/headless';
+import {buildPager, SearchEngine} from '@coveo/headless';
 import type {Pager, PagerState as HeadlessPagerState} from '@coveo/headless';
 
 export interface PagerState extends HeadlessPagerState {
@@ -30,8 +30,8 @@ export default Vue.extend({
     return {
       pager: pager,
       state: {...pager.state, total: 0},
-      totalCount: (this.$root.$data.$engine as Engine).state.search.response
-        .totalCountFiltered,
+      totalCount: (this.$root.$data.$engine as SearchEngine).state.search
+        .response.totalCountFiltered,
     };
   },
   methods: {

--- a/packages/vue-cli-plugin-typescript/generator/template/src/components/SearchPage.vue
+++ b/packages/vue-cli-plugin-typescript/generator/template/src/components/SearchPage.vue
@@ -38,7 +38,6 @@ import SearchBox from './SearchBox.vue';
 import Facets from './Facets.vue';
 import Summary from './Summary.vue';
 import Pager from './Pager.vue';
-import {AnalyticsActions, SearchActions} from '@coveo/headless';
 Vue.use(Buefy);
 
 export default Vue.extend({
@@ -52,9 +51,7 @@ export default Vue.extend({
   },
   mounted: function (): void {
     this.$nextTick(function () {
-      this.$root.$data.$engine.dispatch(
-        SearchActions.executeSearch(AnalyticsActions.logInterfaceLoad())
-      );
+      this.$root.$data.$engine.executeFirstSearch();
     });
   },
 });


### PR DESCRIPTION
https://coveord.atlassian.net/browse/CDX-392

## Proposed changes

This is a pre-emptive PR for when v1 of Headless is released.

This week (or the next), we will do one last release of Headless 0.x, which contains all the new functionnality, but with the old function/names/types still present (marked as deprecated, however)

When this is released (eg: headless@0.25), I will be able to merge this PR and do a release of the CLI. 

Right now, the build should fail because all the breaking changes are not released as latest yet (which is what the CLI install by default).

When 1.x is released after that, this will be transparent, as all the necessary upgrade/changes will have already happened in the CLI.

Hopefully that's not too confusing :D 
