### PR TITLE
test(e2e): sanitize github actions variable for angular

### DIFF
--- a/packages/cli-e2e/setup.ts
+++ b/packages/cli-e2e/setup.ts
@@ -23,8 +23,11 @@ async function clearChromeBrowsingData(browser: Browser) {
 
 export default async function () {
   mkdirSync(SCREENSHOTS_PATH, {recursive: true});
-  process.env.GITHUB_ACTION =
-    process.env.GITHUB_ACTION || randomBytes(16).toString('hex');
+  process.env.GITHUB_ACTION = (
+    process.env.GITHUB_ACTION || randomBytes(16).toString('hex')
+  )
+    .replace(/^_*/g, '') // Remove all `-` prefix
+    .replace(/_/g, '-'); // Replace alls other '_' by a '-'
   const browser = await connectToChromeBrowser();
   await clearChromeBrowsingData(browser);
   await clearAccessTokenFromConfig();

--- a/packages/cli-e2e/setup.ts
+++ b/packages/cli-e2e/setup.ts
@@ -23,12 +23,15 @@ async function clearChromeBrowsingData(browser: Browser) {
 
 export default async function () {
   mkdirSync(SCREENSHOTS_PATH, {recursive: true});
+  const leadingUnderscorePrefix = /^_*/g;
+  const allUnderscores = /_/g;
+  const allDashesFollowedByADigit = /-*(?=\d)/g;
   process.env.GITHUB_ACTION = (
     process.env.GITHUB_ACTION || randomBytes(16).toString('hex')
   )
-    .replace(/^_*/g, '') // Remove all `-` prefix
-    .replace(/_/g, '-') // Replace all others '_' by a '-'
-    .replace(/-*(?=\d)/g, ''); // Remove all '-' followed by a digit.
+    .replace(leadingUnderscorePrefix, '')
+    .replace(allUnderscores, '-')
+    .replace(allDashesFollowedByADigit, '');
   const browser = await connectToChromeBrowser();
   await clearChromeBrowsingData(browser);
   await clearAccessTokenFromConfig();

--- a/packages/cli-e2e/setup.ts
+++ b/packages/cli-e2e/setup.ts
@@ -27,7 +27,8 @@ export default async function () {
     process.env.GITHUB_ACTION || randomBytes(16).toString('hex')
   )
     .replace(/^_*/g, '') // Remove all `-` prefix
-    .replace(/_/g, '-'); // Replace all others '_' by a '-'
+    .replace(/_/g, '-') // Replace all others '_' by a '-'
+    .replace(/-*(?=\d)/g, '-'); // Remove all '-' followed by a digit.
   const browser = await connectToChromeBrowser();
   await clearChromeBrowsingData(browser);
   await clearAccessTokenFromConfig();

--- a/packages/cli-e2e/setup.ts
+++ b/packages/cli-e2e/setup.ts
@@ -28,7 +28,7 @@ export default async function () {
   )
     .replace(/^_*/g, '') // Remove all `-` prefix
     .replace(/_/g, '-') // Replace all others '_' by a '-'
-    .replace(/-*(?=\d)/g, '-'); // Remove all '-' followed by a digit.
+    .replace(/-*(?=\d)/g, ''); // Remove all '-' followed by a digit.
   const browser = await connectToChromeBrowser();
   await clearChromeBrowsingData(browser);
   await clearAccessTokenFromConfig();

--- a/packages/cli-e2e/setup.ts
+++ b/packages/cli-e2e/setup.ts
@@ -27,7 +27,7 @@ export default async function () {
     process.env.GITHUB_ACTION || randomBytes(16).toString('hex')
   )
     .replace(/^_*/g, '') // Remove all `-` prefix
-    .replace(/_/g, '-'); // Replace alls other '_' by a '-'
+    .replace(/_/g, '-'); // Replace all others '_' by a '-'
   const browser = await connectToChromeBrowser();
   await clearChromeBrowsingData(browser);
   await clearAccessTokenFromConfig();

--- a/packages/cli-e2e/utils/terminal/terminal.ts
+++ b/packages/cli-e2e/utils/terminal/terminal.ts
@@ -1,6 +1,7 @@
-import type {
+import {
   SpawnOptionsWithoutStdio,
   ChildProcessWithoutNullStreams,
+  spawnSync,
 } from 'child_process';
 import type {Condition} from './condition';
 import type {When} from './when';
@@ -35,6 +36,12 @@ export class Terminal {
 
     const fileLogger = new FileLogger(
       debugName ?? `${command}-${args?.join('-')}`.replace(/[^\w\d]/g, '-')
+    );
+    fileLogger.stdout.write(`Command: ${command}`);
+    fileLogger.stdout.write(`Args: ${JSON.stringify(args)}`);
+    fileLogger.stdout.write(`Options: ${JSON.stringify(options)}`);
+    fileLogger.stdout.write(
+      `CWD_LS: ${spawnSync('ls', {cwd: options?.cwd}).stdout.toString()}`
     );
     this.logIntoFile(fileLogger);
     this.orchestrator = new Orchestrator(this.childProcess);

--- a/packages/cli-e2e/utils/terminal/terminal.ts
+++ b/packages/cli-e2e/utils/terminal/terminal.ts
@@ -1,7 +1,6 @@
-import {
+import type {
   SpawnOptionsWithoutStdio,
   ChildProcessWithoutNullStreams,
-  spawnSync,
 } from 'child_process';
 import type {Condition} from './condition';
 import type {When} from './when';
@@ -36,12 +35,6 @@ export class Terminal {
 
     const fileLogger = new FileLogger(
       debugName ?? `${command}-${args?.join('-')}`.replace(/[^\w\d]/g, '-')
-    );
-    fileLogger.stdout.write(`Command: ${command}`);
-    fileLogger.stdout.write(`Args: ${JSON.stringify(args)}`);
-    fileLogger.stdout.write(`Options: ${JSON.stringify(options)}`);
-    fileLogger.stdout.write(
-      `CWD_LS: ${spawnSync('ls', {cwd: options?.cwd}).stdout.toString()}`
     );
     this.logIntoFile(fileLogger);
     this.orchestrator = new Orchestrator(this.childProcess);


### PR DESCRIPTION
## Proposed changes

Angular wants URL-friendly text for the project name. Somehow GitHub Action switched from `run-#` to `__run_#`. Which 💥.

I implemented three regexes to counter-act this and sanitize the variable:
 - first one remove all leading underscore from the variable name.
 - second to replace all other underscores with a dash
 - third to remove the dash if the first character of the right side of the dash is a digit (angular ain't liking it either)

## Testing

- [x] Unit Tests: n.a.
- [x] Functional Tests: Covered. If the bug was here, no angular spec would go green.
- [x] Manual Tests: Regex101 to test the regex.

-----
CDX-431