### PR TITLE
chore(renovate): use auto range strategy

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,5 @@
 {
   "enabled": true,
-  "extends": ["config:base"],
   "schedule": ["before 2am"],
   "packageRules": [
     {

--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,7 @@
 {
   "enabled": true,
+  "extends": [":semanticPrefixFixDepsChoreOthers"],
   "schedule": ["before 2am"],
-  "extends": [":semanticPrefixFixDepsChoreOthers"]
   "packageRules": [
     {
       "matchPackagePatterns": ["*"],

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,7 @@
 {
   "enabled": true,
   "schedule": ["before 2am"],
+  "extends": [":semanticPrefixFixDepsChoreOthers"]
   "packageRules": [
     {
       "matchPackagePatterns": ["*"],

--- a/renovate.json
+++ b/renovate.json
@@ -9,6 +9,7 @@
       "groupSlug": "all"
     }
   ],
+  "rangeStrategy": "auto",
   "lockFileMaintenance": {
     "enabled": false
   },


### PR DESCRIPTION
## Proposed changes

Use auto range strategy instead of the default `replace` to limit changes.
See https://docs.renovatebot.com/configuration-options/#rangestrategy

Remove the extends from "config:base" because it's too much of a black-box. Kept the semantic.

## Testing

N.A., still experimenting and tweaking.

-----
CDX-451
