### PR TITLE
fix(push): fix incorrect types for timestamp when using delete older than

### DIFF
--- a/packages/cli/src/commands/source/push/delete.spec.ts
+++ b/packages/cli/src/commands/source/push/delete.spec.ts
@@ -86,6 +86,36 @@ describe('source:push:delete', () => {
       expect(mockedSource).toHaveBeenCalledWith('the_token', 'the_org');
     });
 
+  [
+    '2000/01/01',
+    '2000-01-01',
+    '2000-01-01T06:00:00+00:00',
+    'Monday, 2000-Jan-01 06:00:00 UTC',
+  ].forEach((testCase) => {
+    test
+      .stdout()
+      .command(['source:push:delete', 'mysource', '-d', testCase])
+      .it(
+        `pass correct values to push-api-client when deleting with date as string: ${testCase}`,
+        () => {
+          expect(mockDeleteOlderThan).toHaveBeenCalledWith(
+            'mysource',
+            testCase
+          );
+        }
+      );
+  });
+
+  test
+    .stdout()
+    .command(['source:push:delete', 'mysource', '-d', '123123123'])
+    .it(
+      'pass correct values to push-api-client when deleting with date as number',
+      () => {
+        expect(mockDeleteOlderThan).toHaveBeenCalledWith('mysource', 123123123);
+      }
+    );
+
   test
     .do(() => {
       mockDeleteOlderThan.mockReturnValueOnce(

--- a/packages/cli/src/commands/source/push/delete.ts
+++ b/packages/cli/src/commands/source/push/delete.ts
@@ -104,20 +104,12 @@ export default class SourcePushDelete extends Command {
     const {flags, args} = this.parse(SourcePushDelete);
     const toDelete = `older than ${flags.deleteOlderThan}`;
     try {
-      const isNumber = flags.deleteOlderThan?.match(/^[0-9]+$/);
+      const isNumber = flags.deleteOlderThan?.match(/^\d+$/);
 
-      let res: AxiosResponse;
-      if (!isNumber) {
-        res = await source.deleteDocumentsOlderThan(
+      const res = await source.deleteDocumentsOlderThan(
           args.sourceId,
-          flags.deleteOlderThan!
+          isNumber ? parseInt(flags.deleteOlderThan!, 10) : flags.deleteOlderThan!
         );
-      } else {
-        res = await source.deleteDocumentsOlderThan(
-          args.sourceId,
-          parseInt(flags.deleteOlderThan!, 10)
-        );
-      }
       this.successMessageOnDeletion(toDelete, res);
     } catch (e) {
       this.errorMessageOnDeletion(toDelete, e);

--- a/packages/cli/src/commands/source/push/delete.ts
+++ b/packages/cli/src/commands/source/push/delete.ts
@@ -107,9 +107,9 @@ export default class SourcePushDelete extends Command {
       const isNumber = flags.deleteOlderThan?.match(/^\d+$/);
 
       const res = await source.deleteDocumentsOlderThan(
-          args.sourceId,
-          isNumber ? parseInt(flags.deleteOlderThan!, 10) : flags.deleteOlderThan!
-        );
+        args.sourceId,
+        isNumber ? parseInt(flags.deleteOlderThan!, 10) : flags.deleteOlderThan!
+      );
       this.successMessageOnDeletion(toDelete, res);
     } catch (e) {
       this.errorMessageOnDeletion(toDelete, e);

--- a/packages/cli/src/commands/source/push/delete.ts
+++ b/packages/cli/src/commands/source/push/delete.ts
@@ -104,10 +104,20 @@ export default class SourcePushDelete extends Command {
     const {flags, args} = this.parse(SourcePushDelete);
     const toDelete = `older than ${flags.deleteOlderThan}`;
     try {
-      const res = await source.deleteDocumentsOlderThan(
-        args.sourceId,
-        flags.deleteOlderThan!
-      );
+      const isNumber = flags.deleteOlderThan?.match(/^[0-9]+$/);
+
+      let res: AxiosResponse;
+      if (!isNumber) {
+        res = await source.deleteDocumentsOlderThan(
+          args.sourceId,
+          flags.deleteOlderThan!
+        );
+      } else {
+        res = await source.deleteDocumentsOlderThan(
+          args.sourceId,
+          parseInt(flags.deleteOlderThan!, 10)
+        );
+      }
       this.successMessageOnDeletion(toDelete, res);
     } catch (e) {
       this.errorMessageOnDeletion(toDelete, e);


### PR DESCRIPTION


## Proposed changes

Fix issue when doing deleteOlderThan using timestamp


## Testing

- [X] Unit Tests:
- [X] Manual Tests:

https://coveord.atlassian.net/browse/CDX-477
