### PR TITLE
feat(push): support security identities in JSON documents

### DIFF
--- a/packages/cli/package-lock.json
+++ b/packages/cli/package-lock.json
@@ -3599,9 +3599,9 @@
       "integrity": "sha512-z0v7HtT3uKYe5egoTKxcGKlIkq+UwHrEZzPm1sln4iRCrwzWoqYOao8GPqVSCjIt4CGVbOTAR+2DqeiKs1uQSQ=="
     },
     "@coveo/push-api-client": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@coveo/push-api-client/-/push-api-client-1.0.0.tgz",
-      "integrity": "sha512-Rg0x+I/cAJuQym6ZIc5tjXHlhd39KMhtf3y7O0ny8BonDOruAcPAofxfWgadclQVdsK2GP3WDS8qSh5vLOCnCw==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@coveo/push-api-client/-/push-api-client-1.1.2.tgz",
+      "integrity": "sha512-fh9pavQ9N95Fs1pzFk52ENa17TaKrNbnBDA5tACI+6GPymqkMVzgXff79PsEgmODlVebD9kk2m8eDTjdZjsbyA==",
       "requires": {
         "@coveord/platform-client": "^19.1.0",
         "abortcontroller-polyfill": "^1.7.1",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -8,7 +8,7 @@
   "dependencies": {
     "@angular/cli": "^12.1.1",
     "@coveo/bueno": "^0.1.0",
-    "@coveo/push-api-client": "^1.0.0",
+    "@coveo/push-api-client": "^1.1.2",
     "@coveord/platform-client": "^22.3.0",
     "@oclif/command": "^1",
     "@oclif/config": "^1",

--- a/packages/cli/src/__stub__/jsondocuments/identityAllowAnonymousNotABoolean.json
+++ b/packages/cli/src/__stub__/jsondocuments/identityAllowAnonymousNotABoolean.json
@@ -1,0 +1,14 @@
+{
+  "DocumentId": "https://www.themoviedb.org/movie/550",
+  "title": "Fight Club",
+  "permissions": {
+    "allowAnonymous": 123123,
+    "allowedPermissions": [
+      {
+        "identity": "bob@foo.com",
+        "identityType": "USER",
+        "securityProvider": "Email Security Provider"
+      }
+    ]
+  }
+}

--- a/packages/cli/src/__stub__/jsondocuments/identityNotAString.json
+++ b/packages/cli/src/__stub__/jsondocuments/identityNotAString.json
@@ -1,0 +1,14 @@
+{
+  "DocumentId": "https://www.themoviedb.org/movie/550",
+  "title": "Fight Club",
+  "permissions": {
+    "allowAnonymous": false,
+    "allowedPermissions": [
+      {
+        "identity": 123123,
+        "identityType": "USER",
+        "securityProvider": "Email Security Provider"
+      }
+    ]
+  }
+}

--- a/packages/cli/src/__stub__/jsondocuments/identityTypeInvalidValue.json
+++ b/packages/cli/src/__stub__/jsondocuments/identityTypeInvalidValue.json
@@ -1,0 +1,14 @@
+{
+  "DocumentId": "https://www.themoviedb.org/movie/550",
+  "title": "Fight Club",
+  "permissions": {
+    "allowAnonymous": false,
+    "allowedPermissions": [
+      {
+        "identity": "bob@foo.com",
+        "identityType": "BAD_VALUE",
+        "securityProvider": "Email Security Provider"
+      }
+    ]
+  }
+}

--- a/packages/cli/src/__stub__/jsondocuments/noIdentity.json
+++ b/packages/cli/src/__stub__/jsondocuments/noIdentity.json
@@ -1,0 +1,10 @@
+{
+  "DocumentId": "https://www.themoviedb.org/movie/550",
+  "title": "Fight Club",
+  "permissions": {
+    "allowAnonymous": false,
+    "allowedPermissions": [
+      {"identityType": "USER", "securityProvider": "Email Security Provider"}
+    ]
+  }
+}

--- a/packages/cli/src/commands/source/push/add.spec.ts
+++ b/packages/cli/src/commands/source/push/add.spec.ts
@@ -181,4 +181,59 @@ describe('source:push:add', () => {
       expect(ctx.stdout).toContain('Status code: 412');
       expect(ctx.stdout).toContain('Error code: BAD_REQUEST');
     });
+
+  test
+    .stdout()
+    .command([
+      'source:push:add',
+      'mysource',
+      '-f',
+      cwd() + '/src/__stub__/jsondocuments/noIdentity.json',
+    ])
+    .catch(
+      `${cwd()}/src/__stub__/jsondocuments/noIdentity.json is not a valid JSON document: Document contains an invalid value for allowedpermissions:  value does not contain identity`
+    )
+    .it('should output error message on missing identity');
+
+  test
+    .stdout()
+    .command([
+      'source:push:add',
+      'mysource',
+      '-f',
+      cwd() + '/src/__stub__/jsondocuments/identityNotAString.json',
+    ])
+    .catch(
+      `${cwd()}/src/__stub__/jsondocuments/identityNotAString.json is not a valid JSON document: Document contains an invalid value for allowedpermissions:   value is not a string.`
+    )
+    .it('should output error message on identity with an invalid string');
+
+  test
+    .stdout()
+    .command([
+      'source:push:add',
+      'mysource',
+      '-f',
+      cwd() +
+        '/src/__stub__/jsondocuments/identityAllowAnonymousNotABoolean.json',
+    ])
+    .catch(
+      `${cwd()}/src/__stub__/jsondocuments/identityAllowAnonymousNotABoolean.json is not a valid JSON document: Document contains an invalid value for allowanonymous: value is not a boolean.`
+    )
+    .it(
+      'should output error message on allow anonymous with an invalid boolean'
+    );
+
+  test
+    .stdout()
+    .command([
+      'source:push:add',
+      'mysource',
+      '-f',
+      cwd() + '/src/__stub__/jsondocuments/identityTypeInvalidValue.json',
+    ])
+    .catch(
+      `${cwd()}/src/__stub__/jsondocuments/identityTypeInvalidValue.json is not a valid JSON document: Document contains an invalid value for allowedpermissions:   value should be one of: UNKNOWN, USER, GROUP, VIRTUAL_GROUP.`
+    )
+    .it('should output error message on identityType with an invalid value');
 });

--- a/packages/cli/src/lib/push/knownKey.ts
+++ b/packages/cli/src/lib/push/knownKey.ts
@@ -1,11 +1,11 @@
-import {isNullOrUndefined} from '@coveo/bueno';
+import {isNullOrUndefined, PrimitivesValues} from '@coveo/bueno';
 import {CaseInsensitiveDocument} from './caseInsensitiveDocument';
 
-export class KnownKeys<T> {
+export class KnownKeys<T extends PrimitivesValues> {
   private keys: string[];
   public constructor(
     k: string | string[],
-    private doc: CaseInsensitiveDocument<T>
+    private doc: CaseInsensitiveDocument<PrimitivesValues>
   ) {
     if (Array.isArray(k)) {
       this.keys = k;
@@ -27,7 +27,7 @@ export class KnownKeys<T> {
 
   public whenExists(cb: (v: T) => void) {
     if (!isNullOrUndefined(this.value)) {
-      cb(this.value);
+      cb(this.value as T);
     }
   }
 }

--- a/packages/cli/src/lib/push/parseFile.ts
+++ b/packages/cli/src/lib/push/parseFile.ts
@@ -1,4 +1,10 @@
-import {ArrayValue, BooleanValue, RecordValue, StringValue} from '@coveo/bueno';
+import {
+  ArrayValue,
+  BooleanValue,
+  PrimitivesValues,
+  RecordValue,
+  StringValue,
+} from '@coveo/bueno';
 import {
   DocumentBuilder,
   MetadataValue,
@@ -32,33 +38,23 @@ export const parseAndGetDocumentBuilderFromJSONDocument = (
 };
 
 const processDocument = (
-  fileContent: Record<string, string | {}>,
+  fileContent: Record<string, PrimitivesValues>,
   documentPath: PathLike
 ) => {
   const caseInsensitiveDoc = new CaseInsensitiveDocument(fileContent);
 
   const documentBuilder = validateRequiredKeysAndGetDocumentBuilder(
-    caseInsensitiveDoc as CaseInsensitiveDocument<string>,
+    caseInsensitiveDoc,
     documentPath
   );
-  processKnownKeys(
-    caseInsensitiveDoc as CaseInsensitiveDocument<string>,
-    documentBuilder
-  );
-  processSecurityIdentities(
-    caseInsensitiveDoc as CaseInsensitiveDocument<Document['permissions']>,
-    documentBuilder,
-    documentPath
-  );
-  processMetadata(
-    caseInsensitiveDoc as CaseInsensitiveDocument<MetadataValue>,
-    documentBuilder
-  );
+  processKnownKeys(caseInsensitiveDoc, documentBuilder);
+  processSecurityIdentities(caseInsensitiveDoc, documentBuilder, documentPath);
+  processMetadata(caseInsensitiveDoc, documentBuilder);
   return documentBuilder;
 };
 
 const validateRequiredKeysAndGetDocumentBuilder = (
-  caseInsensitiveDoc: CaseInsensitiveDocument<string>,
+  caseInsensitiveDoc: CaseInsensitiveDocument<PrimitivesValues>,
   documentPath: PathLike
 ) => {
   const requiredDocumentId = new RequiredKeyValidator<string>(
@@ -91,7 +87,7 @@ const validateRequiredKeysAndGetDocumentBuilder = (
 };
 
 const processKnownKeys = (
-  caseInsensitiveDoc: CaseInsensitiveDocument<string>,
+  caseInsensitiveDoc: CaseInsensitiveDocument<PrimitivesValues>,
   documentBuilder: DocumentBuilder
 ) => {
   new KnownKeys<string>('author', caseInsensitiveDoc).whenExists((author) => {
@@ -133,7 +129,7 @@ const processKnownKeys = (
 };
 
 const processSecurityIdentities = (
-  caseInsensitiveDoc: CaseInsensitiveDocument<Document['permissions']>,
+  caseInsensitiveDoc: CaseInsensitiveDocument<PrimitivesValues>,
   documentBuilder: DocumentBuilder,
   documentPath: PathLike
 ) => {
@@ -207,11 +203,11 @@ const processSecurityIdentities = (
 };
 
 const processMetadata = (
-  caseInsensitiveDoc: CaseInsensitiveDocument<MetadataValue>,
+  caseInsensitiveDoc: CaseInsensitiveDocument<PrimitivesValues>,
   documentBuilder: DocumentBuilder
 ) => {
   Object.entries(caseInsensitiveDoc.documentRecord).forEach(([k, v]) => {
-    documentBuilder.withMetadataValue(k, v);
+    documentBuilder.withMetadataValue(k, v!);
   });
 };
 

--- a/packages/cli/src/lib/push/parseFile.ts
+++ b/packages/cli/src/lib/push/parseFile.ts
@@ -7,7 +7,6 @@ import {
 } from '@coveo/bueno';
 import {
   DocumentBuilder,
-  MetadataValue,
   Document,
   SecurityIdentity,
   AnySecurityIdentityBuilder,

--- a/packages/cli/src/lib/push/parseFile.ts
+++ b/packages/cli/src/lib/push/parseFile.ts
@@ -10,6 +10,7 @@ import {
   Document,
   SecurityIdentity,
   AnySecurityIdentityBuilder,
+  MetadataValue,
 } from '@coveo/push-api-client';
 import {existsSync, lstatSync, PathLike, readFileSync} from 'fs';
 import {CaseInsensitiveDocument} from './caseInsensitiveDocument';
@@ -206,7 +207,10 @@ const processMetadata = (
   documentBuilder: DocumentBuilder
 ) => {
   Object.entries(caseInsensitiveDoc.documentRecord).forEach(([k, v]) => {
-    documentBuilder.withMetadataValue(k, v!);
+    documentBuilder.withMetadataValue(
+      k,
+      v! as Extract<PrimitivesValues, MetadataValue>
+    );
   });
 };
 


### PR DESCRIPTION
https://coveord.atlassian.net/browse/CDX-481

## Proposed changes

Add support to parse security identities in JSON documents.

Goes hand in hand with this PR: https://github.com/coveo/push-api-client.js/pull/21


## Testing

- [X] Unit Tests:
- [X] Manual Tests:


