### PR TITLE
ci(cdn): invalidate cache on prod release 

### DIFF
--- a/.deployment.config.json
+++ b/.deployment.config.json
@@ -11,17 +11,30 @@
       "sequential": ["us-east-1"]
     }
   },
-  "phases": {
-    "terraform": {},
-    "s3": {
-      "bucket": "{terraform.infra.infra.bucket_binaries}",
-      "directory": "proda/StaticCDN/cli",
-      "source": "./artifacts",
-      "parameters": {
-        "acl": "public-read"
+  "ordered_phases": [
+    {"id": "terraform", "terraform": {}},
+    {
+      "id": "s3",
+      "s3": {
+        "bucket": "{terraform.infra.infra.bucket_binaries}",
+        "directory": "proda/StaticCDN/cli",
+        "source": "./artifacts",
+        "parameters": {
+          "acl": "public-read"
+        }
+      }
+    },
+    {
+      "id": "invalidate_cache",
+      "team_jenkins": {
+        "job_name": "cli-cloudfront-invalidation",
+        "disabled": true,
+        "prd": {
+          "disabled": false
+        }
       }
     }
-  },
+  ],
   "snyk": {
     "org": "coveo-developer-experience",
     "no_container_images": true,

--- a/JenkinsfileCloudfrontInvalidation
+++ b/JenkinsfileCloudfrontInvalidation
@@ -1,0 +1,15 @@
+node('linux && docker') {
+  checkout scm
+
+  environment {
+        AWS_ACCESS_KEY_ID     = 'FOO'
+        AWS_SECRET_ACCESS_KEY = 'BAR'
+  }
+
+  withDockerContainer(image: 'node:14', args: '-u=root') {
+
+    stage('Cloudfront invalidation') {
+        echo "ID ${env.AWS_ACCESS_KEY_ID} KEY ${env.AWS_SECRET_ACCESS_KEY}"
+    }
+  }
+}

--- a/JenkinsfileCloudfrontInvalidation
+++ b/JenkinsfileCloudfrontInvalidation
@@ -1,15 +1,18 @@
 node('linux && docker') {
   checkout scm
 
-  environment {
-        AWS_ACCESS_KEY_ID     = 'FOO'
-        AWS_SECRET_ACCESS_KEY = 'BAR'
-  }
-
   withDockerContainer(image: 'node:14', args: '-u=root') {
 
-    stage('Cloudfront invalidation') {
-        echo "ID ${env.AWS_ACCESS_KEY_ID} KEY ${env.AWS_SECRET_ACCESS_KEY}"
+    withCredentials([
+      [
+        $class: "AmazonWebServicesCredentialsBinding",
+        credentialsId: "CloudfrontCacheInvalidation",
+      ]
+    ]) {
+      stage('Cloudfront invalidation') {
+        sh 'node ./scripts/invalidate-cloudfront.js'
+      }
+
     }
   }
 }

--- a/JenkinsfileCloudfrontInvalidation
+++ b/JenkinsfileCloudfrontInvalidation
@@ -10,6 +10,7 @@ node('linux && docker') {
       ]
     ]) {
       stage('Cloudfront invalidation') {
+        sh 'npm ci';
         sh 'node ./scripts/invalidate-cloudfront.js'
       }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -3092,6 +3092,44 @@
       "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
       "dev": true
     },
+    "aws-sdk": {
+      "version": "2.951.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.951.0.tgz",
+      "integrity": "sha512-YPqhdESUzd4+pSuGJcfMnG1qNVbmZjnmsa85Z9jofR1ilIpuV31onIiFHv8iubM59ETok/+zy3QOmxRSLYzFmQ==",
+      "requires": {
+        "buffer": "4.9.2",
+        "events": "1.1.1",
+        "ieee754": "1.1.13",
+        "jmespath": "0.15.0",
+        "querystring": "0.2.0",
+        "sax": "1.2.1",
+        "url": "0.10.3",
+        "uuid": "3.3.2",
+        "xml2js": "0.4.19"
+      },
+      "dependencies": {
+        "buffer": {
+          "version": "4.9.2",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
+          "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
+          "requires": {
+            "base64-js": "^1.0.2",
+            "ieee754": "^1.1.4",
+            "isarray": "^1.0.0"
+          }
+        },
+        "ieee754": {
+          "version": "1.1.13",
+          "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
+          "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
+        },
+        "uuid": {
+          "version": "3.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+          "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+        }
+      }
+    },
     "aws-sign2": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
@@ -3122,8 +3160,7 @@
     "base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "dev": true
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
     },
     "bcrypt-pbkdf": {
       "version": "1.0.2",
@@ -4963,6 +5000,11 @@
       "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
       "dev": true
     },
+    "events": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
+      "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
+    },
     "execa": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/execa/-/execa-5.0.0.tgz",
@@ -6509,8 +6551,7 @@
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-      "dev": true
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
     "isexe": {
       "version": "2.0.0",
@@ -6529,6 +6570,11 @@
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
       "dev": true
+    },
+    "jmespath": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
+      "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc="
     },
     "js-tokens": {
       "version": "4.0.0",
@@ -8615,6 +8661,11 @@
         "strict-uri-encode": "^2.0.0"
       }
     },
+    "querystring": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
+    },
     "quick-lru": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-4.0.1.tgz",
@@ -9097,6 +9148,11 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true
+    },
+    "sax": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
+      "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o="
     },
     "semver": {
       "version": "7.3.2",
@@ -9926,6 +9982,22 @@
         "punycode": "^2.1.0"
       }
     },
+    "url": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
+      "integrity": "sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=",
+      "requires": {
+        "punycode": "1.3.2",
+        "querystring": "0.2.0"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+          "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
+        }
+      }
+    },
     "url-parse-lax": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
@@ -10234,6 +10306,20 @@
       "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-4.0.0.tgz",
       "integrity": "sha512-PSNhEJDejZYV7h50BohL09Er9VaIefr2LMAf3OEmpCkjOi34eYyQYAXUTjEQtZJTKcF0E2UKTh+osDLsgNim9Q==",
       "dev": true
+    },
+    "xml2js": {
+      "version": "0.4.19",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
+      "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+      "requires": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~9.0.1"
+      }
+    },
+    "xmlbuilder": {
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+      "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
     },
     "xtend": {
       "version": "4.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3093,9 +3093,10 @@
       "dev": true
     },
     "aws-sdk": {
-      "version": "2.951.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.951.0.tgz",
-      "integrity": "sha512-YPqhdESUzd4+pSuGJcfMnG1qNVbmZjnmsa85Z9jofR1ilIpuV31onIiFHv8iubM59ETok/+zy3QOmxRSLYzFmQ==",
+      "version": "2.952.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.952.0.tgz",
+      "integrity": "sha512-FZkmOWAyDSQMeD8iioeoSW873ZjPXLfGejr0gNi8kQB7JrllOayPaexpq70aT+7n5bAzArjSIH8OAB+BoHYijA==",
+      "dev": true,
       "requires": {
         "buffer": "4.9.2",
         "events": "1.1.1",
@@ -3112,6 +3113,7 @@
           "version": "4.9.2",
           "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
           "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
+          "dev": true,
           "requires": {
             "base64-js": "^1.0.2",
             "ieee754": "^1.1.4",
@@ -3121,12 +3123,14 @@
         "ieee754": {
           "version": "1.1.13",
           "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
-          "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
+          "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==",
+          "dev": true
         },
         "uuid": {
           "version": "3.3.2",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-          "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+          "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
+          "dev": true
         }
       }
     },
@@ -3160,7 +3164,8 @@
     "base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true
     },
     "bcrypt-pbkdf": {
       "version": "1.0.2",
@@ -5003,7 +5008,8 @@
     "events": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
-      "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
+      "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=",
+      "dev": true
     },
     "execa": {
       "version": "5.0.0",
@@ -6551,7 +6557,8 @@
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "dev": true
     },
     "isexe": {
       "version": "2.0.0",
@@ -6574,7 +6581,8 @@
     "jmespath": {
       "version": "0.15.0",
       "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
-      "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc="
+      "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc=",
+      "dev": true
     },
     "js-tokens": {
       "version": "4.0.0",
@@ -8664,7 +8672,8 @@
     "querystring": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
-      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
+      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
+      "dev": true
     },
     "quick-lru": {
       "version": "4.0.1",
@@ -9152,7 +9161,8 @@
     "sax": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
-      "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o="
+      "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o=",
+      "dev": true
     },
     "semver": {
       "version": "7.3.2",
@@ -9986,6 +9996,7 @@
       "version": "0.10.3",
       "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
       "integrity": "sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=",
+      "dev": true,
       "requires": {
         "punycode": "1.3.2",
         "querystring": "0.2.0"
@@ -9994,7 +10005,8 @@
         "punycode": {
           "version": "1.3.2",
           "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
-          "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
+          "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
+          "dev": true
         }
       }
     },
@@ -10311,6 +10323,7 @@
       "version": "0.4.19",
       "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
       "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+      "dev": true,
       "requires": {
         "sax": ">=0.6.0",
         "xmlbuilder": "~9.0.1"
@@ -10319,7 +10332,8 @@
     "xmlbuilder": {
       "version": "9.0.7",
       "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
-      "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
+      "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=",
+      "dev": true
     },
     "xtend": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -8,9 +8,6 @@
   },
   "license": "Apache-2.0",
   "bugs": "https://github.com/coveo/cli/issues",
-  "dependencies": {
-    "aws-sdk": "^2.951.0"
-  },
   "devDependencies": {
     "@actions/core": "1.4.0",
     "@actions/github": "5.0.0",
@@ -22,6 +19,7 @@
     "@typescript-eslint/eslint-plugin": "4.28.4",
     "@typescript-eslint/parser": "4.28.4",
     "async-retry": "1.3.1",
+    "aws-sdk": "^2.952.0",
     "axios": "0.21.1",
     "cz-conventional-changelog": "3.3.0",
     "eslint": "7.31.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
   },
   "license": "Apache-2.0",
   "bugs": "https://github.com/coveo/cli/issues",
-  "dependencies": {},
+  "dependencies": {
+    "aws-sdk": "^2.951.0"
+  },
   "devDependencies": {
     "@actions/core": "1.4.0",
     "@actions/github": "5.0.0",

--- a/scripts/invalidate-cloudfront.js
+++ b/scripts/invalidate-cloudfront.js
@@ -6,7 +6,7 @@ const cloudfront = new AWS.CloudFront();
 const pathToInvalidate = `/cli/*`;
 
 const invalidationRequest = cloudfront.createInvalidation({
-  DistributionId: process.env.AWS_CLOUDFRONT_DISTRIBUTION_ID,
+  DistributionId: 'E2VWLFSCSD1GLA',
   InvalidationBatch: {
     CallerReference: new Date().getTime().toString(),
     Paths: {

--- a/scripts/invalidate-cloudfront.js
+++ b/scripts/invalidate-cloudfront.js
@@ -1,0 +1,37 @@
+const exec = require('child_process').exec;
+const colors = require('colors');
+const AWS = require('aws-sdk');
+
+const cloudfront = new AWS.CloudFront();
+const pathToInvalidate = `/cli/*`;
+
+const invalidationRequest = cloudfront.createInvalidation({
+  DistributionId: process.env.AWS_CLOUDFRONT_DISTRIBUTION_ID,
+  InvalidationBatch: {
+    CallerReference: new Date().getTime().toString(),
+    Paths: {
+      Quantity: 1,
+      Items: [pathToInvalidate],
+    },
+  },
+});
+
+invalidationRequest.send((error, success) => {
+  if (error) {
+    console.log(
+      colors.red('ERROR WHILE INVALIDATING RESSOURCES ON CLOUDFRONT')
+    );
+    console.log(colors.red('*************'));
+    console.log(colors.red(error.message));
+    console.log(colors.red('*************'));
+    exec('travis_terminate 1');
+    throw error;
+  }
+  if (success) {
+    console.log(colors.green('INVALIDATION ON CLOUDFRONT SUCCESSFUL'));
+    console.log(colors.green('*************'));
+    console.log(colors.green(`PATH INVALIDATED: ${pathToInvalidate}`));
+    console.log(colors.green(`INVALIDATION ID : ${success.Invalidation.Id}`));
+    console.log(colors.green('*************'));
+  }
+});

--- a/scripts/invalidate-cloudfront.js
+++ b/scripts/invalidate-cloudfront.js
@@ -1,5 +1,3 @@
-const exec = require('child_process').exec;
-const colors = require('colors');
 const AWS = require('aws-sdk');
 
 const cloudfront = new AWS.CloudFront();
@@ -18,20 +16,17 @@ const invalidationRequest = cloudfront.createInvalidation({
 
 invalidationRequest.send((error, success) => {
   if (error) {
-    console.log(
-      colors.red('ERROR WHILE INVALIDATING RESSOURCES ON CLOUDFRONT')
-    );
-    console.log(colors.red('*************'));
-    console.log(colors.red(error.message));
-    console.log(colors.red('*************'));
-    exec('travis_terminate 1');
+    console.log('ERROR WHILE INVALIDATING RESSOURCES ON CLOUDFRONT');
+    console.log('*************');
+    console.log(error.message);
+    console.log('*************');
     throw error;
   }
   if (success) {
-    console.log(colors.green('INVALIDATION ON CLOUDFRONT SUCCESSFUL'));
-    console.log(colors.green('*************'));
-    console.log(colors.green(`PATH INVALIDATED: ${pathToInvalidate}`));
-    console.log(colors.green(`INVALIDATION ID : ${success.Invalidation.Id}`));
-    console.log(colors.green('*************'));
+    console.log('INVALIDATION ON CLOUDFRONT SUCCESSFUL');
+    console.log('*************');
+    console.log(`PATH INVALIDATED: ${pathToInvalidate}`);
+    console.log(`INVALIDATION ID : ${success.Invalidation.Id}`);
+    console.log('*************');
   }
 });


### PR DESCRIPTION
## Proposed changes

Added a new deployment phases (that runs only in prod) using the "ordered_phases" property of the deployment pipeline.

After binaries have been uploaded to S3, do a Cloudfront cache invalidation so that end users can immediately upgrade when it is released.

Without this, it can take up to 24 hours for new version to be detected by the update command.

Deployment pipeline can only trigger Jenkins job (for now?) so there's a small `JenkinsfileCloudfrontInvalidation ` file that is run through Jenkins job called `cli-cloudfront-invalidation` in the team Jenkins.

The AWS creds are also stored in Jenkins under the `CloudfrontCacheInvalidation` ID.

## Testing

- [X] Manual Tests:


https://coveord.atlassian.net/browse/CDX-495
