### PR TITLE
fix(vue): Remove `FieldActions` warning

### DIFF
--- a/packages/vue-cli-plugin-typescript/generator/template/src/components/ResultList.vue
+++ b/packages/vue-cli-plugin-typescript/generator/template/src/components/ResultList.vue
@@ -47,7 +47,7 @@
 
 <script lang="ts">
 import Vue from 'vue';
-import {buildResultList, FieldActions} from '@coveo/headless';
+import {buildResultList} from '@coveo/headless';
 import type {ResultListState, ResultList} from '@coveo/headless';
 
 export interface IResultList {


### PR DESCRIPTION
https://coveord.atlassian.net/browse/CDX-510

## Proposed changes

Just removing an unused variable that causes a lint warning.

## Testing

- [ ] Unit Tests:
<!-- Did you write unit tests for your feature? If not, explains why?  -->
- [ ] Functionnal Tests:
<!-- Did you write functionnal tests for your feature? If not, explains why?  -->
- [x] Manual Tests:


-----
CDX-510
