### PR TITLE
fix pathing

### DIFF
--- a/packages/cli/src/lib/project/project.spec.ts
+++ b/packages/cli/src/lib/project/project.spec.ts
@@ -68,7 +68,12 @@ describe('Project', () => {
     it('should ensure resources folder exists', async () => {
       doMockFileDoesNotExists('resources');
       const project = projectCreator();
-      project.compressResources();
+      await project.compressResources();
+
+      expect(mockedExistSync).toHaveBeenNthCalledWith(
+        2,
+        join('dummy/path', 'resources')
+      );
       expect(mockedError).toHaveBeenCalledWith(
         new Error(
           'dummy/path is not a valid project: Does not contain any resources folder'
@@ -80,7 +85,13 @@ describe('Project', () => {
       doMockFileDoesNotExists('_');
       const project = projectCreator();
       doMockFileDoesNotExists('.coveo');
-      project.compressResources();
+
+      await project.compressResources();
+
+      expect(mockedExistSync).toHaveBeenNthCalledWith(
+        3,
+        join('dummy/path', '.coveo')
+      );
       expect(mockedError).toHaveBeenCalledWith(
         new Error(
           'dummy/path is not a valid project: Does not contain any .coveo folder'

--- a/packages/cli/src/lib/project/project.ts
+++ b/packages/cli/src/lib/project/project.ts
@@ -7,6 +7,7 @@ import extract from 'extract-zip';
 import {DotFolder, DotFolderConfig} from './dotFolder';
 
 export class Project {
+  private static readonly resourceFolderName = 'resources';
   public constructor(private pathToProject: string) {
     if (!this.isCoveoProject) {
       this.makeCoveoProject();
@@ -70,7 +71,7 @@ export class Project {
   }
 
   private get resourcePath() {
-    return join(this.pathToProject, 'resources');
+    return join(this.pathToProject, Project.resourceFolderName);
   }
 
   private get isCoveoProject() {
@@ -78,7 +79,7 @@ export class Project {
   }
 
   private get isResourcesProject() {
-    return this.contains(this.resourcePath);
+    return this.contains(Project.resourceFolderName);
   }
 
   private makeCoveoProject() {


### PR DESCRIPTION
When checking for the `resources` folder, `this.pathToProject` was appended twice in the check: once by `contains`, another by `resourcePath`.

This fixes that and ensure we check the proper paths too to avoid this in the future