### PR TITLE
fix: `org:config:monitor` doesn't show any feedback

### DIFF
--- a/packages/cli/src/commands/org/config/monitor.ts
+++ b/packages/cli/src/commands/org/config/monitor.ts
@@ -45,9 +45,9 @@ export default class Monitor extends Command {
 
   @Preconditions(IsAuthenticated())
   public async run() {
-    const snapshot = await this.getSnapshot();
+    this.printHeader();
 
-    this.printHeader(snapshot.id);
+    const snapshot = await this.getSnapshot();
 
     await this.monitorSnapshot(snapshot);
     this.config.runHook('analytics', buildAnalyticsSuccessHook(this, flags));
@@ -76,11 +76,14 @@ export default class Monitor extends Command {
     cli.action.stop(this.getReportStatus(snapshot.latestReport));
   }
 
-  private printHeader(snapshotId: string) {
+  private printHeader() {
+    const {args} = this.parse(Monitor);
+    const snapshotId = args.snapshotId;
     const header = ReportViewerStyles.header(
-      `\nMonitoring snapshot ${snapshotId}:`
+      `Monitoring snapshot ${snapshotId}`
     );
-    cli.log(header);
+    cli.log('');
+    cli.action.start(header);
   }
 
   private prettyPrint(str: string): string {


### PR DESCRIPTION
https://coveord.atlassian.net/browse/CDX-526

## Proposed changes
The cli.action was not showing because it was at the wrong place.
![image](https://user-images.githubusercontent.com/12199712/128196622-7b2b1e62-0034-41e2-a073-e7fa774130f9.png)

## Testing

- [ ] Unit Tests:
<!-- Did you write unit tests for your feature? If not, explains why?  -->
- [ ] Functionnal Tests:
<!-- Did you write functionnal tests for your feature? If not, explains why?  -->
- [x] Manual Tests:
see image



-----
CDX-526


