### PR TITLE
fix(cli): handle npx 7

### DIFF
--- a/packages/cli/src/commands/ui/create/react.ts
+++ b/packages/cli/src/commands/ui/create/react.ts
@@ -6,7 +6,7 @@ import {
 } from '../../../hooks/analytics/analytics';
 import {Config} from '../../../lib/config/config';
 import {platformUrl} from '../../../lib/platform/environment';
-import {spawnProcessOutput, spawnProcessPTY} from '../../../lib/utils/process';
+import {spawnProcessOutput} from '../../../lib/utils/process';
 import {AuthenticatedClient} from '../../../lib/platform/authenticatedClient';
 import {getPackageVersion} from '../../../lib/utils/misc';
 import {join} from 'path';
@@ -18,6 +18,7 @@ import {
 } from '../../../lib/decorators/preconditions';
 import {appendCmdIfWindows} from '../../../lib/utils/os';
 import {EOL} from 'os';
+import {npxInPty} from '../../../lib/utils/npx';
 
 export default class React extends Command {
   public static templateName = '@coveo/cra-template';
@@ -163,13 +164,12 @@ export default class React extends Command {
   }
 
   private async runReactCliCommand(commandArgs: string[], options = {}) {
-    return new Promise<string>((resolve, reject) => {
-      const child = spawnProcessPTY(
-        appendCmdIfWindows`npx`,
-        ['create-react-app'].concat([...commandArgs]),
-        options
-      );
+    const child = await npxInPty(
+      ['create-react-app'].concat([...commandArgs]),
+      options
+    );
 
+    return new Promise<string>((resolve, reject) => {
       const args = this.args;
       let stopWritingInTerminal = false;
       let remainingString = '';

--- a/packages/cli/src/lib/utils/npx.spec.ts
+++ b/packages/cli/src/lib/utils/npx.spec.ts
@@ -1,0 +1,65 @@
+jest.mock('./process');
+jest.mock('./os');
+
+import {mocked} from 'ts-jest/utils';
+import {npxInPty} from './npx';
+import {appendCmdIfWindows} from './os';
+import {spawnProcessOutput, spawnProcessPTY} from './process';
+
+describe('#npxInPty', () => {
+  const mockedSpawnProcessOutput = mocked(spawnProcessOutput);
+  const mockedSpawnProcessPTY = mocked(spawnProcessPTY);
+  const mockNpxVersion = (output: string) =>
+    mockedSpawnProcessOutput.mockResolvedValue({
+      stdout: output,
+      stderr: '',
+      exitCode: 0,
+    });
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  describe('when npx --version returned string is not a semantic version', () => {
+    beforeEach(async () => {
+      mockNpxVersion('this is not a version');
+    });
+
+    it('should throw an Error', async () => {
+      await expect(npxInPty([])).rejects.toEqual(
+        'Failed to check NPX version.'
+      );
+    });
+  });
+
+  describe('when npx --version returned a version greater or equal to 7', () => {
+    beforeEach(async () => {
+      mockNpxVersion('7.0.0');
+    });
+
+    it('should spawn npx with the --yes flag', async () => {
+      await npxInPty(['potato']);
+
+      expect(mockedSpawnProcessPTY).toHaveBeenCalledWith(
+        appendCmdIfWindows`npx`,
+        ['--yes', 'potato'],
+        {}
+      );
+    });
+  });
+
+  describe('when npx --version returned a version lesser than 7', () => {
+    beforeEach(async () => {
+      mockNpxVersion('6.0.0');
+    });
+
+    it('should spawn npx without the --yes flag', async () => {
+      await npxInPty(['potato']);
+
+      expect(mockedSpawnProcessPTY).toHaveBeenCalledWith(
+        appendCmdIfWindows`npx`,
+        ['potato'],
+        {}
+      );
+    });
+  });
+});

--- a/packages/cli/src/lib/utils/npx.ts
+++ b/packages/cli/src/lib/utils/npx.ts
@@ -1,0 +1,26 @@
+import {appendCmdIfWindows} from './os';
+import {spawnProcessOutput, spawnProcessPTY} from './process';
+import {parse} from 'semver';
+import type {IWindowsPtyForkOptions} from 'node-pty';
+
+export async function npxInPty(
+  args: string[],
+  options: IWindowsPtyForkOptions = {}
+) {
+  const npxVersion = await getNpxMajorVersion();
+  if (npxVersion >= 7) {
+    args.unshift('--yes');
+  }
+  return spawnProcessPTY(appendCmdIfWindows`npx`, args, options);
+}
+
+async function getNpxMajorVersion() {
+  const output = await spawnProcessOutput(appendCmdIfWindows`npx`, [
+    '--version',
+  ]);
+  const version = parse(output.stdout.trim());
+  if (!version) {
+    throw 'Failed to check NPX version.';
+  }
+  return version.major;
+}


### PR DESCRIPTION
## Proposed changes

Starting with NPX 7, when you run an `npx` command that requires an installation, a prompt is given to the user to confirm the installation.
In our use-case, this occurs with `react` and the `create-react-app`. However, this should not be a concern for the user of the Coveo CLI, so we'll use the `--yes` flag with NPX iif its version is equal or greater than 7.

## Testing

- [x] Unit Tests: 💯 
- [x] Manual Tests

-----
CDX-530