### PR TITLE
fix(snapshot): delete zip artifact on error

### DIFF
--- a/packages/cli/src/commands/org/config/monitor.ts
+++ b/packages/cli/src/commands/org/config/monitor.ts
@@ -58,7 +58,7 @@ export default class Monitor extends Command {
 
   public async catch(err?: Error) {
     const {flags} = this.parse(Monitor);
-    handleSnapshotError(err);
+    handleSnapshotError(this.projectPath, err);
     await this.config.runHook(
       'analytics',
       buildAnalyticsFailureHook(this, flags, err)

--- a/packages/cli/src/commands/org/config/preview.spec.ts
+++ b/packages/cli/src/commands/org/config/preview.spec.ts
@@ -185,6 +185,18 @@ describe('org:config:preview', () => {
       });
 
     test
+      .do(() => {
+        mockedValidateSnapshot.mockImplementationOnce(() => {
+          throw new Error('You shall not pass');
+        });
+      })
+      .command(['org:config:preview'])
+      .catch(() => {
+        expect(mockedDeleteTemporaryZipFile).toHaveBeenCalledTimes(1);
+      })
+      .it('should delete the compressed folder on error');
+
+    test
       .command(['org:config:preview'])
       .it('should delete the snapshot', () => {
         expect(mockedDeleteSnapshot).toHaveBeenCalledTimes(1);

--- a/packages/cli/src/commands/org/config/preview.ts
+++ b/packages/cli/src/commands/org/config/preview.ts
@@ -77,7 +77,7 @@ export default class Preview extends Command {
 
   public async catch(err?: Error) {
     const {flags} = this.parse(Preview);
-    handleSnapshotError(err);
+    handleSnapshotError(this.projectPath, err);
     await this.displayAdditionalErrorMessage(err);
     await this.config.runHook(
       'analytics',

--- a/packages/cli/src/commands/org/config/pull.ts
+++ b/packages/cli/src/commands/org/config/pull.ts
@@ -73,7 +73,7 @@ export default class Pull extends Command {
 
   public async catch(err?: Error) {
     const {flags} = this.parse(Pull);
-    handleSnapshotError(err);
+    handleSnapshotError(this.projectPath, err);
     await this.displayAdditionalErrorMessage(err);
     await this.config.runHook(
       'analytics',

--- a/packages/cli/src/commands/org/config/push.spec.ts
+++ b/packages/cli/src/commands/org/config/push.spec.ts
@@ -219,6 +219,19 @@ describe('org:config:push', () => {
 
     test
       .stub(cli, 'confirm', () => async () => true)
+      .do(() => {
+        mockedValidateSnapshot.mockImplementationOnce(() => {
+          throw new Error('You shall not pass');
+        });
+      })
+      .command(['org:config:push'])
+      .catch(() => {
+        expect(mockedDeleteTemporaryZipFile).toHaveBeenCalledTimes(1);
+      })
+      .it('should delete the compressed folder on error');
+
+    test
+      .stub(cli, 'confirm', () => async () => true)
       .command(['org:config:push'])
       .it('should delete the snapshot', () => {
         expect(mockedDeleteSnapshot).toHaveBeenCalledTimes(1);

--- a/packages/cli/src/commands/org/config/push.ts
+++ b/packages/cli/src/commands/org/config/push.ts
@@ -81,7 +81,7 @@ export default class Push extends Command {
 
   public async catch(err?: Error) {
     const {flags} = this.parse(Push);
-    handleSnapshotError(err);
+    handleSnapshotError(this.projectPath, err);
     await this.config.runHook(
       'analytics',
       buildAnalyticsFailureHook(this, flags, err)

--- a/packages/cli/src/lib/project/project.ts
+++ b/packages/cli/src/lib/project/project.ts
@@ -23,7 +23,9 @@ export class Project {
   }
 
   public deleteTemporaryZipFile() {
-    unlinkSync(this.pathToTemporaryZip);
+    if (existsSync(this.pathToTemporaryZip)) {
+      unlinkSync(this.pathToTemporaryZip);
+    }
   }
 
   private ensureProjectCompliance() {

--- a/packages/cli/src/lib/snapshot/snapshotCommon.ts
+++ b/packages/cli/src/lib/snapshot/snapshotCommon.ts
@@ -93,7 +93,10 @@ export async function getTargetOrg(config: Config, target?: string) {
   return cfg.organization;
 }
 
-export function handleSnapshotError(err?: Error) {
+export function handleSnapshotError(projectPath: string, err?: Error) {
+  const project = new Project(normalize(projectPath));
+  project.deleteTemporaryZipFile();
+
   if (err instanceof SnapshotOperationTimeoutError) {
     cli.action.stop('Incomplete');
     cli.log(operationGettingTooMuchTimeMessage(err.snapshot));


### PR DESCRIPTION
## Proposed changes

The snapshot.zip file was not deleted whenever an invalid snapshot error was throw.

 ## Testing

- [x] Unit Tests:
<!-- Did you write unit tests for your feature? If not, explains why?  -->
- [ ] Functionnal Tests:
<!-- Did you write functionnal tests for your feature? If not, explains why?  -->
- [x] Manual Tests:
<!-- How did you test your changeset?  -->

<!-- For Coveo Employees only. Fill and uncomment this section.

-----
CDX-XXX

-->
