### PR TITLE
cd(win): fix signing

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -52,13 +52,14 @@ jobs:
           mv ./dist/version ./dist/${{ matrix.os }}-version
           mv ./dist/coveo-${{ env.tag }}/coveo-${{ env.tag }}.tar.gz ./dist/coveo-${{ env.tag }}/${{ matrix.os }}-coveo-${{ env.tag }}.tar.gz
       - name: Sign Executable
+        working-directory: ./packages/cli
         if: ${{matrix.os == 'windows-latest'}}
         run: |
           New-Item -Force -ItemType directory -Path tmp 
           echo "${{ secrets.COVEO_PFX }}" > ./tmp/cert.txt
           certutil -decode ./tmp/cert.txt ./tmp/cert.pfx
-          Start-Process -FilePath "C:\Program Files (x86)\Windows Kits\10\bin\10.0.19041.0\x64\signtool.exe" -ArgumentList "sign /f ./tmp/cert.pfx /p ${{ secrets.COVEO_PFX_PWD }} /fd SHA256 /td SHA256 /tr http://timestamp.digicert.com ./dist/win/coveo-${{env.tag}}-x64.exe" -PassThru | Wait-Process
-          Start-Process -FilePath "C:\Program Files (x86)\Windows Kits\10\bin\10.0.19041.0\x64\signtool.exe" -ArgumentList "sign /f ./tmp/cert.pfx /p ${{ secrets.COVEO_PFX_PWD }} /fd SHA256 /td SHA256 /tr http://timestamp.digicert.com ./dist/win/coveo-${{env.tag}}-x86.exe" -PassThru | Wait-Process
+          Start-Process -FilePath "C:\Program Files (x86)\Windows Kits\10\bin\10.0.19041.0\x64\signtool.exe" -ArgumentList "sign /f ./tmp/cert.pfx /p ${{ secrets.COVEO_PFX_PWD }} /fd SHA256 /tr http://timestamp.digicert.com /td SHA256 ./dist/win/coveo-${{env.tag}}-x64.exe" -PassThru | Wait-Process
+          Start-Process -FilePath "C:\Program Files (x86)\Windows Kits\10\bin\10.0.19041.0\x64\signtool.exe" -ArgumentList "sign /f ./tmp/cert.pfx /p ${{ secrets.COVEO_PFX_PWD }} /fd SHA256 /tr http://timestamp.digicert.com /td SHA256 ./dist/win/coveo-${{env.tag}}-x86.exe" -PassThru | Wait-Process
       - name: Upload binaries
         uses: svenstaro/upload-release-action@v2
         with:


### PR DESCRIPTION
## Proposed changes

- Put `/td SHA256` after `/tr` as mentioned in the documentation https://docs.microsoft.com/en-us/dotnet/framework/tools/signtool-exe
- Set the `working-directory` to be the same as when we build, otherwise, we do not match up.

## Testing

- [X] Manual Tests:
  - Ran some tests in a fork to check it up, but was not able to complete without taking the risk of compromising the certificate. (this was primarily used for the `working_directory` fix, the error evolved to another related to the composition of my bogus testcert)
  - Reproduce the error due to the bogus certificate locally and fix it just by switching to the real one. (could not do it in fork for security reasons)

-----
CDX-524