### PR TITLE
test(snapshot): rewrite test from BDD/TDD to purer TDD

### DIFF
--- a/packages/cli/src/lib/snapshot/snapshot.spec.ts
+++ b/packages/cli/src/lib/snapshot/snapshot.spec.ts
@@ -1,7 +1,6 @@
 import {
   ResourceSnapshotsModel,
   ResourceSnapshotsReportModel,
-  ResourceSnapshotsReportStatus,
   ResourceSnapshotsReportType,
   SnapshotExportContentFormat,
 } from '@coveord/platform-client';
@@ -27,7 +26,7 @@ jest.mock('./expandedPreviewer/expandedPreviewer');
 
 import {AuthenticatedClient} from '../platform/authenticatedClient';
 import {ensureFileSync, writeJSONSync} from 'fs-extra';
-import retry, {RetryFunction} from 'async-retry';
+import retry from 'async-retry';
 import {SnapshotReporter} from './snapshotReporter';
 import {ReportViewer} from './reportPreviewer/reportPreviewer';
 import {Project} from '../project/project';
@@ -37,7 +36,6 @@ import {SnapshotOperationTimeoutError} from '../errors';
 
 const mockedRetry = mocked(retry);
 const mockedExpandedPreviewer = mocked(ExpandedPreviewer, true);
-const mockedProject = mocked(Project, true);
 const mockedSnapshotReporter = mocked(SnapshotReporter, true);
 const mockedReportViewer = mocked(ReportViewer, true);
 const mockedAuthenticatedClient = mocked(AuthenticatedClient, true);
@@ -63,11 +61,6 @@ describe('Snapshot', () => {
     snapshotId: string
   ): ResourceSnapshotsReportModel =>
     getSuccessReport(snapshotId, ResourceSnapshotsReportType.DryRun);
-
-  const getErrorDryRunReport = (
-    snapshotId: string
-  ): ResourceSnapshotsReportModel =>
-    getErrorReport(snapshotId, ResourceSnapshotsReportType.DryRun);
 
   const getSuccessApplyReport = (
     snapshotId: string
@@ -97,25 +90,6 @@ describe('Snapshot', () => {
     mockedAuthenticatedClient.prototype.getClient.mockImplementation(
       mockedGetClient
     );
-  };
-
-  const doMockGetSnapshotWithoutError = async () => {
-    const successValidateReport = getSuccessDryRunReport(snapshotId);
-    const futureValidateSnapshotState = getDummySnapshotModel(
-      targetOrgId,
-      snapshotId,
-      [successValidateReport]
-    );
-    const successApplyReport = getSuccessApplyReport(snapshotId);
-    const futureApplySnapshotState = getDummySnapshotModel(
-      targetOrgId,
-      snapshotId,
-      [successApplyReport]
-    );
-
-    mockedGetSnapshot
-      .mockResolvedValueOnce(futureValidateSnapshotState)
-      .mockResolvedValueOnce(futureApplySnapshotState);
   };
 
   const doMockWaitUntilDone = () => {

--- a/packages/cli/src/lib/snapshot/snapshot.spec.ts
+++ b/packages/cli/src/lib/snapshot/snapshot.spec.ts
@@ -1,315 +1,554 @@
-jest.mock('../platform/authenticatedClient');
-jest.mock('fs');
-jest.mock('fs-extra');
-
 import {
   ResourceSnapshotsModel,
   ResourceSnapshotsReportModel,
+  ResourceSnapshotsReportStatus,
   ResourceSnapshotsReportType,
+  SnapshotExportContentFormat,
 } from '@coveord/platform-client';
-import {writeJsonSync, ensureFileSync} from 'fs-extra';
-import {join, normalize} from 'path';
 import {mocked} from 'ts-jest/utils';
+
 import {getDummySnapshotModel} from '../../__stub__/resourceSnapshotsModel';
 import {
   getErrorReport,
+  getPendingReport,
   getSuccessReport,
 } from '../../__stub__/resourceSnapshotsReportModel';
-import {AuthenticatedClient} from '../platform/authenticatedClient';
+
 import {Snapshot} from './snapshot';
 
+//#region Mocks
+jest.mock('../platform/authenticatedClient');
+jest.mock('fs-extra');
+jest.mock('async-retry');
+jest.mock('./snapshotReporter');
+jest.mock('./reportPreviewer/reportPreviewer');
+jest.mock('../project/project');
+jest.mock('./expandedPreviewer/expandedPreviewer');
+
+import {AuthenticatedClient} from '../platform/authenticatedClient';
+import {ensureFileSync, writeJSONSync} from 'fs-extra';
+import retry, {RetryFunction} from 'async-retry';
+import {SnapshotReporter} from './snapshotReporter';
+import {ReportViewer} from './reportPreviewer/reportPreviewer';
+import {Project} from '../project/project';
+import {ExpandedPreviewer} from './expandedPreviewer/expandedPreviewer';
+import {join} from 'path';
+import {SnapshotOperationTimeoutError} from '../errors';
+
+const mockedRetry = mocked(retry);
+const mockedExpandedPreviewer = mocked(ExpandedPreviewer, true);
+const mockedProject = mocked(Project, true);
+const mockedSnapshotReporter = mocked(SnapshotReporter, true);
+const mockedReportViewer = mocked(ReportViewer, true);
 const mockedAuthenticatedClient = mocked(AuthenticatedClient, true);
 const mockedEnsureFileSync = mocked(ensureFileSync);
+const mockedWriteJsonSync = mocked(writeJSONSync);
 const mockedCreateSnapshotFromBuffer = jest.fn();
 const mockedPushSnapshot = jest.fn();
 const mockedDeleteSnapshot = jest.fn();
 const mockedGetSnapshot = jest.fn();
+const mockedExportSnapshot = jest.fn();
 const mockedApplySnapshot = jest.fn();
 const mockedDryRunSnapshot = jest.fn();
 const mockedGetClient = jest.fn();
-
-const getSuccessDryRunReport = (
-  snapshotId: string
-): ResourceSnapshotsReportModel =>
-  getSuccessReport(snapshotId, ResourceSnapshotsReportType.DryRun);
-
-const getErrorDryRunReport = (
-  snapshotId: string
-): ResourceSnapshotsReportModel =>
-  getErrorReport(snapshotId, ResourceSnapshotsReportType.DryRun);
-
-const getSuccessApplyReport = (
-  snapshotId: string
-): ResourceSnapshotsReportModel =>
-  getSuccessReport(snapshotId, ResourceSnapshotsReportType.Apply);
-
-const getErrorApplyReport = (
-  snapshotId: string
-): ResourceSnapshotsReportModel =>
-  getErrorReport(snapshotId, ResourceSnapshotsReportType.Apply);
-
-const doMockAuthenticatedClient = () => {
-  mockedGetClient.mockImplementation(() =>
-    Promise.resolve({
-      resourceSnapshot: {
-        createFromBuffer: mockedCreateSnapshotFromBuffer,
-        push: mockedPushSnapshot,
-        delete: mockedDeleteSnapshot,
-        dryRun: mockedDryRunSnapshot,
-        get: mockedGetSnapshot,
-        apply: mockedApplySnapshot,
-      },
-    })
-  );
-
-  mockedAuthenticatedClient.prototype.getClient.mockImplementation(
-    mockedGetClient
-  );
-};
+//#endregion Mocks
 
 describe('Snapshot', () => {
   const targetOrgId = 'target-org';
   const snapshotId = 'target-org-snapshot-id';
+
+  let snapshot: Snapshot;
+  //#region MockFactories
+  const getSuccessDryRunReport = (
+    snapshotId: string
+  ): ResourceSnapshotsReportModel =>
+    getSuccessReport(snapshotId, ResourceSnapshotsReportType.DryRun);
+
+  const getErrorDryRunReport = (
+    snapshotId: string
+  ): ResourceSnapshotsReportModel =>
+    getErrorReport(snapshotId, ResourceSnapshotsReportType.DryRun);
+
+  const getSuccessApplyReport = (
+    snapshotId: string
+  ): ResourceSnapshotsReportModel =>
+    getSuccessReport(snapshotId, ResourceSnapshotsReportType.Apply);
+
+  const getErrorApplyReport = (
+    snapshotId: string
+  ): ResourceSnapshotsReportModel =>
+    getErrorReport(snapshotId, ResourceSnapshotsReportType.Apply);
+
+  const doMockAuthenticatedClient = () => {
+    mockedGetClient.mockImplementation(() =>
+      Promise.resolve({
+        resourceSnapshot: {
+          createFromBuffer: mockedCreateSnapshotFromBuffer,
+          push: mockedPushSnapshot,
+          delete: mockedDeleteSnapshot,
+          dryRun: mockedDryRunSnapshot,
+          get: mockedGetSnapshot,
+          export: mockedExportSnapshot,
+          apply: mockedApplySnapshot,
+        },
+      })
+    );
+
+    mockedAuthenticatedClient.prototype.getClient.mockImplementation(
+      mockedGetClient
+    );
+  };
+
+  const doMockGetSnapshotWithoutError = async () => {
+    const successValidateReport = getSuccessDryRunReport(snapshotId);
+    const futureValidateSnapshotState = getDummySnapshotModel(
+      targetOrgId,
+      snapshotId,
+      [successValidateReport]
+    );
+    const successApplyReport = getSuccessApplyReport(snapshotId);
+    const futureApplySnapshotState = getDummySnapshotModel(
+      targetOrgId,
+      snapshotId,
+      [successApplyReport]
+    );
+
+    mockedGetSnapshot
+      .mockResolvedValueOnce(futureValidateSnapshotState)
+      .mockResolvedValueOnce(futureApplySnapshotState);
+  };
+
+  const doMockWaitUntilDone = () => {
+    const mockedWaitUntilDone = jest.fn().mockReturnValue(Promise.resolve());
+    snapshot.waitUntilDone = mockedWaitUntilDone;
+    return mockedWaitUntilDone;
+  };
+
+  //#endregion
+
+  const getSnapshot = async (
+    reports?: ResourceSnapshotsReportModel | ResourceSnapshotsReportModel[]
+  ): Promise<[Snapshot, ResourceSnapshotsModel]> => {
+    if (reports && !Array.isArray(reports)) {
+      reports = [reports];
+    }
+    const initialSnapshotState = getDummySnapshotModel(
+      targetOrgId,
+      snapshotId,
+      reports
+    );
+    return [
+      new Snapshot(
+        initialSnapshotState,
+        await new AuthenticatedClient().getClient()
+      ),
+      initialSnapshotState,
+    ];
+  };
+
   beforeEach(() => {
-    jest.resetAllMocks();
     doMockAuthenticatedClient();
   });
 
-  afterAll(() => {
-    jest.clearAllMocks();
+  afterEach(() => {
+    jest.resetAllMocks();
   });
 
-  describe('when validating resources in error', () => {
-    let snapshot: Snapshot;
-    let initialSnapshotState: ResourceSnapshotsModel;
-
-    const doMockGetSnapshotInError = () => {
-      const validateErrorReport = getErrorDryRunReport(snapshotId);
-      const validateSnapshotState = getDummySnapshotModel(
-        targetOrgId,
-        snapshotId,
-        [validateErrorReport]
-      );
-      const applyErrorReport = getErrorApplyReport(snapshotId);
-      const applySnapshotState = getDummySnapshotModel(
-        targetOrgId,
-        snapshotId,
-        [applyErrorReport]
-      );
-
-      mockedGetSnapshot
-        .mockResolvedValueOnce(validateSnapshotState)
-        .mockResolvedValueOnce(applySnapshotState);
-    };
+  describe('#validate', () => {
+    let mockedWaitUntilDone: jest.FunctionLike;
+    let mockedDryRunReport: ResourceSnapshotsReportModel;
 
     beforeEach(async () => {
-      doMockGetSnapshotInError();
+      mockedDryRunReport = getSuccessDryRunReport(snapshotId);
+      [snapshot] = await getSnapshot(mockedDryRunReport);
+      mockedWaitUntilDone = doMockWaitUntilDone();
+    });
 
-      initialSnapshotState = await getDummySnapshotModel(
-        targetOrgId,
-        snapshotId
-      );
-      snapshot = new Snapshot(
-        initialSnapshotState,
-        await new AuthenticatedClient().getClient()
+    it.each([
+      [undefined, false],
+      [true, true],
+      [false, false],
+    ])(
+      'should request to dry-run the snapshot to the platform',
+      async (validateParam, snapshotClientParam) => {
+        await snapshot.validate(validateParam);
+
+        expect(mockedDryRunSnapshot).toHaveBeenCalledWith(snapshotId, {
+          deleteMissingResources: snapshotClientParam,
+        });
+      }
+    );
+
+    it('should wait for the backend-operation to complete', async () => {
+      await snapshot.validate();
+      await snapshot.validate(undefined, {wait: 10});
+
+      expect(mockedWaitUntilDone).toHaveBeenNthCalledWith(1, {
+        operationToWaitFor: ResourceSnapshotsReportType.DryRun,
+      });
+      expect(mockedWaitUntilDone).toHaveBeenNthCalledWith(2, {
+        operationToWaitFor: ResourceSnapshotsReportType.DryRun,
+        wait: 10,
+      });
+    });
+
+    it('should create and return a SnapshotReporter of the latest report', async () => {
+      const returnedReporter = await snapshot.validate();
+
+      expect(mockedSnapshotReporter).toHaveBeenCalledTimes(1);
+      expect(mockedSnapshotReporter).toHaveBeenCalledWith(mockedDryRunReport);
+      expect(returnedReporter).toBe(mockedSnapshotReporter.mock.instances[0]);
+    });
+  });
+
+  describe('#preview', () => {
+    let someReport: ResourceSnapshotsReportModel;
+
+    beforeEach(async () => {
+      someReport = getSuccessDryRunReport(snapshotId);
+      [snapshot] = await getSnapshot(someReport);
+    });
+
+    it('should display the the light preview', async () => {
+      await snapshot.preview(new Project(''));
+
+      expect(mockedSnapshotReporter).toBeCalledWith(someReport);
+      expect(mockedReportViewer).toBeCalledWith(
+        mockedSnapshotReporter.mock.instances[0]
       );
     });
 
-    it('#validate should execute a snapshot dryrun', async () => {
-      await snapshot.validate();
-      expect(mockedDryRunSnapshot).toHaveBeenCalledWith(
-        'target-org-snapshot-id',
-        {
-          deleteMissingResources: false,
+    describe('when the latest report is succesful', () => {
+      beforeEach(() => {
+        mockedSnapshotReporter.mockImplementation(
+          () =>
+            ({
+              isSuccessReport: () => true,
+            } as unknown as SnapshotReporter)
+        );
+      });
+
+      it.each([
+        [undefined, false],
+        [true, true],
+        [false, false],
+      ])(
+        'should generate the expanded preview',
+        async (previewParam, expandedPreviewerParam) => {
+          const someProject = new Project('');
+
+          await snapshot.preview(someProject, previewParam);
+
+          expect(mockedExpandedPreviewer).toBeCalledWith(
+            someReport,
+            targetOrgId,
+            someProject,
+            expandedPreviewerParam
+          );
+          expect(
+            mockedExpandedPreviewer.mock.instances[0].preview
+          ).toHaveBeenCalled();
         }
       );
     });
 
-    it('#validate should return false', async () => {
-      const reporter = await snapshot.validate();
-      expect(reporter.isSuccessReport()).toBe(false);
-    });
+    describe('when the latest report is not succesful', () => {
+      beforeEach(() => {
+        mockedSnapshotReporter.mockImplementation(
+          () =>
+            ({
+              isSuccessReport: () => false,
+            } as unknown as SnapshotReporter)
+        );
+      });
 
-    it('#apply should return false', async () => {
-      const reporter = await snapshot.apply();
-      expect(reporter.isSuccessReport()).toBe(false);
-    });
+      it('should not generate the expanded preview', async () => {
+        await snapshot.preview(new Project(''));
 
-    it('#validate should return the error in the detailed report', async () => {
-      const reporter = await snapshot.validate();
-      expect(reporter.report).toEqual(
-        expect.objectContaining({
-          id: 'target-org-snapshot-id',
-          resultCode: 'RESOURCES_IN_ERROR',
-          status: 'COMPLETED',
-          type: 'DRY_RUN',
-        })
-      );
-    });
-
-    it('#latestReport should return an error if detailed report does not exist', () => {
-      expect(() => snapshot.latestReport).toThrow(/No detailed report found/);
-    });
-
-    it('#latestReport should return detailed report with error', async () => {
-      await snapshot.validate();
-      const report = snapshot.latestReport;
-      expect(report).toEqual(
-        expect.objectContaining({
-          id: 'target-org-snapshot-id',
-          resultCode: 'RESOURCES_IN_ERROR',
-          status: 'COMPLETED',
-          type: 'DRY_RUN',
-        })
-      );
-    });
-
-    it('#latestReport should ensure the file exists', async () => {
-      await snapshot.validate();
-      snapshot.saveDetailedReport(normalize(join('path', 'to', 'report')));
-      expect(mockedEnsureFileSync).toHaveBeenCalledWith(
-        normalize(
-          join(
-            'path',
-            'to',
-            'report',
-            'snapshot-reports',
-            'target-org-snapshot-id.json'
-          )
-        )
-      );
-    });
-
-    it('#latestReport should save detailed report', async () => {
-      await snapshot.validate();
-      snapshot.saveDetailedReport(normalize(join('path', 'to', 'report')));
-      expect(writeJsonSync).toHaveBeenCalledWith(
-        normalize(
-          join(
-            'path',
-            'to',
-            'report',
-            'snapshot-reports',
-            'target-org-snapshot-id.json'
-          )
-        ),
-        expect.objectContaining({
-          id: 'target-org-snapshot-id',
-          resultCode: 'RESOURCES_IN_ERROR',
-          status: 'COMPLETED',
-          type: 'DRY_RUN',
-        }),
-        {spaces: 2}
-      );
+        expect(mockedExpandedPreviewer).not.toBeCalled();
+      });
     });
   });
 
-  describe('when the snapshot is successfully created', () => {
-    let snapshot: Snapshot;
-    let initialSnapshotState: ResourceSnapshotsModel;
-
-    const doMockGetSnapshotWithoutError = async () => {
-      const successValidateReport = getSuccessDryRunReport(snapshotId);
-      const futureValidateSnapshotState = await getDummySnapshotModel(
-        targetOrgId,
-        snapshotId,
-        [successValidateReport]
-      );
-      const successApplyReport = getSuccessApplyReport(snapshotId);
-      const futureApplySnapshotState = await getDummySnapshotModel(
-        targetOrgId,
-        snapshotId,
-        [successApplyReport]
-      );
-
-      mockedGetSnapshot
-        .mockResolvedValueOnce(futureValidateSnapshotState)
-        .mockResolvedValueOnce(futureApplySnapshotState);
-    };
+  describe('#apply', () => {
+    let mockedWaitUntilDone: jest.FunctionLike;
+    let mockedApplyRunReport: ResourceSnapshotsReportModel;
 
     beforeEach(async () => {
-      doMockGetSnapshotWithoutError();
-
-      initialSnapshotState = await getDummySnapshotModel(
-        targetOrgId,
-        snapshotId
-      );
-      snapshot = new Snapshot(
-        initialSnapshotState,
-        await new AuthenticatedClient().getClient()
-      );
+      mockedApplyRunReport = getSuccessApplyReport(snapshotId);
+      [snapshot] = await getSnapshot(mockedApplyRunReport);
+      mockedWaitUntilDone = doMockWaitUntilDone();
     });
 
-    it('#id should return snapshot id', () => {
-      expect(snapshot.id).toEqual('target-org-snapshot-id');
-    });
+    it.each([
+      [undefined, false],
+      [true, true],
+      [false, false],
+    ])(
+      'should request to apply the snapshot to the platform',
+      async (validateParam, snapshotClientParam) => {
+        await snapshot.apply(validateParam);
 
-    it('#targetId should return snapshot targetId', () => {
-      expect(snapshot.targetId).toEqual('target-org');
-    });
+        expect(mockedApplySnapshot).toHaveBeenCalledWith(snapshotId, {
+          deleteMissingResources: snapshotClientParam,
+        });
+      }
+    );
 
-    it('report should contain the info of the last DryRun operation', async () => {
-      const reporter = await snapshot.validate();
-      expect(reporter.report.type).toBe(ResourceSnapshotsReportType.DryRun);
-    });
-
-    it('report should contain the info of the last Apply operation', async () => {
-      const reporter = await snapshot.apply();
-      expect(reporter.report.type).toBe(ResourceSnapshotsReportType.Apply);
-    });
-
-    it('should refresh the snapshot until the right operation is processed', async () => {
+    it('should wait for the backend-operation to complete', async () => {
       await snapshot.apply();
-      expect(mockedGetSnapshot).toHaveBeenCalledTimes(2);
+      await snapshot.apply(true, {wait: 10});
+
+      expect(mockedWaitUntilDone).toHaveBeenNthCalledWith(1, {
+        operationToWaitFor: ResourceSnapshotsReportType.Apply,
+      });
+      expect(mockedWaitUntilDone).toHaveBeenNthCalledWith(2, {
+        operationToWaitFor: ResourceSnapshotsReportType.Apply,
+        wait: 10,
+      });
     });
 
-    it('#latestReport should return snapshot latestReport', async () => {
-      await snapshot.validate();
-      const report = snapshot.latestReport;
-      expect(report).toEqual(
-        expect.objectContaining({
-          id: 'target-org-snapshot-id',
-          resultCode: 'SUCCESS',
-          status: 'COMPLETED',
-          type: 'DRY_RUN',
-        })
-      );
+    it('should create and return a SnapshotReporter of the latest report', async () => {
+      const returnedReporter = await snapshot.apply();
+
+      expect(mockedSnapshotReporter).toHaveBeenCalledTimes(1);
+      expect(mockedSnapshotReporter).toHaveBeenCalledWith(mockedApplyRunReport);
+      expect(returnedReporter).toBe(mockedSnapshotReporter.mock.instances[0]);
+    });
+  });
+
+  describe('#delete', () => {
+    beforeEach(async () => {
+      [snapshot] = await getSnapshot();
     });
 
-    it('#validate should return true', async () => {
-      const reporter = await snapshot.validate();
-      expect(reporter.isSuccessReport()).toBe(true);
-    });
-
-    it('#apply should apply a snapshot to the target org', async () => {
-      await snapshot.apply();
-      expect(mockedApplySnapshot).toHaveBeenCalledTimes(1);
-      expect(mockedApplySnapshot).toHaveBeenCalledWith(
-        'target-org-snapshot-id',
-        {deleteMissingResources: false}
-      );
-    });
-
-    it('#apply should return true', async () => {
-      const reporter = await snapshot.apply();
-      expect(reporter.isSuccessReport()).toBe(true);
-    });
-
-    it('#apply should apply a snapshot with deleteMissingResources flag', async () => {
-      await snapshot.apply(true);
-      expect(mockedApplySnapshot).toHaveBeenCalledTimes(1);
-      expect(mockedApplySnapshot).toHaveBeenCalledWith(
-        'target-org-snapshot-id',
-        {deleteMissingResources: true}
-      );
-    });
-
-    it('should be deleted', async () => {
+    it('should request to delete the snapshot to the platform', async () => {
       await snapshot.delete();
-      expect(mockedDeleteSnapshot).toHaveBeenCalledTimes(1);
-      expect(mockedDeleteSnapshot).toHaveBeenCalledWith(
-        'target-org-snapshot-id'
+
+      expect(mockedDeleteSnapshot).toHaveBeenCalledWith(snapshotId);
+    });
+  });
+
+  describe('#download', () => {
+    beforeEach(async () => {
+      [snapshot] = await getSnapshot();
+    });
+
+    it('should download the snapshot', async () => {
+      const fakeResponse = Promise.resolve();
+      mockedExportSnapshot.mockReturnValueOnce(fakeResponse);
+
+      const returnBlob = snapshot.download();
+
+      expect(mockedExportSnapshot).toHaveBeenCalledWith(snapshotId, {
+        contentFormat: SnapshotExportContentFormat.SplitPerType,
+      });
+      expect(returnBlob).toBe(fakeResponse);
+    });
+  });
+
+  describe('#requiresSynchronization', () => {
+    let latestReport: ResourceSnapshotsReportModel;
+    beforeEach(async () => {
+      [snapshot] = await getSnapshot(latestReport);
+    });
+
+    describe('when the latestReport resultCode is ResourcesInError', () => {
+      beforeAll(() => {
+        latestReport = getErrorApplyReport(snapshotId);
+      });
+
+      it('should return true', () => {
+        expect(snapshot.requiresSynchronization()).toBe(true);
+      });
+    });
+
+    describe('when the latestReport resultCode is ResourcesInError', () => {
+      beforeAll(() => {
+        latestReport = getSuccessApplyReport(snapshotId);
+      });
+
+      it('should return false', () => {
+        expect(snapshot.requiresSynchronization()).toBe(false);
+      });
+    });
+  });
+
+  describe('#saveDetailedReport', () => {
+    let someReport: ResourceSnapshotsReportModel;
+    beforeEach(async () => {
+      someReport = getSuccessApplyReport(snapshotId);
+      [snapshot] = await getSnapshot(someReport);
+    });
+
+    it('should write the report on disk at the appropriate path and return the latter', () => {
+      const somePathStr = 'foo/bar/baz';
+
+      const returnValue = snapshot.saveDetailedReport(somePathStr);
+
+      const expectedFilePath = join(
+        somePathStr,
+        'snapshot-reports',
+        `${someReport.id}.json`
       );
+
+      expect(mockedEnsureFileSync).toBeCalledWith(expectedFilePath);
+      expect(mockedWriteJsonSync).toBeCalledWith(expectedFilePath, someReport, {
+        spaces: 2,
+      });
+      expect(returnValue).toBe(expectedFilePath);
+    });
+  });
+
+  describe('#waitUntilDone', () => {
+    let someReport: ResourceSnapshotsReportModel;
+    let initialModel: ResourceSnapshotsModel;
+
+    beforeEach(async () => {
+      someReport = getSuccessApplyReport(snapshotId);
+      [snapshot, initialModel] = await getSnapshot(someReport);
+    });
+
+    it('should use default wait, waitInterval and callback by default', () => {
+      snapshot.waitUntilDone();
+
+      expect(mockedRetry).toHaveBeenCalledWith(expect.anything(), {
+        retries: Math.ceil(
+          Snapshot.defaultWaitOptions.wait /
+            Snapshot.defaultWaitOptions.waitInterval
+        ),
+        minTimeout: Snapshot.defaultWaitOptions.waitInterval * 1e3,
+        maxTimeout: Snapshot.defaultWaitOptions.waitInterval * 1e3,
+        maxRetryTime: Snapshot.defaultWaitOptions.wait * 1e3,
+      });
+    });
+
+    it('should use provided wait and waitInterval and compute how many attempts to do', () => {
+      snapshot.waitUntilDone({wait: 10, waitInterval: 5});
+
+      expect(mockedRetry).toHaveBeenCalledWith(expect.anything(), {
+        retries: 2,
+        minTimeout: 5 * 1e3,
+        maxTimeout: 5 * 1e3,
+        maxRetryTime: 10 * 1e3,
+      });
+    });
+
+    it('should return the retrier from async-retry', () => {
+      const expectedReturnPromise = Promise.resolve();
+      mockedRetry.mockReturnValue(expectedReturnPromise);
+
+      const returnValue = snapshot.waitUntilDone();
+
+      expect(returnValue).toBe(expectedReturnPromise);
+    });
+
+    describe('when a retry happens', () => {
+      it('should refresh the snapshotData and call the onRetryCallback', async () => {
+        mockedGetSnapshot.mockReturnValue(initialModel);
+        const someCallBack = jest.fn();
+        snapshot.waitUntilDone({onRetryCb: someCallBack});
+        const waitUntilDoneRetryFunction = mockedRetry.mock.calls[0][0];
+
+        await waitUntilDoneRetryFunction(jest.fn(), 0);
+
+        expect(mockedGetSnapshot).toHaveBeenCalledWith(snapshotId, {
+          includeReports: true,
+        });
+        expect(someCallBack).toHaveBeenCalledWith(someReport);
+      });
+
+      it('should not resolves when the latestReport status is an ongoing on', async () => {
+        const model = {...initialModel};
+        model.reports = [
+          getPendingReport(snapshotId, ResourceSnapshotsReportType.Apply),
+        ];
+        mockedGetSnapshot.mockReturnValue(model);
+        snapshot.waitUntilDone();
+        const waitUntilDoneRetryFunction = mockedRetry.mock.calls[0][0];
+
+        expect(waitUntilDoneRetryFunction(jest.fn(), 0)).rejects.toMatch(
+          expect.any(SnapshotOperationTimeoutError)
+        );
+      });
+
+      describe("when there's no operation to wait for", () => {
+        it('should resolves when the latestReport status is not an ongoing on', async () => {
+          const model = {...initialModel};
+          model.reports = [getSuccessApplyReport(snapshotId)];
+          mockedGetSnapshot.mockReturnValue(model);
+          snapshot.waitUntilDone();
+          const waitUntilDoneRetryFunction = mockedRetry.mock.calls[0][0];
+
+          expect(
+            waitUntilDoneRetryFunction(jest.fn(), 0)
+          ).resolves.not.toThrow();
+        });
+      });
+
+      describe("when there's an operation to wait for", () => {
+        it('should resolves when the latestReport status is not an ongoing on and the latesReport operations match', async () => {
+          const model = {...initialModel};
+          model.reports = [getSuccessApplyReport(snapshotId)];
+          mockedGetSnapshot.mockReturnValue(model);
+          snapshot.waitUntilDone({
+            operationToWaitFor: ResourceSnapshotsReportType.Apply,
+          });
+          const waitUntilDoneRetryFunction = mockedRetry.mock.calls[0][0];
+
+          expect(
+            waitUntilDoneRetryFunction(jest.fn(), 0)
+          ).resolves.not.toThrow();
+        });
+
+        it('should not resolves when the latestReport operation does not match', async () => {
+          const model = {...initialModel};
+          model.reports = [getSuccessApplyReport(snapshotId)];
+          mockedGetSnapshot.mockReturnValue(model);
+          snapshot.waitUntilDone({
+            operationToWaitFor: ResourceSnapshotsReportType.DryRun,
+          });
+          const waitUntilDoneRetryFunction = mockedRetry.mock.calls[0][0];
+
+          expect(waitUntilDoneRetryFunction(jest.fn(), 0)).rejects.toMatch(
+            expect.any(SnapshotOperationTimeoutError)
+          );
+        });
+      });
+    });
+  });
+
+  describe('[get]-latestReport', () => {
+    describe.each([undefined, []])('when there is no reports', (reports) => {
+      beforeEach(async () => {
+        [snapshot] = await getSnapshot(reports);
+      });
+
+      it('should throw an Error', () => {
+        expect(() => snapshot.latestReport).toThrowError(
+          `No detailed report found for the snapshot ${snapshotId}`
+        );
+      });
+    });
+
+    describe('when there is at least one report', () => {
+      let reports: ResourceSnapshotsReportModel[];
+      let mostRecentReport: ResourceSnapshotsReportModel;
+
+      beforeEach(async () => {
+        reports = [
+          getSuccessApplyReport(snapshotId),
+          getSuccessApplyReport(snapshotId),
+          getSuccessApplyReport(snapshotId),
+        ];
+        reports[1].updatedDate++;
+        mostRecentReport = reports[1];
+        [snapshot] = await getSnapshot(reports);
+      });
+
+      it('should return the most recent one', () => {
+        expect(snapshot.latestReport).toBe(mostRecentReport);
+      });
     });
   });
 });

--- a/packages/cli/src/lib/snapshot/snapshot.ts
+++ b/packages/cli/src/lib/snapshot/snapshot.ts
@@ -27,13 +27,16 @@ export interface WaitUntilDoneOptions {
    */
   waitInterval?: number; // in seconds
   /**
-   * The operation to wait for. If not specified, the method will wait for any operation to complete.
-   */
-  operationToWaitFor?: ResourceSnapshotsReportType;
-  /**
    * Callback to execute every time a request is being made to retrieve the snapshot data
    */
   onRetryCb?: (report: ResourceSnapshotsReportModel) => void;
+}
+
+export interface WaitUntilOperationDone extends WaitUntilDoneOptions {
+  /**
+   * The operation to wait for. If not specified, the method will wait for any operation to complete.
+   */
+  operationToWaitFor?: ResourceSnapshotsReportType;
 }
 
 export class Snapshot {
@@ -76,7 +79,13 @@ export class Snapshot {
     deleteMissingResources = false
   ) {
     this.displayLightPreview();
-    await this.displayExpandedPreview(projectToPreview, deleteMissingResources);
+    const reporter = new SnapshotReporter(this.latestReport);
+    if (reporter.isSuccessReport()) {
+      await this.generateExpandedPreview(
+        projectToPreview,
+        deleteMissingResources
+      );
+    }
   }
 
   public async apply(
@@ -151,7 +160,7 @@ export class Snapshot {
     viewer.display();
   }
 
-  private async displayExpandedPreview(
+  private async generateExpandedPreview(
     projectToPreview: Project,
     shouldDelete: boolean
   ) {
@@ -170,7 +179,7 @@ export class Snapshot {
     });
   }
 
-  public waitUntilDone(options: WaitUntilDoneOptions = {}) {
+  public waitUntilDone(options: WaitUntilOperationDone = {}) {
     const opts = {...Snapshot.defaultWaitOptions, ...options};
     const toMilliseconds = (seconds: number) => seconds * 1e3;
 

--- a/packages/cli/src/lib/snapshot/snapshot.ts
+++ b/packages/cli/src/lib/snapshot/snapshot.ts
@@ -40,9 +40,7 @@ export interface WaitUntilOperationDone extends WaitUntilDoneOptions {
 }
 
 export class Snapshot {
-  public static defaultWaitOptions: Required<
-    Omit<WaitUntilDoneOptions, 'operationToWaitFor'>
-  > = {
+  public static defaultWaitOptions: Required<WaitUntilDoneOptions> = {
     waitInterval: 1,
     wait: 60,
     onRetryCb: (_report: ResourceSnapshotsReportModel) => {},


### PR DESCRIPTION
## Proposed changes

The Snapshot class has evolved a lot since its inception. In the beginning, it had a lot of things to do and so testing its global behaviour was sensible and the easiest.

However, it has not evolved as one if not the centrepiece of the Snapshot feature, this means that it calls a lot of other classes, and gets also called a lot.
In #427, I faced a wall to add new unit tests because the tests were a bit mixed bag between TDD and BDD:
- There was no specific 'describe' plan for the previewing.
- There were quite a few `#funcName` references that make me think of TDD, which was odd in this context.

I tried to include them in the existing structure but was not happy about the result (TL;DR: 🍝 overload :hurtrealbad:), so I rewrote them all starting with the public method/accessors(mainly `latestReport` for the latter) TDD style and covered some missing spots.
I did compromise on the TDD by putting testing descriptions that might be more akin to BDD sometimes when I thought it to be best.

_Include tests for #427_

## Testing

- [x] Unit Tests: Well. :P


## ToDos

- [x] Merge #427
d
-----
CDX-536
