### PR TITLE
build(renovate): add jira suffix for vuln pr

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,6 +2,9 @@
   "enabled": true,
   "extends": [":semanticPrefixFixDepsChoreOthers"],
   "schedule": ["before 2am"],
+  "vulnerabilityAlerts": {
+    "commitMessageSuffix": "[SECURITY] J:CDX-227"
+  },
   "packageRules": [
     {
       "matchPackagePatterns": ["*"],


### PR DESCRIPTION
## Proposed changes

We hit a snag with the vulnerability fix PRs from renovate bot, where our suffix was ignored. It should not be anymore with that PR.
Inspired from: https://github.com/renovatebot/renovate/blob/a73d82787b551d22f60276068b2437d05e4cb012/lib/config/definitions.ts#L1319-L1334

## Testing

None, hard to test without any vulnerability coming our way.

-----
CDX-538
