### PR TITLE
fix(cli): use proper region suffix

### DIFF
--- a/packages/cli/jest.config.js
+++ b/packages/cli/jest.config.js
@@ -1,8 +1,15 @@
+const {defaults} = require('jest-config');
+
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
   verbose: true,
   collectCoverage: true,
+  coveragePathIgnorePatterns: [
+    ...defaults.coveragePathIgnorePatterns,
+    '/__test__/',
+    '/__stub__/',
+  ],
   clearMocks: true,
   testTimeout: 60e3,
 };

--- a/packages/cli/src/__stub__/configuration.ts
+++ b/packages/cli/src/__stub__/configuration.ts
@@ -1,0 +1,19 @@
+import {Region} from '@coveord/platform-client';
+import type {Config, Configuration} from '../lib/config/config';
+import {PlatformEnvironment} from '../lib/platform/environment';
+
+export const defaultConfiguration = {
+  environment: PlatformEnvironment.Dev,
+  organization: 'my-org',
+  region: Region.US,
+  analyticsEnabled: true,
+} as Configuration;
+
+export const configurationMock: (
+  configuration?: Configuration
+) => () => Config =
+  (configuration = defaultConfiguration) =>
+  () =>
+    ({
+      get: () => configuration,
+    } as Config);

--- a/packages/cli/src/commands/auth/login.spec.ts
+++ b/packages/cli/src/commands/auth/login.spec.ts
@@ -4,6 +4,7 @@ jest.mock('../../hooks/analytics/analytics');
 jest.mock('../../hooks/prerun/prerun');
 jest.mock('../../lib/platform/authenticatedClient');
 jest.mock('@coveord/platform-client');
+import {Region} from '@coveord/platform-client';
 import {test} from '@oclif/test';
 import {mocked} from 'ts-jest/utils';
 import {Config} from '../../lib/config/config';
@@ -18,7 +19,7 @@ describe('auth:login', () => {
 
   const mockConfigGet = jest.fn().mockReturnValue(
     Promise.resolve({
-      region: 'us-east-1',
+      region: 'us',
       organization: 'foo',
       environment: 'prod',
     })
@@ -89,13 +90,7 @@ describe('auth:login', () => {
       );
   });
 
-  [
-    'us-east-1',
-    'eu-west-1',
-    'eu-west-3',
-    'ap-southeast-2',
-    'us-west-2',
-  ].forEach((region) => {
+  Object.keys(Region).forEach((region) => {
     test
       .stdout()
       .command(['auth:login', '-r', region, '-o', 'foo'])
@@ -158,7 +153,7 @@ describe('auth:login', () => {
       );
       mockConfigGet.mockReturnValueOnce(
         Promise.resolve({
-          region: 'us-east-1',
+          region: 'us',
           organization: 'the_first_org_available',
           environment: 'prod',
         })

--- a/packages/cli/src/commands/auth/login.ts
+++ b/packages/cli/src/commands/auth/login.ts
@@ -2,14 +2,13 @@ import {Command, flags} from '@oclif/command';
 import {Config} from '../../lib/config/config';
 import {OAuth} from '../../lib/oauth/oauth';
 import {AuthenticatedClient} from '../../lib/platform/authenticatedClient';
-import {
-  PlatformEnvironment,
-  PlatformRegion,
-} from '../../lib/platform/environment';
+import {PlatformEnvironment} from '../../lib/platform/environment';
 import {
   buildAnalyticsFailureHook,
   buildAnalyticsSuccessHook,
 } from '../../hooks/analytics/analytics';
+import {Region} from '@coveord/platform-client';
+import {withEnvironment, withRegion} from '../../lib/flags/platformCommonFlags';
 
 export default class Login extends Command {
   private configuration!: Config;
@@ -19,25 +18,8 @@ export default class Login extends Command {
   public static examples = ['$ coveo auth:login'];
 
   public static flags = {
-    region: flags.string({
-      char: 'r',
-      options: [
-        'us-east-1',
-        'eu-west-1',
-        'eu-west-3',
-        'ap-southeast-2',
-        'us-west-2',
-      ],
-      default: 'us-east-1',
-      description:
-        'The Coveo Platform region to log in to. See <https://docs.coveo.com/en/2976>.',
-    }),
-    environment: flags.string({
-      char: 'e',
-      options: ['dev', 'qa', 'prod', 'hipaa'],
-      default: 'prod',
-      description: 'The Coveo Platform environment to log in to.',
-    }),
+    ...withRegion(),
+    ...withEnvironment(),
     organization: flags.string({
       char: 'o',
       description:
@@ -83,7 +65,7 @@ export default class Login extends Command {
     const flags = this.flags;
     const {accessToken} = await new OAuth({
       environment: flags.environment as PlatformEnvironment,
-      region: flags.region as PlatformRegion,
+      region: flags.region as Region,
     }).getToken();
     await this.configuration.set('accessToken', accessToken);
   }
@@ -92,7 +74,7 @@ export default class Login extends Command {
     const flags = this.flags;
     const cfg = this.configuration;
     await cfg.set('environment', flags.environment as PlatformEnvironment);
-    await cfg.set('region', flags.region as PlatformRegion);
+    await cfg.set('region', flags.region as Region);
   }
 
   private async persistOrganization() {

--- a/packages/cli/src/commands/auth/token.spec.ts
+++ b/packages/cli/src/commands/auth/token.spec.ts
@@ -4,10 +4,12 @@ jest.mock('../../hooks/analytics/analytics');
 jest.mock('../../hooks/prerun/prerun');
 jest.mock('../../lib/platform/authenticatedClient');
 jest.mock('@coveord/platform-client');
+import {Region} from '@coveord/platform-client';
 import {test} from '@oclif/test';
 import {mocked} from 'ts-jest/utils';
 import {Config} from '../../lib/config/config';
 import {AuthenticatedClient} from '../../lib/platform/authenticatedClient';
+import {PlatformEnvironment} from '../../lib/platform/environment';
 const mockedConfig = mocked(Config, true);
 const mockedAuthenticatedClient = mocked(AuthenticatedClient);
 
@@ -16,7 +18,7 @@ describe('auth:token', () => {
 
   const mockConfigGet = jest.fn().mockReturnValue(
     Promise.resolve({
-      region: 'us-east-1',
+      region: 'us',
       organization: 'foo',
       environment: 'prod',
     })
@@ -62,7 +64,7 @@ describe('auth:token', () => {
     .catch(/Expected --region=foo/)
     .it('reject invalid region', async () => {});
 
-  ['dev', 'qa', 'prod', 'hipaa'].forEach((environment) => {
+  Object.values(PlatformEnvironment).forEach((environment) => {
     test
       .stdout()
       .command(['auth:token', '-e', environment, '-t', 'someToken'])
@@ -71,13 +73,7 @@ describe('auth:token', () => {
       });
   });
 
-  [
-    'us-east-1',
-    'eu-west-1',
-    'eu-west-3',
-    'ap-southeast-2',
-    'us-west-2',
-  ].forEach((region) => {
+  Object.keys(Region).forEach((region) => {
     test
       .stdout()
       .command(['auth:token', '-r', region, '-t', 'someToken'])

--- a/packages/cli/src/commands/auth/token.ts
+++ b/packages/cli/src/commands/auth/token.ts
@@ -1,14 +1,13 @@
 import {Command, flags} from '@oclif/command';
 import {Config} from '../../lib/config/config';
 import {AuthenticatedClient} from '../../lib/platform/authenticatedClient';
-import {
-  PlatformEnvironment,
-  PlatformRegion,
-} from '../../lib/platform/environment';
+import {PlatformEnvironment} from '../../lib/platform/environment';
 import {
   buildAnalyticsFailureHook,
   buildAnalyticsSuccessHook,
 } from '../../hooks/analytics/analytics';
+import {Region} from '@coveord/platform-client';
+import {withEnvironment, withRegion} from '../../lib/flags/platformCommonFlags';
 
 export default class Token extends Command {
   private configuration!: Config;
@@ -18,25 +17,8 @@ export default class Token extends Command {
   public static examples = ['$ coveo auth:token'];
 
   public static flags = {
-    region: flags.string({
-      char: 'r',
-      options: [
-        'us-east-1',
-        'eu-west-1',
-        'eu-west-3',
-        'ap-southeast-2',
-        'us-west-2',
-      ],
-      default: 'us-east-1',
-      description:
-        'The Coveo Platform region to log in to. See <https://docs.coveo.com/en/2976>.',
-    }),
-    environment: flags.string({
-      char: 'e',
-      options: ['dev', 'qa', 'prod', 'hipaa'],
-      default: 'prod',
-      description: 'The Coveo Platform environment to log in to.',
-    }),
+    ...withRegion(),
+    ...withEnvironment(),
     token: flags.string({
       char: 't',
       description:
@@ -88,7 +70,7 @@ export default class Token extends Command {
     const flags = this.flags;
     const cfg = this.configuration;
     cfg.set('environment', flags.environment as PlatformEnvironment);
-    cfg.set('region', flags.region as PlatformRegion);
+    cfg.set('region', flags.region as Region);
   }
 
   private async fetchAndSaveOrgId() {

--- a/packages/cli/src/commands/config/set.spec.ts
+++ b/packages/cli/src/commands/config/set.spec.ts
@@ -7,6 +7,8 @@ import {mocked} from 'ts-jest/utils';
 import {Config} from '../../lib/config/config';
 import {test} from '@oclif/test';
 import {AuthenticatedClient} from '../../lib/platform/authenticatedClient';
+import {Region} from '@coveord/platform-client';
+import {PlatformEnvironment} from '../../lib/platform/environment';
 const mockedConfig = mocked(Config);
 const mockedClient = mocked(AuthenticatedClient);
 
@@ -38,7 +40,7 @@ describe('config:set', () => {
       }
     );
 
-  ['dev', 'qa', 'prod', 'hipaa'].forEach((environment) => {
+  Object.values(PlatformEnvironment).forEach((environment) => {
     test
       .stdout()
       .command(['config:set', '-e', environment])
@@ -55,13 +57,7 @@ describe('config:set', () => {
       expect(mockSet).not.toHaveBeenCalled();
     });
 
-  [
-    'us-east-1',
-    'eu-west-1',
-    'eu-west-3',
-    'ap-southeast-2',
-    'us-west-2',
-  ].forEach((region) => {
+  Object.keys(Region).forEach((region) => {
     test
       .stdout()
       .command(['config:set', '-r', region])
@@ -99,7 +95,7 @@ describe('config:set', () => {
     .command(['config:set', '-o', 'the_org'])
     .catch(/don't have access to organization the_org/)
     .it(
-      'fails when trying to set to an invalid organzation the user does not have access to',
+      'fails when trying to set to an invalid organization the user does not have access to',
       () => {
         expect(mockSet).not.toHaveBeenCalled();
       }

--- a/packages/cli/src/commands/config/set.ts
+++ b/packages/cli/src/commands/config/set.ts
@@ -9,33 +9,16 @@ import {
   IsAuthenticated,
   Preconditions,
 } from '../../lib/decorators/preconditions';
-import {
-  PlatformEnvironment,
-  PlatformRegion,
-} from '../../lib/platform/environment';
+import {PlatformEnvironment} from '../../lib/platform/environment';
+import {withEnvironment, withRegion} from '../../lib/flags/platformCommonFlags';
+import {Region} from '@coveord/platform-client';
 
 export default class Set extends Command {
   public static description = 'Modify the current configuration.';
 
   public static flags = {
-    region: flags.string({
-      char: 'r',
-      options: [
-        'us-east-1',
-        'eu-west-1',
-        'eu-west-3',
-        'ap-southeast-2',
-        'us-west-2',
-      ],
-      description:
-        'The Coveo Platform region inside which to perform operations. See <https://docs.coveo.com/en/2976>.',
-    }),
-    environment: flags.string({
-      char: 'e',
-      options: ['dev', 'qa', 'prod', 'hipaa'],
-      description:
-        'The Coveo Platform environment inside which to perform operations.',
-    }),
+    ...withRegion(false),
+    ...withEnvironment(false),
     organization: flags.string({
       char: 'o',
       description:
@@ -61,7 +44,7 @@ export default class Set extends Command {
       cfg.set('organization', flags.organization);
     }
     if (flags.region) {
-      cfg.set('region', flags.region as PlatformRegion);
+      cfg.set('region', flags.region as Region);
     }
     if (flags.analytics) {
       cfg.set('analyticsEnabled', flags.analytics === 'y');

--- a/packages/cli/src/commands/org/config/monitor.spec.ts
+++ b/packages/cli/src/commands/org/config/monitor.spec.ts
@@ -20,7 +20,7 @@ const mockedGetSnapshot = jest.fn();
 const doMockConfig = () => {
   mockedConfigGet.mockReturnValue(
     Promise.resolve({
-      region: 'us-east-1',
+      region: 'us',
       organization: 'default-org',
       environment: 'prod',
     })

--- a/packages/cli/src/commands/org/config/preview.spec.ts
+++ b/packages/cli/src/commands/org/config/preview.spec.ts
@@ -54,7 +54,7 @@ const mockProject = () => {
 const mockConfig = () => {
   mockedConfigGet.mockReturnValue(
     Promise.resolve({
-      region: 'us-east-1',
+      region: 'us',
       organization: 'foo',
       environment: 'prod',
     })

--- a/packages/cli/src/commands/org/config/pull.spec.ts
+++ b/packages/cli/src/commands/org/config/pull.spec.ts
@@ -26,7 +26,7 @@ const mockedDeleteSnapshot = jest.fn();
 const doMockConfig = () => {
   mockedConfigGet.mockReturnValue(
     Promise.resolve({
-      region: 'us-east-1',
+      region: 'us',
       organization: 'default-org',
       environment: 'prod',
     })

--- a/packages/cli/src/commands/org/config/push.spec.ts
+++ b/packages/cli/src/commands/org/config/push.spec.ts
@@ -51,7 +51,7 @@ const mockProject = () => {
 const mockConfig = () => {
   mockedConfigGet.mockReturnValue(
     Promise.resolve({
-      region: 'us-east-1',
+      region: 'us',
       organization: 'foo',
       environment: 'prod',
     })

--- a/packages/cli/src/commands/ui/create/angular.spec.ts
+++ b/packages/cli/src/commands/ui/create/angular.spec.ts
@@ -10,13 +10,12 @@ jest.mock('../../../lib/platform/authenticatedClient');
 jest.mock('../../../lib/utils/misc');
 jest.mock('@coveord/platform-client');
 
-import {join} from 'path';
 import {mocked} from 'ts-jest/utils';
 import {test} from '@oclif/test';
 import {spawnProcess} from '../../../lib/utils/process';
 import {AuthenticatedClient} from '../../../lib/platform/authenticatedClient';
 import PlatformClient from '@coveord/platform-client';
-import {Config, Configuration} from '../../../lib/config/config';
+import {Config} from '../../../lib/config/config';
 import {
   IsNpmVersionInRange,
   IsNodeVersionInRange,
@@ -24,6 +23,7 @@ import {
 import {getPackageVersion} from '../../../lib/utils/misc';
 import Command from '@oclif/command';
 import {IsNgInstalled} from '../../../lib/decorators/preconditions/ng';
+import {configurationMock} from '../../../__stub__/configuration';
 
 describe('ui:create:angular', () => {
   const mockedConfig = mocked(Config);
@@ -65,18 +65,7 @@ describe('ui:create:angular', () => {
   };
 
   const doMockConfiguration = () => {
-    mockedConfig.mockImplementation(
-      () =>
-        ({
-          get: () =>
-            ({
-              environment: 'dev',
-              organization: 'my-org',
-              region: 'us-east-1',
-              analyticsEnabled: true,
-            } as Configuration),
-        } as Config)
-    );
+    mockedConfig.mockImplementation(configurationMock());
   };
 
   const doMockAuthenticatedClient = () => {

--- a/packages/cli/src/commands/ui/create/react.spec.ts
+++ b/packages/cli/src/commands/ui/create/react.spec.ts
@@ -16,7 +16,7 @@ import {spawnProcessOutput} from '../../../lib/utils/process';
 import {npxInPty} from '../../../lib/utils/npx';
 import {AuthenticatedClient} from '../../../lib/platform/authenticatedClient';
 import PlatformClient from '@coveord/platform-client';
-import {Config, Configuration} from '../../../lib/config/config';
+import {Config} from '../../../lib/config/config';
 import {
   IsNpxInstalled,
   IsNodeVersionInRange,
@@ -25,6 +25,7 @@ import {getPackageVersion} from '../../../lib/utils/misc';
 import Command from '@oclif/command';
 import {appendCmdIfWindows} from '../../../lib/utils/os';
 import {IPty} from 'node-pty';
+import {configurationMock} from '../../../__stub__/configuration';
 
 describe('ui:create:react', () => {
   const mockedConfig = mocked(Config);
@@ -75,18 +76,7 @@ describe('ui:create:react', () => {
   };
 
   const doMockConfiguration = () => {
-    mockedConfig.mockImplementation(
-      () =>
-        ({
-          get: () =>
-            ({
-              environment: 'dev',
-              organization: 'my-org',
-              region: 'us-east-1',
-              analyticsEnabled: true,
-            } as Configuration),
-        } as Config)
-    );
+    mockedConfig.mockImplementation(configurationMock());
   };
 
   const doMockAuthenticatedClient = () => {

--- a/packages/cli/src/commands/ui/create/vue.spec.ts
+++ b/packages/cli/src/commands/ui/create/vue.spec.ts
@@ -14,13 +14,14 @@ import {test} from '@oclif/test';
 import {spawnProcess} from '../../../lib/utils/process';
 import {AuthenticatedClient} from '../../../lib/platform/authenticatedClient';
 import PlatformClient from '@coveord/platform-client';
-import {Config, Configuration} from '../../../lib/config/config';
+import {Config} from '../../../lib/config/config';
 import {
   IsNodeVersionInRange,
   IsNpxInstalled,
 } from '../../../lib/decorators/preconditions/';
 import {getPackageVersion} from '../../../lib/utils/misc';
 import Command from '@oclif/command';
+import {configurationMock} from '../../../__stub__/configuration';
 
 describe('ui:create:vue', () => {
   const mockedConfig = mocked(Config);
@@ -57,18 +58,7 @@ describe('ui:create:vue', () => {
   };
 
   const doMockConfiguration = () => {
-    mockedConfig.mockImplementation(
-      () =>
-        ({
-          get: () =>
-            ({
-              environment: 'dev',
-              organization: 'my-org',
-              region: 'us-east-1',
-              analyticsEnabled: true,
-            } as Configuration),
-        } as Config)
-    );
+    mockedConfig.mockImplementation(configurationMock());
   };
 
   const doMockAuthenticatedClient = () => {

--- a/packages/cli/src/hooks/analytics/analytics.spec.ts
+++ b/packages/cli/src/hooks/analytics/analytics.spec.ts
@@ -14,6 +14,10 @@ import hook, {AnalyticsHook} from './analytics';
 import {IConfig} from '@oclif/config';
 import {PlatformClient} from '@coveord/platform-client';
 import {WebStorage} from 'coveo.analytics/dist/definitions/storage';
+import {
+  configurationMock,
+  defaultConfiguration,
+} from '../../__stub__/configuration';
 const mockedAnalytics = mocked(CoveoAnalyticsClient);
 const mockedConfig = mocked(Config);
 const mockedPlatformClient = mocked(PlatformClient);
@@ -62,18 +66,7 @@ describe('analytics hook', () => {
   };
 
   const doMockConfiguration = () => {
-    mockedConfig.mockImplementation(
-      () =>
-        ({
-          get: () =>
-            ({
-              environment: 'dev',
-              organization: 'foo',
-              region: 'us-east-1',
-              analyticsEnabled: true,
-            } as Configuration),
-        } as Config)
-    );
+    mockedConfig.mockImplementation(configurationMock());
   };
 
   const doMockAuthenticatedClient = () => {
@@ -153,7 +146,7 @@ describe('analytics hook', () => {
     await hook(getAnalyticsHook({}));
     expect(sendCustomEvent).toHaveBeenCalledWith(
       expect.objectContaining({
-        customData: expect.objectContaining({organization: 'foo'}),
+        customData: expect.objectContaining({organization: 'my-org'}),
       })
     );
   });
@@ -162,7 +155,7 @@ describe('analytics hook', () => {
     await hook(getAnalyticsHook({}));
     expect(sendCustomEvent).toHaveBeenCalledWith(
       expect.objectContaining({
-        customData: expect.objectContaining({region: 'us-east-1'}),
+        customData: expect.objectContaining({region: 'us'}),
       })
     );
   });
@@ -186,7 +179,7 @@ describe('analytics hook', () => {
   });
 
   it('should send command flags', async () => {
-    const flags = {'-e': 'dev', '-r': 'us-east-1'};
+    const flags = {'-e': 'dev', '-r': 'us'};
     await hook(getAnalyticsHook({flags}));
     expect(sendCustomEvent).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -241,17 +234,7 @@ describe('analytics hook', () => {
 
   it('should not fetch userinfo if anonymous is set to true in the config', async () => {
     mockedConfig.mockImplementation(
-      () =>
-        ({
-          get: () =>
-            ({
-              environment: 'dev',
-              organization: 'foo',
-              region: 'us-east-1',
-              analyticsEnabled: true,
-              anonymous: true,
-            } as Configuration),
-        } as Config)
+      configurationMock({...defaultConfiguration, anonymous: true})
     );
 
     await hook(getAnalyticsHook({}));

--- a/packages/cli/src/lib/config/config.spec.ts
+++ b/packages/cli/src/lib/config/config.spec.ts
@@ -6,6 +6,8 @@ import {
 } from 'fs-extra';
 import {join} from 'path';
 import {mocked} from 'ts-jest/utils';
+import {defaultConfiguration} from '../../__stub__/configuration';
+import {PlatformEnvironment} from '../platform/environment';
 import {Config} from './config';
 jest.mock('fs-extra');
 const mockedPathExists = mocked(pathExistsSync);
@@ -66,13 +68,7 @@ describe('config', () => {
     });
 
     it('should write config on replace', async () => {
-      const theNewConfig = {
-        environment: 'prod' as const,
-        region: 'us-east-1' as const,
-        organization: 'foo',
-        analyticsEnabled: true,
-        accessToken: 'the-token',
-      };
+      const theNewConfig = {...defaultConfiguration};
       new Config('foo/bar').replace(theNewConfig);
       expect(mockedWriteJSON).toHaveBeenCalledWith(
         join('foo', 'bar', 'config.json'),
@@ -82,7 +78,7 @@ describe('config', () => {
 
     it('should write config on set', async () => {
       mockedReadJSON.mockImplementationOnce(() => ({hello: 'world'}));
-      new Config('foo/bar').set('environment', 'dev');
+      new Config('foo/bar').set('environment', PlatformEnvironment.Dev);
       expect(mockedWriteJSON).toHaveBeenCalledWith(
         join('foo', 'bar', 'config.json'),
         expect.objectContaining({

--- a/packages/cli/src/lib/config/config.ts
+++ b/packages/cli/src/lib/config/config.ts
@@ -1,3 +1,4 @@
+import {Region} from '@coveord/platform-client';
 import {
   pathExistsSync,
   createFileSync,
@@ -5,10 +6,14 @@ import {
   readJSONSync,
 } from 'fs-extra';
 import {join} from 'path';
-import {PlatformEnvironment, PlatformRegion} from '../platform/environment';
+import {
+  DEFAULT_ENVIRONMENT,
+  DEFAULT_REGION,
+  PlatformEnvironment,
+} from '../platform/environment';
 
 export interface Configuration {
-  region: PlatformRegion;
+  region: Region;
   environment: PlatformEnvironment;
   organization: string;
   [k: string]: unknown;
@@ -18,8 +23,8 @@ export interface Configuration {
 }
 
 export const DefaultConfig: Configuration = {
-  environment: 'prod',
-  region: 'us-east-1',
+  environment: DEFAULT_ENVIRONMENT,
+  region: DEFAULT_REGION,
   organization: '',
   analyticsEnabled: undefined,
   accessToken: undefined,

--- a/packages/cli/src/lib/flags/platformCommonFlags.ts
+++ b/packages/cli/src/lib/flags/platformCommonFlags.ts
@@ -1,0 +1,26 @@
+import {Region} from '@coveord/platform-client';
+import {flags} from '@oclif/command';
+import {
+  DEFAULT_ENVIRONMENT,
+  DEFAULT_REGION,
+  PlatformEnvironment,
+} from '../platform/environment';
+
+export const withRegion = (withDefault = true) => ({
+  region: flags.string({
+    char: 'r',
+    options: Object.keys(Region),
+    default: withDefault ? DEFAULT_REGION : undefined,
+    description:
+      'The Coveo Platform region to log in to. See <https://docs.coveo.com/en/2976>.',
+  }),
+});
+
+export const withEnvironment = (withDefault = true) => ({
+  environment: flags.string({
+    char: 'e',
+    options: Object.values(PlatformEnvironment),
+    default: withDefault ? DEFAULT_ENVIRONMENT : undefined,
+    description: 'The Coveo Platform environment to log in to.',
+  }),
+});

--- a/packages/cli/src/lib/oauth/oauth.spec.ts
+++ b/packages/cli/src/lib/oauth/oauth.spec.ts
@@ -1,13 +1,10 @@
+import {Region} from '@coveord/platform-client';
 import {
   AuthorizationServiceConfiguration,
   BaseTokenRequestHandler,
 } from '@openid/appauth';
 import {NodeBasedHandler} from '@openid/appauth/built/node_support';
-import {
-  PlatformEnvironment,
-  PlatformRegion,
-  platformUrl,
-} from '../platform/environment';
+import {PlatformEnvironment, platformUrl} from '../platform/environment';
 import {OAuth} from './oauth';
 
 jest.mock('@openid/appauth/built/node_support');
@@ -56,14 +53,15 @@ describe('OAuth', () => {
   describe('should use proper @openid AuthorizationServiceConfiguration', () => {
     const endpoints = (opts?: {
       environment?: PlatformEnvironment;
-      region?: PlatformRegion;
+      region?: Region;
     }) => ({
       authorization_endpoint: `${platformUrl(opts)}/oauth/authorize`,
       revocation_endpoint: `${platformUrl(opts)}/logout`,
       token_endpoint: `${platformUrl(opts)}/oauth/token`,
     });
+
     it('in prod', async () => {
-      const opts = {environment: 'prod' as const};
+      const opts = {environment: PlatformEnvironment.Prod};
       await new OAuth(opts).getToken();
       expect(AuthorizationServiceConfiguration).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -74,8 +72,9 @@ describe('OAuth', () => {
         })
       );
     });
+
     it('in qa', async () => {
-      const opts = {environment: 'qa' as const};
+      const opts = {environment: PlatformEnvironment.QA};
       await new OAuth(opts).getToken();
       expect(AuthorizationServiceConfiguration).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -83,8 +82,9 @@ describe('OAuth', () => {
         })
       );
     });
+
     it('in dev', async () => {
-      const opts = {environment: 'dev' as const};
+      const opts = {environment: PlatformEnvironment.Dev};
       await new OAuth(opts).getToken();
       expect(AuthorizationServiceConfiguration).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -92,8 +92,9 @@ describe('OAuth', () => {
         })
       );
     });
+
     it('in hipaa', async () => {
-      const opts = {environment: 'hipaa' as const};
+      const opts = {environment: PlatformEnvironment.QA};
       await new OAuth(opts).getToken();
       expect(AuthorizationServiceConfiguration).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -101,8 +102,9 @@ describe('OAuth', () => {
         })
       );
     });
-    it('in europe', async () => {
-      const opts = {region: 'eu-west-1' as const};
+
+    it('in Europe', async () => {
+      const opts = {region: Region.EU};
       await new OAuth(opts).getToken();
       expect(AuthorizationServiceConfiguration).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -110,11 +112,15 @@ describe('OAuth', () => {
         })
       );
     });
-    it('it should be us-east-1 prod by default', async () => {
+
+    it('it should be U.S. prod by default', async () => {
       await new OAuth().getToken();
       expect(AuthorizationServiceConfiguration).toHaveBeenCalledWith(
         expect.objectContaining({
-          ...endpoints({environment: 'prod', region: 'us-east-1'}),
+          ...endpoints({
+            environment: PlatformEnvironment.Prod,
+            region: Region.US,
+          }),
         })
       );
     });

--- a/packages/cli/src/lib/oauth/oauth.ts
+++ b/packages/cli/src/lib/oauth/oauth.ts
@@ -1,6 +1,7 @@
 import {
+  DEFAULT_ENVIRONMENT,
+  DEFAULT_REGION,
   PlatformEnvironment,
-  PlatformRegion,
   platformUrl,
 } from '../platform/environment';
 import {
@@ -17,11 +18,12 @@ import {
   NodeCrypto,
   NodeRequestor,
 } from '@openid/appauth/built/node_support';
+import {Region} from '@coveord/platform-client';
 
 export interface OAuthOptions {
   port: number;
   environment: PlatformEnvironment;
-  region: PlatformRegion;
+  region: Region;
 }
 
 export class OAuth {
@@ -29,8 +31,8 @@ export class OAuth {
   public constructor(opts?: Partial<OAuthOptions>) {
     const baseOptions: OAuthOptions = {
       port: 32111,
-      environment: 'prod',
-      region: 'us-east-1',
+      environment: DEFAULT_ENVIRONMENT,
+      region: DEFAULT_REGION,
     };
 
     this.opts = {

--- a/packages/cli/src/lib/platform/authenticatedClient.spec.ts
+++ b/packages/cli/src/lib/platform/authenticatedClient.spec.ts
@@ -12,7 +12,7 @@ import {mocked} from 'ts-jest/utils';
 import PlatformClient from '@coveord/platform-client';
 import {
   castEnvironmentToPlatformClient,
-  castRegionToPlatformClient,
+  PlatformEnvironment,
 } from './environment';
 const mockConfig = mocked(Config);
 const mockPlatformClient = mocked(PlatformClient);
@@ -21,7 +21,7 @@ describe('AuthenticatedClient', () => {
   const mockGet = jest.fn().mockReturnValue(
     Promise.resolve({
       environment: 'dev',
-      region: 'eu-west-1',
+      region: 'eu',
       organization: 'my_org',
       accessToken: 'my_token',
     })
@@ -86,8 +86,8 @@ describe('AuthenticatedClient', () => {
     await new AuthenticatedClient().getClient();
     expect(mockPlatformClient).toHaveBeenLastCalledWith(
       expect.objectContaining({
-        environment: castEnvironmentToPlatformClient('dev'),
-        region: castRegionToPlatformClient('eu-west-1'),
+        environment: castEnvironmentToPlatformClient(PlatformEnvironment.Dev),
+        region: 'eu',
         organizationId: 'my_org',
         accessToken: 'my_token',
       })

--- a/packages/cli/src/lib/platform/authenticatedClient.ts
+++ b/packages/cli/src/lib/platform/authenticatedClient.ts
@@ -3,10 +3,7 @@ require('abortcontroller-polyfill');
 
 import PlatformClient from '@coveord/platform-client';
 import {Config, Configuration} from '../config/config';
-import {
-  castEnvironmentToPlatformClient,
-  castRegionToPlatformClient,
-} from './environment';
+import {castEnvironmentToPlatformClient} from './environment';
 
 export class AuthenticatedClient {
   public cfg: Config;
@@ -35,7 +32,7 @@ export class AuthenticatedClient {
 
     return new PlatformClient({
       environment: castEnvironmentToPlatformClient(resolvedConfig.environment),
-      region: castRegionToPlatformClient(resolvedConfig.region),
+      region: resolvedConfig.region,
       organizationId: resolvedConfig.organization,
       accessToken: resolvedConfig.accessToken!,
     });

--- a/packages/cli/src/lib/platform/environment.spec.ts
+++ b/packages/cli/src/lib/platform/environment.spec.ts
@@ -1,9 +1,7 @@
 import {Environment, Region} from '@coveord/platform-client';
 import {
   castEnvironmentToPlatformClient,
-  castRegionToPlatformClient,
   PlatformEnvironment,
-  PlatformRegion,
   platformUrl,
 } from './environment';
 
@@ -14,29 +12,29 @@ describe('platformUrl helper', () => {
 
   it(`when the environment is prod
     should not return it in the url e.g. https://platform.cloud.coveo.com`, () => {
-    expect(platformUrl({environment: 'prod'})).toBe(
+    expect(platformUrl({environment: PlatformEnvironment.Prod})).toBe(
       'https://platform.cloud.coveo.com'
     );
   });
 
   it(`when the environment is not prod
     should return it in the url e.g. https://platformdev.cloud.coveo.com`, () => {
-    expect(platformUrl({environment: 'dev'})).toBe(
+    expect(platformUrl({environment: PlatformEnvironment.Dev})).toBe(
       'https://platformdev.cloud.coveo.com'
     );
   });
 
-  it(`when the region is us-east-1
+  it(`when the region is U.S.
     should not return it in the url e.g. https://platform.cloud.coveo.com`, () => {
-    expect(platformUrl({region: 'us-east-1'})).toBe(
+    expect(platformUrl({region: Region.US})).toBe(
       'https://platform.cloud.coveo.com'
     );
   });
 
-  it(`when the region is not us-east-1
-    should return it in the url e.g. https://platform-us-west-2.cloud.coveo.com`, () => {
-    expect(platformUrl({region: 'us-west-2'})).toBe(
-      'https://platform-us-west-2.cloud.coveo.com'
+  it(`when the region is not U.S.
+    should return it in the url e.g. https://platform-eu.cloud.coveo.com`, () => {
+    expect(platformUrl({region: Region.EU})).toBe(
+      'https://platform-eu.cloud.coveo.com'
     );
   });
 
@@ -50,21 +48,6 @@ describe('platformUrl helper', () => {
     ].forEach((testCase) => {
       expect(
         castEnvironmentToPlatformClient(testCase.env as PlatformEnvironment)
-      ).toBe(testCase.platformClient);
-    });
-  });
-
-  it('should #castRegionToPlatformClient correctly', () => {
-    [
-      {region: 'us-east-1', platformClient: Region.US},
-      {region: 'us-west-2', platformClient: Region.US},
-      {region: 'eu-west-1', platformClient: Region.EU},
-      {region: 'eu-west-3', platformClient: Region.EU},
-      {region: 'ap-southeast-2', platformClient: Region.AU},
-      {region: 'something_random', platformClient: Region.US},
-    ].forEach((testCase) => {
-      expect(
-        castRegionToPlatformClient(testCase.region as PlatformRegion)
       ).toBe(testCase.platformClient);
     });
   });

--- a/packages/cli/src/lib/platform/environment.ts
+++ b/packages/cli/src/lib/platform/environment.ts
@@ -1,23 +1,18 @@
 import {Environment, Region} from '@coveord/platform-client';
 
-type PlatformCombination =
-  | {env: 'dev'; region: 'us-east-1' | 'eu-west-1' | 'eu-west-3'}
-  | {env: 'qa'; region: 'us-east-1' | 'eu-west-1' | 'ap-southeast-2'}
-  | {env: 'hipaa'; region: 'us-east-1'}
-  | {env: 'prod'; region: 'us-east-1' | 'us-west-2' | 'eu-west-1'};
+export enum PlatformEnvironment {
+  Dev = 'dev',
+  QA = 'qa',
+  Hipaa = 'hipaa',
+  Prod = 'prod',
+}
 
-export type PlatformEnvironment = PlatformCombination['env'];
-export type PlatformRegion = Extract<
-  PlatformCombination,
-  {env: PlatformEnvironment}
->['region'];
-
-export const DEFAULT_ENVIRONMENT = 'prod' as const;
-export const DEFAULT_REGION = 'us-east-1' as const;
+export const DEFAULT_ENVIRONMENT = PlatformEnvironment.Prod as const;
+export const DEFAULT_REGION = Region.US as const;
 
 export type PlatformUrlOptions = {
   environment: PlatformEnvironment;
-  region: PlatformRegion;
+  region: Region;
 };
 
 const defaultOptions: PlatformUrlOptions = {
@@ -49,20 +44,5 @@ export function castEnvironmentToPlatformClient(
       return Environment.hipaa;
     default:
       return Environment.prod;
-  }
-}
-
-export function castRegionToPlatformClient(r: PlatformRegion): Region {
-  switch (r) {
-    case 'us-east-1':
-    case 'us-west-2':
-      return Region.US;
-    case 'eu-west-1':
-    case 'eu-west-3':
-      return Region.EU;
-    case 'ap-southeast-2':
-      return Region.AU;
-    default:
-      return Region.US;
   }
 }

--- a/packages/cli/src/lib/platform/url.spec.ts
+++ b/packages/cli/src/lib/platform/url.spec.ts
@@ -1,49 +1,53 @@
-import {PlatformUrlOptions} from './environment';
+import {Region} from '@coveord/platform-client';
+import {mocked} from 'ts-jest/utils';
+
+jest.mock('./environment');
+import {PlatformEnvironment, platformUrl} from './environment';
 import {snapshotSynchronizationUrl, snapshotUrl} from './url';
 
 describe('url', () => {
-  const targetOrgId = 'foo';
-  const snapshotId = 'bar';
+  const mockedPlatformUrl = mocked(platformUrl);
+  beforeEach(() => {
+    mockedPlatformUrl.mockReturnValue('https://foo.test');
+  });
 
-  describe('when the region is us-west-2', () => {
-    const options: PlatformUrlOptions = {
-      environment: 'prod',
-      region: 'us-west-2',
-    };
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
 
-    it('#snapshotUrl should return the url to the snapshot page', () => {
-      expect(snapshotUrl(targetOrgId, snapshotId, options)).toEqual(
-        'https://platform-us-west-2.cloud.coveo.com/admin/#foo/organization/resource-snapshots/bar'
-      );
-    });
-
-    it('#snapshotSynchronizationUrl should return the url to the snapshot synchronization page', () => {
+  describe('#snapshotUrl', () => {
+    it('should build the URL properly', () => {
       expect(
-        snapshotSynchronizationUrl(targetOrgId, snapshotId, options)
-      ).toEqual(
-        'https://platform-us-west-2.cloud.coveo.com/admin/#foo/organization/resource-snapshots/bar/synchronization'
+        snapshotUrl('some-org', 'some-snapshot', {
+          environment: PlatformEnvironment.QA,
+          region: Region.AU,
+        })
+      ).toBe(
+        'https://foo.test/admin/#some-org/organization/resource-snapshots/some-snapshot'
       );
+
+      expect(platformUrl).toBeCalledWith({
+        environment: PlatformEnvironment.QA,
+        region: Region.AU,
+      });
     });
   });
 
-  describe('when the environment is dev', () => {
-    const options: PlatformUrlOptions = {
-      environment: 'dev',
-      region: 'us-east-1',
-    };
-
-    it('#snapshotUrl should return the url to the snapshot page', () => {
-      expect(snapshotUrl(targetOrgId, snapshotId, options)).toEqual(
-        'https://platformdev.cloud.coveo.com/admin/#foo/organization/resource-snapshots/bar'
-      );
-    });
-
-    it('#snapshotSynchronizationUrl should return the url to the snapshot synchronization page', () => {
+  describe('#snapshotSyncrhonizationUrl', () => {
+    it('should build the URL properly', () => {
       expect(
-        snapshotSynchronizationUrl(targetOrgId, snapshotId, options)
-      ).toEqual(
-        'https://platformdev.cloud.coveo.com/admin/#foo/organization/resource-snapshots/bar/synchronization'
+        snapshotSynchronizationUrl('some-org', 'some-snapshot', {
+          environment: PlatformEnvironment.QA,
+          region: Region.AU,
+        })
+      ).toBe(
+        'https://foo.test/admin/#some-org/organization/resource-snapshots/some-snapshot/synchronization'
       );
+
+      expect(platformUrl).toBeCalledWith({
+        environment: PlatformEnvironment.QA,
+        region: Region.AU,
+      });
     });
   });
 });

--- a/packages/cli/src/lib/snapshot/snapshotUrlBuilder.spec.ts
+++ b/packages/cli/src/lib/snapshot/snapshotUrlBuilder.spec.ts
@@ -1,12 +1,13 @@
 jest.mock('../platform/authenticatedClient');
 
-import {ResourceSnapshotsReportType} from '@coveord/platform-client';
+import {Region, ResourceSnapshotsReportType} from '@coveord/platform-client';
 import {getDummySnapshotModel} from '../../__stub__/resourceSnapshotsModel';
 import {getSuccessReport} from '../../__stub__/resourceSnapshotsReportModel';
 import {Configuration} from '../config/config';
 import {Snapshot} from './snapshot';
 import {SnapshotUrlBuilder} from './snapshotUrlBuilder';
 import {AuthenticatedClient} from '../platform/authenticatedClient';
+import {PlatformEnvironment} from '../platform/environment';
 
 const createSnapshot = async () => {
   const snapshotID = 'my-snapshot';
@@ -19,16 +20,16 @@ const createSnapshot = async () => {
 };
 
 const getUSProdConfig = (): Configuration => ({
-  region: 'us-east-1',
-  environment: 'prod',
+  region: Region.US,
+  environment: PlatformEnvironment.Prod,
   organization: 'does not matter',
   accessToken: 'xxx',
   analyticsEnabled: undefined,
 });
 
 const getEUDevConfig = (): Configuration => ({
-  region: 'eu-west-1',
-  environment: 'dev',
+  region: Region.EU,
+  environment: PlatformEnvironment.Dev,
   organization: 'does not matter',
   accessToken: 'xxx',
   analyticsEnabled: undefined,
@@ -62,7 +63,7 @@ describe('SnapshotUrlBuilder', () => {
   it('#getSynchronizationPage should return the URL to the synchronization page for Dev', () => {
     snapshotUrlBuilder = new SnapshotUrlBuilder(getEUDevConfig());
     expect(snapshotUrlBuilder.getSynchronizationPage(snapshot)).toEqual(
-      'https://platformdev-eu-west-1.cloud.coveo.com/admin/#foo/organization/resource-snapshots/my-snapshot/synchronization'
+      'https://platformdev-eu.cloud.coveo.com/admin/#foo/organization/resource-snapshots/my-snapshot/synchronization'
     );
   });
 });


### PR DESCRIPTION
## Proposed changes

Use `us` `eu` `au` instead of the AWS abv.

## Breaking changes

Existing user settings will ungracefully break with only this Jira.
I scoped the user setting in another Jira to keep PR tidy.

## Testing

- [X] Unit Tests: adapted
- [X] Functional Tests: existing should work, other regions added for future investigation on 'testing environment'.
- [X] Manual test: yep.

-----
CDX-544