### PR TITLE
feat(react): commit /server directory on project creation **WIP**

### DIFF
--- a/packages/cli-e2e/__tests__/react.specs.ts
+++ b/packages/cli-e2e/__tests__/react.specs.ts
@@ -15,7 +15,7 @@ import {
   restoreEnvironmentFile,
 } from '../utils/file';
 import {BrowserConsoleInterceptor} from '../utils/browserConsoleInterceptor';
-import {commitProject, undoCommit} from '../utils/git';
+import {isDirectoryClean} from '../utils/git';
 import {appendFileSync, readFileSync, truncateSync} from 'fs';
 import {EOL} from 'os';
 import {parse} from 'dotenv';
@@ -169,11 +169,6 @@ describe('ui:create:react', () => {
     });
 
     afterAll(async () => {
-      await undoCommit(
-        serverProcessManager,
-        getProjectPath(projectName),
-        projectName
-      );
       await serverProcessManager.killAllProcesses();
     }, 30e3);
 
@@ -229,17 +224,17 @@ describe('ui:create:react', () => {
       });
     });
 
-    it('should be commited without lint-stage errors', async () => {
-      const eslintErrorSpy = jest.fn();
+    it('should have a clean working directory', async () => {
+      const gitDirtyWorkingTreeSpy = jest.fn();
 
-      commitProject(
+      await isDirectoryClean(
         serverProcessManager,
         getProjectPath(projectName),
         projectName,
-        eslintErrorSpy
+        gitDirtyWorkingTreeSpy
       );
 
-      expect(eslintErrorSpy).not.toBeCalled();
+      expect(gitDirtyWorkingTreeSpy).not.toBeCalled();
     }, 10e3);
   });
 


### PR DESCRIPTION
https://coveord.atlassian.net/browse/CDX-545

## Proposed changes

Running `ui:create:react` performs an initial git commit, but does not include the `/server` directory.
Unfortunately, we do not control how and when the initial commit is being done. `create-react-app` is handling the initial commit and does not expose any flag to prevent that.

The solution is to perform a second commit to include the server directory
 
## Testing

- [x] Unit Tests:
<!-- Did you write unit tests for your feature? If not, explains why?  -->
- [x] Functionnal Tests:
<!-- Did you write functionnal tests for your feature? If not, explains why?  -->
- [ ] Manual Tests:
<!-- How did you test your changeset?  -->

 

-----
CDX-545

 