### PR TITLE
chore: add repository key on search-token-server

### DIFF
--- a/packages/search-token-server/package.json
+++ b/packages/search-token-server/package.json
@@ -3,6 +3,10 @@
   "version": "1.13.0",
   "main": "server.ts",
   "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:coveo/cli.git"
+  },
   "dependencies": {
     "@coveord/platform-client": "^25.0.0",
     "@types/express": "^4.17.11",


### PR DESCRIPTION
https://coveord.atlassian.net/browse/CDX-547

## Proposed changes

Just to prevent the following warning:
```
Created git commit.

›   Warning: 
›         An unknown error occurred while trying to copy the search token server. Please refer to cdx545/README.md for more information.
›         npm notice created a lockfile as package-lock.json. You should commit this file.
›   npm WARN @coveo/search-token-server@1.13.0 No repository field.
›
›
›      
```

  
## Testing

Pretty straight forward... not sure we need tests for that
- [ ] Unit Tests:
<!-- Did you write unit tests for your feature? If not, explains why?  -->
- [ ] Functionnal Tests:
<!-- Did you write functionnal tests for your feature? If not, explains why?  -->
- [ ] Manual Tests:
<!-- How did you test your changeset?  -->
 