### PR TITLE
test: browserInterceptor sometime causes the E2E tests to fail

### DIFF
--- a/packages/cli-e2e/utils/browserConsoleInterceptor.ts
+++ b/packages/cli-e2e/utils/browserConsoleInterceptor.ts
@@ -43,8 +43,10 @@ export class BrowserConsoleInterceptor {
   ) {
     if (typesToIntercept.some((type) => type === message.type)) {
       message.args.forEach((arg) => {
-        this.interceptedMessages.push(arg.value);
-        this.logMessage(arg.value, message.type);
+        if (arg.value) {
+          this.interceptedMessages.push(arg.value);
+          this.logMessage(arg.value, message.type);
+        }
       });
     }
   }


### PR DESCRIPTION
https://coveord.atlassian.net/browse/CDX-555

## Proposed changes
Based on the [doc](https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#type-RemoteObject), `arg.value` is optional on some arguments.

As shown in the image, not all values in the `args` array are relevant to us. We simply need the args containing the actual error message (in this case, the 2 first args).
![image](https://user-images.githubusercontent.com/12199712/131022101-566eb8f3-72ba-41a0-829d-d66d3a805a74.png)

Otherwise, it may cause the E2E tests to fail

## Testing

- [x] Unit Tests:
<!-- Did you write unit tests for your feature? If not, explains why?  -->
- [x] Functionnal Tests:
<!-- Did you write functionnal tests for your feature? If not, explains why?  -->
- [x] Manual Tests:
Tested in the Docker container

-----
CDX-555
