### PR TITLE
ci(pr): ensure pr name are semantic

### DIFF
--- a/.github/workflows/pr-title-semantic-lint.yml
+++ b/.github/workflows/pr-title-semantic-lint.yml
@@ -1,0 +1,16 @@
+name: PrTitleSemanticLint
+on:
+  pull_request:
+    branches: [ main ]
+    types: [opened, edited, synchronize, reopened]
+jobs:
+  Lint:
+      runs-on: ubuntu-latest
+      env:
+        GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+      steps:
+        - uses: actions/checkout@v2
+        - name: Ensure PR Title is Semantic
+          run: |
+            npm ci
+            npx @coveo/is-pr-title-semantic

--- a/.github/workflows/pr-title-semantic-lint.yml
+++ b/.github/workflows/pr-title-semantic-lint.yml
@@ -1,7 +1,7 @@
 name: PrTitleSemanticLint
 on:
   pull_request:
-    branches: [ main ]
+    branches: [ master ]
     types: [opened, edited, synchronize, reopened]
 jobs:
   Lint:

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "devDependencies": {
     "@actions/core": "1.5.0",
     "@actions/github": "5.0.0",
-    "@commitlint/config-conventional": "13.1.0",
+    "@commitlint/config-conventional": "^13.1.0",
     "@commitlint/config-lerna-scopes": "13.1.0",
     "@commitlint/lint": "13.1.0",
     "@oclif/dev-cli": "1.26.0",

--- a/packages/commitlint.config.js
+++ b/packages/commitlint.config.js
@@ -1,0 +1,1 @@
+module.exports = {extends: ['@commitlint/config-conventional']};


### PR DESCRIPTION
## Proposed changes

Use https://github.com/github-actions/is-pr-title-semantic to ensure the title of a PR is semantic.

Like how `@coveo/merge-bot` do, it'll comment directly on the PR when there's a problem (and the process will also fail to mark the checks as invalid)

If all's well, it'll exit with code 0 (i.e. check validated) and delete its comment.

The linter runs on a selection of pull request event that should do the trick :tm: (I try to no go too trigger happy on the event to no spam GH Action)

## Testing

- [x] Manual Tests: on another repo

-----
CDX-561
