### PR TITLE
fix(cli): typescript issues

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,7 +41,7 @@ jobs:
         run: npm run test
       - name: Build CLI
         working-directory: ./packages/cli
-        run: tsc -b
+        run: tsc -p ./tsconfig.json
       - name: End-to-end Tests
         if: ${{matrix.os == 'ubuntu-latest'}}
         run: bash packages/cli-e2e/entrypoints/ci.sh

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "test": "npm run build && jasmine dist/**/*_spec.js",
     "lint": "prettier --check . && eslint .",
-    "build": "tsc -p tsconfig.json",
+    "build": "node_modules/.bin/tsc -p tsconfig.json",
     "prebuild": "node ./scripts/clean.js",
     "postbuild": "node ./scripts/setup.js",
     "prepublishOnly": "npm run build",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -143,7 +143,7 @@
   "repository": "coveo/cli",
   "scripts": {
     "postpack": "rimraf -f oclif.manifest.json",
-    "prepack": "rimraf -rf lib && tsc -b && oclif-dev manifest && oclif-dev readme",
+    "prepack": "rimraf -rf lib && node_modules/.bin/tsc -b && oclif-dev manifest && oclif-dev readme",
     "test": "jest",
     "lint": "prettier --config ../../.prettierrc.js --check . && eslint .",
     "version": "oclif-dev readme && git add README.md",

--- a/packages/cli/src/commands/source/push/add.ts
+++ b/packages/cli/src/commands/source/push/add.ts
@@ -229,7 +229,7 @@ export default class SourcePushAdd extends Command {
       });
       this.successMessageOnAdd(fileNames, batch.length, res);
     } catch (e) {
-      this.errorMessageOnAdd(e);
+      this.errorMessageOnAdd(e as ErrorFromAPI);
     }
   }
 

--- a/packages/cli/src/commands/source/push/delete.ts
+++ b/packages/cli/src/commands/source/push/delete.ts
@@ -103,7 +103,7 @@ export default class SourcePushDelete extends Command {
       );
       this.successMessageOnDeletion(toDelete, res);
     } catch (e) {
-      this.errorMessageOnDeletion(toDelete, e);
+      this.errorMessageOnDeletion(toDelete, e as ErrorFromAPI);
     }
   }
 
@@ -119,7 +119,7 @@ export default class SourcePushDelete extends Command {
           );
           this.successMessageOnDeletion(toDelete, res);
         } catch (e) {
-          this.errorMessageOnDeletion(toDelete, e);
+          this.errorMessageOnDeletion(toDelete, e as ErrorFromAPI);
         }
       })
     );

--- a/packages/cli/src/lib/oauth/oauth.ts
+++ b/packages/cli/src/lib/oauth/oauth.ts
@@ -74,8 +74,8 @@ export class OAuth {
       );
       return response;
     } catch (e) {
-      console.log('ERROR: ', e);
-      return e;
+      console.error('ERROR: ', e as string);
+      throw e;
     }
   }
 

--- a/packages/cli/src/lib/project/project.ts
+++ b/packages/cli/src/lib/project/project.ts
@@ -83,7 +83,7 @@ export class Project {
       });
       return this.temporaryZipPath;
     } catch (error) {
-      cli.error(error);
+      cli.error(error as string | Error);
     }
   }
 

--- a/packages/cli/src/lib/utils/git.ts
+++ b/packages/cli/src/lib/utils/git.ts
@@ -28,7 +28,7 @@ export async function tryGitCommit(
       });
     } catch (error) {
       cli.warn('Git commit not created');
-      cli.warn(error);
+      cli.warn(error as string | Error);
     }
   }
 }


### PR DESCRIPTION
## Proposed changes

- Fix the TypeScript issue that came up on the build.
- Ensure we use the TypeScript version specified in the `package.json`

## What was going on.

TL;DR: TypeScript released the 4.4 version, which introduced some changes that broke our build (more details below) and, unbeknown to us, we were using the 'global' TypeScript that ship with the `virtual-environment`, not the one that we version in our `package.json`, which lead to the error appearing outta thin air without any incriminating changeset.

This PR change that by using the `node_modules/.bin` to prevent uncontrolled update of TypeScript.

Long version:
- Aug 26th: Microsoft promotes 4.4.2 from RC to `latest` tag.
- Aug 31st: GitHub creates the first new release of `ubuntu-latest` virtual environment since the 26th.
- Sept 2nd: First build to uses the new environment. The 1d delay is hypothetically due to rollout time etc on GitHub side. The issue stays undetected on our side until [this build](https://github.com/coveo/cli/actions/runs/1197004779) because all build priors did not reach the build stage.

## Testing

- [x] Automated Test: Ensure commands acquire specific tsconfig.json to be certain it runs proper.
- [x] Manual Tests: `tsc` on my WSL and Windows env.


## Future improvements:
- Add daily build to SAN-check our processes.
-----
CDX-569