### PR TITLE
ci(cli): fix build script win compat

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -141,8 +141,9 @@
   },
   "repository": "coveo/cli",
   "scripts": {
-    "postpack": "rimraf -f oclif.manifest.json",
-    "prepack": "rimraf -rf lib && node_modules/.bin/tsc -b && oclif-dev manifest && oclif-dev readme",
+    "postpack": "rimraf oclif.manifest.json",
+    "prepack": "rimraf lib && npm run build && oclif-dev manifest && oclif-dev readme",
+    "build": "node_modules/.bin/tsc -b",
     "test": "jest",
     "lint": "prettier --config ../../.prettierrc.js --check . && eslint .",
     "version": "oclif-dev readme && git add README.md",


### PR DESCRIPTION
## Proposed changes

Windows do not resolve executable the same in an npm script, this fixes that.

## Testing

- [ ] Unit Tests: n.a.
- [ ] Functionnal Tests: n.a.
- [X] Manual Tests: Tested on my machine.

-----
CDX-578

