### PR TITLE
fix(snapshot): wait flag should support the value `0`

### DIFF
--- a/packages/cli/src/lib/snapshot/snapshot.spec.ts
+++ b/packages/cli/src/lib/snapshot/snapshot.spec.ts
@@ -397,6 +397,7 @@ describe('Snapshot', () => {
           Snapshot.defaultWaitOptions.wait /
             Snapshot.defaultWaitOptions.waitInterval
         ),
+        forever: false,
         minTimeout: Snapshot.defaultWaitOptions.waitInterval * 1e3,
         maxTimeout: Snapshot.defaultWaitOptions.waitInterval * 1e3,
         maxRetryTime: Snapshot.defaultWaitOptions.wait * 1e3,
@@ -408,6 +409,7 @@ describe('Snapshot', () => {
 
       expect(mockedRetry).toHaveBeenCalledWith(expect.anything(), {
         retries: 2,
+        forever: false,
         minTimeout: 5 * 1e3,
         maxTimeout: 5 * 1e3,
         maxRetryTime: 10 * 1e3,

--- a/packages/cli/src/lib/snapshot/snapshot.spec.ts
+++ b/packages/cli/src/lib/snapshot/snapshot.spec.ts
@@ -404,6 +404,18 @@ describe('Snapshot', () => {
       });
     });
 
+    it('should wait indefinitely', () => {
+      snapshot.waitUntilDone({wait: 0});
+
+      expect(mockedRetry).toHaveBeenCalledWith(expect.anything(), {
+        retries: 0,
+        forever: true,
+        minTimeout: Snapshot.defaultWaitOptions.waitInterval * 1e3,
+        maxTimeout: Snapshot.defaultWaitOptions.waitInterval * 1e3,
+        maxRetryTime: 0,
+      });
+    });
+
     it('should use provided wait and waitInterval and compute how many attempts to do', () => {
       snapshot.waitUntilDone({wait: 10, waitInterval: 5});
 

--- a/packages/cli/src/lib/snapshot/snapshot.ts
+++ b/packages/cli/src/lib/snapshot/snapshot.ts
@@ -244,6 +244,7 @@ export class Snapshot {
       // Setting the retry mechanism to follow a time-based logic instead of specifying the  number of attempts.
       {
         retries: Math.ceil(opts.wait / opts.waitInterval),
+        forever: opts.wait === 0,
         minTimeout: toMilliseconds(opts.waitInterval),
         maxTimeout: toMilliseconds(opts.waitInterval),
         maxRetryTime: toMilliseconds(opts.wait),


### PR DESCRIPTION
https://coveord.atlassian.net/browse/CDX-589

## Proposed changes

There is a bug in the retry logic which is causing the `#waitUntilDone` method to automatically exit when the `wait` option equals `0`.

Reason is that `retries  =  Math.ceil(opts.wait / opts.waitInterval)  =  Math.ceil(0/1)  =  0`

The solution is to use the `forever` option.

## Testing

- [x] Unit Tests:
<!-- Did you write unit tests for your feature? If not, explains why?  -->
- [ ] Functionnal Tests:
<!-- Did you write functionnal tests for your feature? If not, explains why?  -->
- [x] Manual Tests:
<!-- How did you test your changeset?  -->

<!-- For Coveo Employees only. Fill and uncomment this section.

-----
CDX-XXX

-->
