### PR TITLE
chore: do not check prettier for package-locks

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -3,3 +3,5 @@ CHANGELOG.md
 **/CHANGELOG.md
 packages/cli/README.md
 packages/cli-e2e/ui-packages
+package-lock.json
+**/package-lock.json


### PR DESCRIPTION
## Proposed changes

Ignore package-lock.json file for prettier checks.

Since NPM 5, package-lock.json indentation is chosen with this 'algorithm':
IF `package-lock.json` already exist THEN use the existing indentation ELSE use the `package.json` indentation
Except that `lerna` seems to break the indent detection rules of npm 😠: the generated lockfile use tab arbitrarily, but not the root one.

I don't want to have a complex prettier config, so I'm just gonna ignore those files for now.
I will revisit if/when we'll drop `lerna` for `npm workspaces`

Will fix CI for #488 

-----
CDX-636
