### PR TITLE
fix(angular): support NPM 8

### DIFF
--- a/packages/cli/src/commands/ui/create/angular.ts
+++ b/packages/cli/src/commands/ui/create/angular.ts
@@ -25,7 +25,7 @@ export default class Angular extends Command {
    * and https://www.npmjs.com/package/@angular/cli package.json engines section.
    */
   public static requiredNodeVersion = '^12.14.1 || >=14.0.0';
-  public static requiredNpmVersion = '^6.11.0 || ^7.5.6';
+  public static requiredNpmVersion = '^6.11.0 || ^7.5.6 || >=8.0.0';
 
   public static description =
     'Create a Coveo Headless-powered search page with the Angular web framework. See <https://docs.coveo.com/headless> and <https://angular.io/>.';


### PR DESCRIPTION
## Proposed changes

Don't tableflip when using NPM 8, it's a 'small' breaking compared to 7, so it's alright.

## Testing

- [x] Unit Tests: existing
- [x] Functionnal Tests: existing
- [x] Manual Tests: yolo

## Refs:
- https://github.com/angular/angular-cli/pull/21909
-----
CDX-639

