### PR TITLE
fix: lock angular cli to 12.x in test environments

### DIFF
--- a/packages/cli-e2e/entrypoints/ci.ps1
+++ b/packages/cli-e2e/entrypoints/ci.ps1
@@ -27,8 +27,8 @@ do {
 
 git config --global user.name "notgroot"
 git config --global user.email "notgroot@coveo.com"
-
-npm install -g @angular/cli
+# TODO CDX-672 remove version lock
+npm install -g @angular/cli@12.x
 npm install -g ts-node
 
 npm set registry http://localhost:4873

--- a/packages/cli-e2e/entrypoints/ci.sh
+++ b/packages/cli-e2e/entrypoints/ci.sh
@@ -9,8 +9,8 @@ Xvfb :1 -screen 0 1024x768x16 & sleep 1
 google-chrome --no-first-run --remote-debugging-port=9222 --disable-dev-shm-usage --window-size=1080,720 >/dev/null 2>&1 &
 
 xdg-settings set default-web-browser google-chrome.desktop
-
-npm install -g @angular/cli
+# TODO CDX-672 remove version lock
+npm install -g @angular/cli@12.x
 npm install -g ts-node
 
 tmp_registry_log=`mktemp`


### PR DESCRIPTION
## Proposed changes

See #531 for RCA. To not block the builds and PR train till we support Angular 13, let's lock the test env to 12.x

## Testing

FT/CI Yolo

-----
CDX-673