### PR TITLE
ci: migrate 3rd party GH action to hash

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -61,7 +61,7 @@ jobs:
           Start-Process -FilePath "C:\Program Files (x86)\Windows Kits\10\bin\10.0.19041.0\x64\signtool.exe" -ArgumentList "sign /f ./tmp/cert.pfx /p ${{ secrets.COVEO_PFX_PWD }} /fd SHA256 /tr http://timestamp.digicert.com /td SHA256 ./dist/win/coveo-${{env.tag}}-x64.exe" -PassThru | Wait-Process
           Start-Process -FilePath "C:\Program Files (x86)\Windows Kits\10\bin\10.0.19041.0\x64\signtool.exe" -ArgumentList "sign /f ./tmp/cert.pfx /p ${{ secrets.COVEO_PFX_PWD }} /fd SHA256 /tr http://timestamp.digicert.com /td SHA256 ./dist/win/coveo-${{env.tag}}-x86.exe" -PassThru | Wait-Process
       - name: Upload binaries
-        uses: svenstaro/upload-release-action@v2
+        uses: svenstaro/upload-release-action@c5cd3d711a186bb9da45dd49f8a7d3c61ad2f4d4
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: ./packages/cli/dist/**/*


### PR DESCRIPTION
## Proposed changes

Migrated the third party action from a specific version to a hash.

Used the 2.0.0 hash, so you should see no changes.

https://github.com/svenstaro/upload-release-action/releases/tag/2.0.0

## Testing

- [ ] Unit Tests:
Does not apply
- [ ] Functionnal Tests:
Does not apply
- [ ] Manual Tests:
Ran the action in another repo with no issue

