### PR TITLE
ci: get and use the latest tag commit

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,8 @@
 node('linux && docker') {
   checkout scm
+  def releaseCommit
 
-  withDockerContainer(image: 'node:14', args: '-u=root') {
+  withDockerContainer(image: 'node:16', args: '-u=root') {
 
     stage('Setup') {
       sh 'npm ci'
@@ -11,14 +12,15 @@ node('linux && docker') {
       withCredentials([
         string(credentialsId: '	github-coveobot_token', variable: 'GITHUB_CREDENTIALS')
       ]) {
-        sh 'node ./scripts/download-release-assets.js'
+        sh 'node ./scripts/get-release-artifact-and-commit-sha.js'
+        releaseCommit = readFile 'latest-commit'
       }
     }
   }
 
   withDockerContainer(image: '458176070654.dkr.ecr.us-east-1.amazonaws.com/jenkins/deployment_package:v7') {
     stage('Create package') {
-      sh "deployment-package package create --artifacts-location ./artifacts/ --with-deploy"
+      sh "deployment-package package create --artifacts-location ./artifacts/ --with-deploy --changeset ${releaseCommit}"
     }
   }
 }

--- a/scripts/get-release-artifact-and-commit-sha.js
+++ b/scripts/get-release-artifact-and-commit-sha.js
@@ -7,7 +7,7 @@ async function main() {
   // This folder structure needs to be respected in order for the CLI update plugin to
   // be able to do it's job properly.
   const topLevelDirectory = './artifacts';
-  const subDirectoryForTarball = `${topLevelDirectory}/coveo-${tag}`;
+  const subDirectoryForTarball = `${topLevelDirectory}/coveo-${tag.name}`;
   const binariesMatcher =
     /^coveo(_|-)(?<_version>v?\d+\.\d+\.\d+(-\d+)?)(?<longExt>.*\.(exe|deb|pkg))$/;
 
@@ -28,6 +28,8 @@ async function main() {
       return topLevelDirectory;
     }
   });
+
+  fs.writeFileSync('latest-commit', tag.commit.sha);
 
   const files = fs.readdirSync(topLevelDirectory, {withFileTypes: true});
   files.forEach((file) => {

--- a/scripts/github-client.js
+++ b/scripts/github-client.js
@@ -46,7 +46,7 @@ const updatePullRequestComment = (comment_id, body) => {
 
 const getLatestTag = async () => {
   const tags = await octokit.rest.repos.listTags({owner, repo});
-  return tags.data[0].name;
+  return tags.data[0];
 };
 
 const createOrUpdateReleaseDescription = async (tag, body) => {


### PR DESCRIPTION
## Proposed changes

Currently, our CD steps in Jenkins are fetching the HEAD of our main branch, instead of the commit of the latest tag, this could lead to discrepancies.
This changes that.

## Testing

Hard to test outside Jenkins :/ 

-----
CDX-718