### PR TITLE
fix(atomic): always use npm

### DIFF
--- a/packages/create-atomic/script/npmInstallTemplate.ts
+++ b/packages/create-atomic/script/npmInstallTemplate.ts
@@ -6,7 +6,7 @@ import {getPackageManager} from '../src/utils.js';
 (async () =>
   await new Promise((resolve, reject) => {
     const childProcess = spawn(
-      getPackageManager(),
+      'npm',
       [process.env.CI ? 'ci' : 'install', '--ignore-scripts'],
       {
         stdio: 'inherit',

--- a/packages/create-atomic/script/npmInstallTemplate.ts
+++ b/packages/create-atomic/script/npmInstallTemplate.ts
@@ -1,11 +1,12 @@
 import {spawn} from 'node:child_process';
 import {join} from 'node:path';
 import {cwd} from 'node:process';
+import {appendCmdIfWindows} from '../src/utils.js';
 
 (async () =>
   await new Promise((resolve, reject) => {
     const childProcess = spawn(
-      'npm',
+      appendCmdIfWindows('npm'),
       [process.env.CI ? 'ci' : 'install', '--ignore-scripts'],
       {
         stdio: 'inherit',

--- a/packages/create-atomic/script/npmInstallTemplate.ts
+++ b/packages/create-atomic/script/npmInstallTemplate.ts
@@ -1,7 +1,6 @@
 import {spawn} from 'node:child_process';
 import {join} from 'node:path';
 import {cwd} from 'node:process';
-import {getPackageManager} from '../src/utils.js';
 
 (async () =>
   await new Promise((resolve, reject) => {

--- a/packages/create-atomic/src/utils.ts
+++ b/packages/create-atomic/src/utils.ts
@@ -1,4 +1,4 @@
-const appendCmdIfWindows = (cmd: string) =>
+export const appendCmdIfWindows = (cmd: string) =>
   `${cmd}${process.platform === 'win32' ? '.cmd' : ''}`;
 
 const DEFAULT_PACKAGE_MANAGER = 'npm';


### PR DESCRIPTION
## Proposed changes

with the `getPackageManager`, lerna is recognized as the 'package manager' in the user agents, which causes issues with `ci` (because `lerna ci` ain't a thing)

-----
CDX-728