### PR TITLE
ci: fix bad keys in deployment config

### DIFF
--- a/.deployment.config.json
+++ b/.deployment.config.json
@@ -98,7 +98,7 @@
       },
       {
         "project_name": "create-atomic",
-        "file": "packages/create-atomic",
+        "directory": "packages/create-atomic",
         "additional_config": {
           "scan_dev_dependencies": true,
           "image": "snyk/snyk-cli:1.778.0-docker"
@@ -106,7 +106,7 @@
       },
       {
         "project_name": "create-atomic-template",
-        "file": "packages/create-atomic/template",
+        "directory": "packages/create-atomic/template",
         "additional_config": {
           "scan_dev_dependencies": true,
           "image": "snyk/snyk-cli:1.778.0-docker"


### PR DESCRIPTION
`file` is used to target a specific file, `directory` leaves Snyk in control of the acquisition (see other packages).
This is why the certifier failed (tried to load a directory as a `package.json` or something alike.

-----
CDX-729
