### PR TITLE
chore(deps): lock npm to 8.4.x

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -50,6 +50,11 @@
       "matchPackageNames": ["fancy-test"],
       "allowedVersions": "1.x",
       "description": "Wait for Oclif 2 TODO:CDX-746"
+    },
+    {
+      "matchPackageNames": ["npm"],
+      "allowedVersions": "8.4.x",
+      "description": "Need NPM to be fixed https://github.com/npm/cli/issues/4404 TODO:CDX-815"
     }
   ],
   "rangeStrategy": "auto",


### PR DESCRIPTION
<!-- For Coveo Employees only. Fill this section.

CDX-815

-->

## Proposed changes

NPM broke some stuff with the workspace and the adduser command in the 8.5.0, see https://github.com/npm/cli/issues/4404
This lock to 8.4.x for the meantime. 