### PR TITLE
ci(test): ensure test run id is generated at the workflow level

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,6 +24,8 @@ jobs:
       PLATFORM_API_KEY: ${{ secrets.PLATFORM_API_KEY }}
       # ID of the organization to log into for the e2e tests
       ORG_ID: ${{ secrets.ORG_ID }}
+      # ID of the test run to identify resources to teardown.
+      TEST_RUN_ID: 'id${{ matrix.os }}-${{ github.sha }}-${{ github.run_attempt }}g'
       COVEO_DISABLE_AUTOUPDATE: true
     steps:
       - name: Setup runner

--- a/packages/cli-e2e/setup.ts
+++ b/packages/cli-e2e/setup.ts
@@ -64,7 +64,8 @@ export default async function () {
   }
   mkdirSync(SCREENSHOTS_PATH, {recursive: true});
   // runId must start and finish with letters to satisfies Angular.
-  process.env.TEST_RUN_ID = `id${randomBytes(16).toString('hex')}g`;
+  process.env.TEST_RUN_ID =
+    process.env.TEST_RUN_ID ?? `id${randomBytes(16).toString('hex')}g`;
   process.env.PLATFORM_ENV = getPlatformEnv();
   process.env.PLATFORM_HOST = getPlatformHost();
   const testOrgName = `cli-e2e-${process.env.TEST_RUN_ID}`;


### PR DESCRIPTION
<!-- For Coveo Employees only. Fill this section.

CDX-816

-->

## Proposed changes

Combine the os of the runner, the commit ID and the # attempt to make a 'good enough' UID for the test run.

This should avoid test runs interfering with each other. (including windows v. Linux on the same commit, which should fix the windows test I hope.)
