### PR TITLE
chore(snyk): snyk code with code scanning alerts as source of truth

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,10 +35,18 @@ jobs:
         run: |
           npx snyk monitor --dev --all-projects
           npx snyk test --dev --all-projects
-      - name: Snyk code
+      - name: Snyk Code
+        continue-on-error: true
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
-        run: npx snyk code --dev --all-projects
+          NODE_OPTIONS: --max-old-space-size=8192
+        run: npx snyk code test    --dev --all-projects --exclude="project.json" --sarif > ./sarifs/snyk-code.sarif
+      - name: Upload result to GitHub Code Scanning
+        uses: github/codeql-action/upload-sarif@v1
+        with:
+          sarif_file: ./sarifs
+      - name: Check Code Scanning alerts
+        run: node ./get-code-scanning-alerts.js
       - name: Setup git SSH remote
         env:
           DEPLOY_KEY: ${{ secrets.DEPLOY_KEY }}

--- a/scripts/get-code-scanning-alerts.js
+++ b/scripts/get-code-scanning-alerts.js
@@ -1,0 +1,7 @@
+const {getSnykCodeAlerts} = require('./github-client');
+
+(async () => {
+  const alerts = (await getSnykCodeAlerts()).data;
+  alerts.filter((alert) => alert.rule.severity === 'error');
+  process.exit(alerts.length > 0 ? 1 : 0);
+})();

--- a/scripts/github-client.js
+++ b/scripts/github-client.js
@@ -95,6 +95,16 @@ const downloadReleaseAssets = async (tag, determineAssetLocation) => {
   });
 };
 
+const getSnykCodeAlerts = () => {
+  return octokit.rest.codeScanning.listAlertsForRepo({
+    owner,
+    repo,
+    ref: 'master',
+    tool_name: 'SnykCode',
+    state: 'open',
+  });
+};
+
 module.exports = {
   getPullRequestTitle,
   getPullRequestComments,
@@ -105,4 +115,5 @@ module.exports = {
   getLatestTag,
   createOrUpdateReleaseDescription,
   downloadReleaseAssets,
+  getSnykCodeAlerts,
 };


### PR DESCRIPTION
<!-- For Coveo Employees only. Fill this section.

CDX-819

-->

## Proposed changes

- Change the Snyk Code gate to allow exemption through https://github.com/coveo/cli/security/code-scanning.

How does it work? Same as the Snyk PR gate:
 - Scan code
 - Export as SARIF to GH Security
 - Get the latest scan result for SnykCode.
 - Filter to keep only the error level and the open (i.e. not fixed or dismissed) ones.
 - If there's one, fliptable, if not carry on
