### PR TITLE
chore(snyk): ensure sarifs directory

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,9 @@ jobs:
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
           NODE_OPTIONS: --max-old-space-size=8192
-        run: npx snyk code test    --dev --all-projects --exclude="project.json" --sarif > ./sarifs/snyk-code.sarif
+        run: |
+          mdkir -p sarifs
+          npx snyk code test    --dev --all-projects --exclude="project.json" --sarif > ./sarifs/snyk-code.sarif
       - name: Upload result to GitHub Code Scanning
         uses: github/codeql-action/upload-sarif@v1
         with:


### PR DESCRIPTION
<!-- For Coveo Employees only. Fill this section.

CDX-820

-->

## Proposed changes

Was not caught in snyk-master because snyk test (with Sarifs) prolly create the dir if absent, snyk code doesn't and was run after.
