### PR TITLE
chore(gh): add missing env

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,7 @@ jobs:
     env:
       SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
       NODE_OPTIONS: --max-old-space-size=8192
+      GITHUB_CREDENTIALS: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # renovate: tag=v2
       - uses: actions/setup-node@1f8c6b94b26d0feae1e387ca63ccbdc44d27b561 # renovate: tag=v2


### PR DESCRIPTION
<!-- For Coveo Employees only. Fill this section.

CDX-823

-->

## Proposed changes

See: https://github.com/coveo/cli/actions/runs/1853348689, the build is failing due to missing creds for the GH related step (i.e. pulling the latest security analysis).

I don't need the full-fledged release token for that, so I'm using the automatic token authentication for that, which is plenty:
https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow