### PR TITLE
chore(gh): ensure create-atomic-template is bumped

### DIFF
--- a/packages/create-atomic/scripts/preparePackageJsonTemplate.mjs
+++ b/packages/create-atomic/scripts/preparePackageJsonTemplate.mjs
@@ -13,7 +13,9 @@ const pkgIndent = detectIndent(pkgRaw).indent || '\t';
 const pkgJson = JSON.parse(pkgRaw);
 
 pkgJson.name = '{{project}}';
+pkgJson.version = '0.1.0';
 pkgJson.scripts.postinstall = 'npm run setup-lambda && npm run setup-cleanup';
+delete pkgJson.scripts['release:phase2'];
 
 writeFileSync(
   resolve(__dirname, '..', 'template', 'package.json.hbs'),

--- a/packages/create-atomic/template/package.json
+++ b/packages/create-atomic/template/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@coveo/create-atomic-template",
   "description": "{{titleCase project}} project",
-  "version": "0.1.0",
+  "version": "1.25.1",
   "private": true,
   "scripts": {
     "setup-lambda": "node ./scripts/setup-lambda.js",
@@ -11,11 +11,12 @@
     "dev:live": "npm run site:link && netlify dev --live",
     "site:init": "netlify init",
     "site:link": "netlify link",
-    "site:deploy": "npm run site:link && npm run build && netlify env:import .env && netlify deploy --prod --open"
+    "site:deploy": "npm run site:link && npm run build && netlify env:import .env && netlify deploy --prod --open",
+    "release:phase2": "node --experimental-specifier-resolution=node ../../scripts/releaseV2/phase2-bump-all-packages.mjs"
   },
   "dependencies": {
     "@coveo/atomic": "1.23.7",
-    "@coveo/search-token-lambda": "1.25.0"
+    "@coveo/search-token-lambda": "1.25.1"
   },
   "devDependencies": {
     "@stencil/core": "2.13.0",


### PR DESCRIPTION
<!-- For Coveo Employees only. Fill this section.

CDX-832

-->

## Proposed changes

Because `create-atomic-template` ain't a published package, I did not run the release phase2 on it, however, this led to an unsynchronized version between the lambda & the template, and thus, to create-atomic itself.

To ensure this does not happen, I tweaked phase2 so it does not generate a changelog nor publish if the package is private. The rest of the operations, notably the 'dep version bump' mechanism is done regardless of the package.json private field value.
