### PR TITLE
chore(gh): fnmatch is odd

### DIFF
--- a/scripts/releaseV2/phase3-git-commit-tag-push.mjs
+++ b/scripts/releaseV2/phase3-git-commit-tag-push.mjs
@@ -43,7 +43,8 @@ import {dedent} from 'ts-dedent';
   gitCommit(
     dedent`
     [version bump] chore(release): Release ${versionTag} [skip ci]
-
+    README.md
+    CHANGELOG.md
     **/README.md
     **/CHANGELOG.md
     **/package.json


### PR DESCRIPTION
<!-- For Coveo Employees only. Fill this section.

CDX-831

-->

## Proposed changes

`fnmatch` doesn't compute glob 'naturally': `**/foo.txt` will not match `foo.txt`.