### PR TITLE
fix(atomic): make sure Stencil start on the good port

### DIFF
--- a/packages/create-atomic/template/start-netlify.mjs
+++ b/packages/create-atomic/template/start-netlify.mjs
@@ -8,7 +8,8 @@ const args = process.argv.slice(2);
 
 const main = async () => {
   // Dynamic Stencil port discovery feature, unsupported by Netlify.
-  const stencilPort = await getPort({port: portNumbers(3333, 3399)});
+  const stencilPort =
+    process.env.STENCIL_PORT || (await getPort({port: [3333]}));
 
   process.on('SIGINT', () => {
     // Intermittent issue with Netlify not shutting down Stencil port properly.
@@ -26,6 +27,7 @@ const main = async () => {
     ],
     {
       stdio: 'inherit',
+      env: {STENCIL_PORT: stencilPort, ...process.env},
     }
   );
 };

--- a/packages/create-atomic/template/stencil.config.ts
+++ b/packages/create-atomic/template/stencil.config.ts
@@ -14,6 +14,9 @@ export const config: Config = {
       copy: [{src: 'pages', keepDirStructure: false}],
     },
   ],
+  devServer: {
+    port: parseInt(process.env.STENCIL_PORT) || 3333,
+  },
   plugins: [dotenvPlugin()],
   rollupPlugins: {
     before: [


### PR DESCRIPTION


<!-- For Coveo Employees only. Fill this section.

CDX-858

-->

## Proposed changes


### What's going on
Netlify even tho it does some framework detection, does not negotiate the 'targetPort' with the frameworks.
To understand why, we have to understand a bit how Netlify works, which is quite simple: As our CLI.
By that, I mean that the Netlify-CLI will do the same thing that we do: start other CLI (like `stencil-cli` in this instance).

However, what it doesn't do is the 'port mapping' between the option given in input and the underlying CLIs.


### Proposed fix
To alleviate that issue, I circumvent the Netlify-CLI by relying on the fact that it's good practice to 'carry the parent process.env around when spawning child processes.
This allows me to spawn `netlify-cli` with the `STENCIL_PORT` in its env, and to get it back when the stencil config is evaluated.

We still pass `targetPort` so that when `netlify-cli` wait for the port of the framework to be open, it waits on the good one.

## Testing

Current FTs are enough, tho for some obscure reason, it was working on Linux. (like, the expected behaviour from our perspective was OK, the fact that it worked in Netlify is pretty nebulous tho).