### PR TITLE
test(e2e): restore access token for teardown job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -252,7 +252,6 @@ jobs:
         run: npm i -g npm@8.4.1
       - run: npm ci
       - name: Decrypt config
-        working-directory: packages/cli-e2e
         run: echo ${{needs.e2e-setup-login.outputs.cliConfigJson}} | base64 --decode | gpg --quiet --batch --yes --decrypt --passphrase="${{ secrets.E2E_TOKEN_PASSPHRASE }}" --output decrypted
       - name: Delete test org
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -225,7 +225,7 @@ jobs:
   e2e-teardown:
     name: End-to-end teardown
     if: ${{ always() }}
-    needs: e2e
+    needs: [e2e, e2e-setup-login]
     runs-on: ubuntu-latest
     env:
       # Platform environment to log into for the e2e tests.
@@ -240,6 +240,7 @@ jobs:
       ORG_ID: ${{ secrets.ORG_ID }}
       # ID of the test run to identify resources to teardown.
       TEST_RUN_ID: '${{ github.sha }}-${{ github.run_attempt }}g'
+      CLI_CONFIG_JSON: ${{needs.e2e-setup-login.outputs.cliConfigJson}}
     steps:
       - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # renovate: tag=v2
       - uses: actions/setup-node@9ced9a43a244f3ac94f13bfd896db8c8f30da67a # tag=v3
@@ -250,6 +251,9 @@ jobs:
         # TODO CDX-815: https://github.com/npm/cli/issues/4518
         run: npm i -g npm@8.4.1
       - run: npm ci
+      - name: Decrypt config
+        working-directory: packages/cli-e2e
+        run: echo ${{needs.e2e-setup-login.outputs.cliConfigJson}} | base64 --decode | gpg --quiet --batch --yes --decrypt --passphrase="${{ secrets.E2E_TOKEN_PASSPHRASE }}" --output decrypted
       - name: Delete test org
         env:
           DISPLAY: ':1'

--- a/packages/cli-e2e/cleaning.ts
+++ b/packages/cli-e2e/cleaning.ts
@@ -1,20 +1,5 @@
-import {mkdirSync} from 'fs';
-import {launch as launchChrome} from 'chrome-launcher';
-import {connectToChromeBrowser, SCREENSHOTS_PATH} from './utils/browser';
-import {loginWithOffice} from './utils/login';
-import {getPlatformHost} from './utils/platform';
-import waitOn from 'wait-on';
 import 'dotenv/config';
-import {ProcessManager} from './utils/processManager';
+import {restoreCliConfig} from './setup/utils';
 (async () => {
-  mkdirSync(SCREENSHOTS_PATH, {recursive: true});
-  global.processManager = new ProcessManager();
-  process.env.PLATFORM_ENV = process.env.PLATFORM_ENV?.toLowerCase() || '';
-  process.env.PLATFORM_HOST = getPlatformHost(process.env.PLATFORM_ENV);
-  const chrome = await launchChrome({port: 9222, userDataDir: false});
-  await waitOn({resources: ['tcp:9222']});
-  const browser = await connectToChromeBrowser();
-  await loginWithOffice(browser);
-  await chrome.kill();
-  await global.processManager.killAllProcesses();
+  restoreCliConfig();
 })();

--- a/packages/cli-e2e/setup/ci.ts
+++ b/packages/cli-e2e/setup/ci.ts
@@ -1,10 +1,13 @@
-import {copyFileSync, mkdirSync} from 'fs';
+import {mkdirSync} from 'fs';
 import {SCREENSHOTS_PATH} from '../utils/browser';
-import {getConfigFilePath} from '../utils/cli';
 import {ProcessManager} from '../utils/processManager';
 
-import {setProcessEnv, createUiProjectDirectory, startVerdaccio} from './utils';
-import {dirname} from 'path';
+import {
+  setProcessEnv,
+  createUiProjectDirectory,
+  startVerdaccio,
+  restoreCliConfig,
+} from './utils';
 
 export default async function () {
   mkdirSync(SCREENSHOTS_PATH, {recursive: true});
@@ -15,9 +18,4 @@ export default async function () {
   global.processManager = new ProcessManager();
   await startVerdaccio();
   restoreCliConfig();
-}
-
-async function restoreCliConfig() {
-  mkdirSync(dirname(getConfigFilePath()), {recursive: true});
-  copyFileSync('decrypted', getConfigFilePath());
 }

--- a/packages/cli-e2e/setup/utils.ts
+++ b/packages/cli-e2e/setup/utils.ts
@@ -1,4 +1,4 @@
-import {mkdirSync} from 'fs';
+import {mkdirSync, copyFileSync} from 'fs';
 import {dirSync as tmpDirSync} from 'tmp';
 import {randomBytes} from 'crypto';
 import {launch as launchChrome} from 'chrome-launcher';
@@ -6,14 +6,14 @@ import type {Browser} from 'puppeteer';
 import {captureScreenshots, connectToChromeBrowser} from '../utils/browser';
 import {clearAccessTokenFromConfig, loginWithOffice} from '../utils/login';
 import {getPlatformHost} from '../utils/platform';
-import {getConfig as getCliConfig} from '../utils/cli';
+import {getConfig as getCliConfig, getConfigFilePath} from '../utils/cli';
 import waitOn from 'wait-on';
 import 'dotenv/config';
 import {Terminal} from '../utils/terminal/terminal';
 import {join, resolve} from 'path';
 import {npm} from '../utils/npm';
 import {MITM_BIN_NAME, resolveBinary} from '../utils/mitmproxy';
-import {parse} from 'path';
+import {parse, dirname} from 'path';
 
 async function clearChromeBrowsingData(browser: Browser) {
   const pages = await browser.pages();
@@ -129,4 +129,9 @@ export function ensureMitmProxyInstalled(): void | never {
   } catch (error) {
     throw 'mitmdump not found in Path. Please install mitmproxy and add its binaries to your path';
   }
+}
+
+export function restoreCliConfig() {
+  mkdirSync(dirname(getConfigFilePath()), {recursive: true});
+  copyFileSync('decrypted', getConfigFilePath());
 }


### PR DESCRIPTION
<!-- For Coveo Employees only. Fill this section.

CDX-871

-->

## Proposed changes

Use the mechanics used to 'log once and carry on' in the e2e-setup-login and the e2e jobs for the e2e teardown.
It's quicker than connecting to chrome.

## Testing

CI/E2E
