### PR TITLE
test(e2e): increase #attempt for chrome launch

### DIFF
--- a/packages/cli-e2e/__tests__/auth.specs.ci.ts
+++ b/packages/cli-e2e/__tests__/auth.specs.ci.ts
@@ -23,11 +23,12 @@ describe('auth', () => {
       chrome = await launchChrome({
         port: 9222,
         userDataDir: false,
+        maxConnectionRetries: 240, //equivalent to 2 minutes with the default pollrate of 500ms
       });
 
       browser = await connectToChromeBrowser();
       processManager = new ProcessManager();
-    }, 3 * 60e3);
+    }, 5 * 60e3);
 
     afterAll(async () => {
       await chrome.kill();


### PR DESCRIPTION
https://coveord.atlassian.net/browse/CDX-821

<!-- For Coveo Employees only. Fill this section.

CDX-821

-->

## Proposed changes

Increase the number of times `chrome-launcher` will try to connect to tcp:9222 before giving up. Pollrate is kept at half a second, 'cause it's localhost:9222, ain't like localhost is gonna throttle itself.

This should reduce the number of
`connect ECONNREFUSED 127.0.0.1:9222`