### PR TITLE
chore(cleaning): login as fallback

### DIFF
--- a/packages/cli-e2e/cleaning.ts
+++ b/packages/cli-e2e/cleaning.ts
@@ -1,5 +1,26 @@
 import 'dotenv/config';
+
+import {mkdirSync, statSync} from 'fs';
+import {launch as launchChrome} from 'chrome-launcher';
+import {connectToChromeBrowser, SCREENSHOTS_PATH} from './utils/browser';
+import {loginWithOffice} from './utils/login';
+import {getPlatformHost} from './utils/platform';
+import waitOn from 'wait-on';
+import {ProcessManager} from './utils/processManager';
 import {restoreCliConfig} from './setup/utils';
 (async () => {
-  restoreCliConfig();
+  if (!statSync('decrypted')) {
+    restoreCliConfig();
+  } else {
+    mkdirSync(SCREENSHOTS_PATH, {recursive: true});
+    global.processManager = new ProcessManager();
+    process.env.PLATFORM_ENV = process.env.PLATFORM_ENV?.toLowerCase() || '';
+    process.env.PLATFORM_HOST = getPlatformHost(process.env.PLATFORM_ENV);
+    const chrome = await launchChrome({port: 9222, userDataDir: false});
+    await waitOn({resources: ['tcp:9222']});
+    const browser = await connectToChromeBrowser();
+    await loginWithOffice(browser);
+    await chrome.kill();
+    await global.processManager.killAllProcesses();
+  }
 })();


### PR DESCRIPTION
<!-- For Coveo Employees only. Fill this section.

CDX-882

-->

## Proposed changes

Revert-ish of https://github.com/coveo/cli/pull/716 when `decrypted` ain't here, which is the case when running the cleaning job