### PR TITLE
chore(e2e): stabilize `mitmproxy`-dependent tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -213,7 +213,9 @@ jobs:
       - name: Tests
         if: ${{matrix.os == 'windows-latest'}}
         working-directory: packages/cli-e2e
-        run: npm run jest:ci -- ${{matrix.spec}}
+        run: |
+          $env:Path = $env:Path + ";C:\Program Files (x86)\mitmproxy\bin"
+          npm run jest:ci -- ${{matrix.spec}}
       - name: Tests
         if: ${{matrix.os == 'ubuntu-latest'}}
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -187,6 +187,11 @@ jobs:
         with:
           node-version: ${{matrix.node}}
           cache: 'npm'
+      - uses: actions/setup-python@0ebf233433c08fb9061af664d501c3f3ff0e9e20 # tag=v3
+        with:
+          cache: 'pip'
+      - name: Install Mitmproxy through pip
+        run: pip install -r packages/cli-e2e/mitmproxy/requirements.txt
       - name: Install locked NPM version.
         # TODO: Remove later, when `npm 8.5.4` is built in.
         run: npm i -g npm@^8.5.4
@@ -213,9 +218,7 @@ jobs:
       - name: Tests
         if: ${{matrix.os == 'windows-latest'}}
         working-directory: packages/cli-e2e
-        run: |
-          $env:Path = $env:Path + ";C:\Program Files (x86)\mitmproxy\bin"
-          npm run jest:ci -- ${{matrix.spec}}
+        run: npm run jest:ci -- ${{matrix.spec}}
       - name: Tests
         if: ${{matrix.os == 'ubuntu-latest'}}
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -213,9 +213,7 @@ jobs:
       - name: Tests
         if: ${{matrix.os == 'windows-latest'}}
         working-directory: packages/cli-e2e
-        run: |
-          $env:Path = $env:Path + ";C:\Program Files (x86)\mitmproxy\bin"
-          npm run jest:ci -- ${{matrix.spec}}
+        run: npm run jest:ci -- ${{matrix.spec}}
       - name: Tests
         if: ${{matrix.os == 'ubuntu-latest'}}
         env:

--- a/.github/workflows/snyk-master.yml
+++ b/.github/workflows/snyk-master.yml
@@ -13,11 +13,10 @@ jobs:
     steps:
       - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # renovate: tag=v2
       - uses: actions/setup-node@9ced9a43a244f3ac94f13bfd896db8c8f30da67a # tag=v3
-      - run: yarn global add @nrwl/cli
       - name: Prepare snyk
         run: |
           npm ci
-          yarn install --no-immutable
+          yarn install --no-immutable --ignore-scripts
       - name: Snyk Monitor
         continue-on-error: true
         if: ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/snyk-master.yml
+++ b/.github/workflows/snyk-master.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Prepare snyk
         run: |
           npm ci
-          yarn install --no-immutable --ignore-scripts
+          yarn install --no-immutable --mode=skip-build
       - name: Snyk Monitor
         continue-on-error: true
         if: ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/snyk-master.yml
+++ b/.github/workflows/snyk-master.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # renovate: tag=v2
       - uses: actions/setup-node@9ced9a43a244f3ac94f13bfd896db8c8f30da67a # tag=v3
-      - run: npm i -g @nrwl/cli
+      - run: yarn global add @nrwl/cli
       - name: Prepare snyk
         run: |
           npm ci

--- a/.github/workflows/snyk-master.yml
+++ b/.github/workflows/snyk-master.yml
@@ -13,6 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # renovate: tag=v2
       - uses: actions/setup-node@9ced9a43a244f3ac94f13bfd896db8c8f30da67a # tag=v3
+      - run: npm i -g @nrwl/cli
       - name: Prepare snyk
         run: |
           npm ci

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "prepare": "husky install",
     "commit-msg": "node ./hooks/commit-msg.js",
     "pre-commit": "lint-staged",
-    "postinstall": "patch-package",
+    "postinstall": "patch-package && nx run-many --target=postinstall --all",
     "release": "npm run nx:graph && npm run release:phase1 && npm run release:phase2 && npm run release:phase3",
     "nx:graph": "nx graph --file=topology.json",
     "release:phase1": "node --experimental-specifier-resolution=node ./scripts/releaseV2/phase1-get-new-version.mjs",

--- a/packages/cli-e2e/__tests__/orgList.specs.ts
+++ b/packages/cli-e2e/__tests__/orgList.specs.ts
@@ -17,8 +17,8 @@ describe('org:list', () => {
       const proxyProcessManager = new ProcessManager();
       processManagers.push(proxyProcessManager);
       proxyTerminal = startMitmProxy(proxyProcessManager);
-      await waitForMitmProxy(proxyTerminal);
-    });
+      await waitForMitmProxy();
+    }, 2 * 60e3);
 
     afterAll(async () => {
       await Promise.all(

--- a/packages/cli-e2e/entrypoints/ci.ps1
+++ b/packages/cli-e2e/entrypoints/ci.ps1
@@ -2,6 +2,7 @@
 # Set the default user browser on Chrome.
 # See http://kolbi.cz/blog/?p=346
 #>
+Write-Output "::group::Setup Chrome"
 $SetUserFTAPath = Resolve-Path '.\packages\cli-e2e\entrypoints\utils\SetUserFTA\SetUserFTA.exe'
 Start-Process -FilePath $SetUserFTAPath -ArgumentList ' http ChromeHTML' -PassThru | Wait-Process
 Start-Process -FilePath $SetUserFTAPath -ArgumentList ' https ChromeHTML' -PassThru | Wait-Process
@@ -15,10 +16,7 @@ npm install -g @angular/cli@13.x
 npm install -g ts-node
 Write-Output "::endgroup::"
 
-Write-Output "::group::Publishing UI templates"
+Write-Output "::group::Setup Git User"
 git config --global user.name "notgroot"
 git config --global user.email "notgroot@coveo.com"
-
-Write-Output "::group::Setup mitmproxy"
-choco.exe install mitmproxy -y
 Write-Output "::endgroup::"

--- a/packages/cli-e2e/entrypoints/ci.ps1
+++ b/packages/cli-e2e/entrypoints/ci.ps1
@@ -21,5 +21,4 @@ git config --global user.email "notgroot@coveo.com"
 
 Write-Output "::group::Setup mitmproxy"
 choco.exe install mitmproxy -y
-$env:Path = $env:Path + ";C:\Program Files (x86)\mitmproxy\bin"
 Write-Output "::endgroup::"

--- a/packages/cli-e2e/entrypoints/ci.sh
+++ b/packages/cli-e2e/entrypoints/ci.sh
@@ -2,13 +2,11 @@
 set -e
 
 echo "::group::System dependencies"
-brew install mitmproxy
 sudo apt-get update
 sudo apt-get install libssl-dev zlib1g-dev llvm libncurses5-dev libncursesw5-dev tk-dev
 echo "::endgroup::"
 
 echo "::group::Setup Chrome"
-export DISPLAY=:1
 Xvfb :1 -screen 0 1024x768x16 & sleep 1
 xdg-settings set default-web-browser google-chrome.desktop
 echo "::endgroup::"
@@ -18,5 +16,7 @@ npm install -g @angular/cli@13.x
 npm install -g ts-node
 echo "::endgroup::"
 
+echo "::group::Setup Git User"
 git config --global user.name "notgroot"
 git config --global user.email "notgroot@coveo.com"
+echo "::endgroup::"

--- a/packages/cli-e2e/mitmproxy/main.py
+++ b/packages/cli-e2e/mitmproxy/main.py
@@ -1,0 +1,3 @@
+from mitmproxy.tools.main import mitmdump
+
+mitmdump()

--- a/packages/cli-e2e/mitmproxy/requirements.txt
+++ b/packages/cli-e2e/mitmproxy/requirements.txt
@@ -1,0 +1,1 @@
+mitmproxy

--- a/packages/cli-e2e/package.json
+++ b/packages/cli-e2e/package.json
@@ -17,7 +17,7 @@
     "url": "git+https://github.com/coveo/cli.git"
   },
   "scripts": {
-    "postinstall": "pip install -r mitmproxy/requirements.txt",
+    "postinstall": "pip install -r mitmproxy/requirements.txt --user",
     "lint": "eslint .",
     "test-e2e": "npm run test:headless",
     "test:headless": "node ./entrypoints/entry.js",

--- a/packages/cli-e2e/package.json
+++ b/packages/cli-e2e/package.json
@@ -17,6 +17,7 @@
     "url": "git+https://github.com/coveo/cli.git"
   },
   "scripts": {
+    "postinstall": "pip install -r mitmproxy/requirements.txt",
     "lint": "eslint .",
     "test-e2e": "npm run test:headless",
     "test:headless": "node ./entrypoints/entry.js",

--- a/packages/cli-e2e/setup/local.ts
+++ b/packages/cli-e2e/setup/local.ts
@@ -7,7 +7,6 @@ import 'dotenv/config';
 
 import {npmLogin} from '../utils/npmLogin';
 import {
-  ensureMitmProxyInstalled,
   useCIConfigIfEnvIncomplete,
   setProcessEnv,
   createUiProjectDirectory,
@@ -18,7 +17,6 @@ import {
 
 export default async function () {
   shimNpm();
-  ensureMitmProxyInstalled();
   useCIConfigIfEnvIncomplete();
   mkdirSync(SCREENSHOTS_PATH, {recursive: true});
   setProcessEnv();

--- a/packages/cli-e2e/utils/mitmproxy.ts
+++ b/packages/cli-e2e/utils/mitmproxy.ts
@@ -19,12 +19,15 @@ export const startMitmProxy = (
   return serverTerminal;
 };
 
-export const waitForMitmProxy = () => waitOn({resources: ['tcp:8080']});
+const mitmProxyCertPath = resolve(
+  homedir(),
+  '.mitmproxy',
+  'mitmproxy-ca-cert.pem'
+);
+
+export const waitForMitmProxy = () =>
+  waitOn({resources: ['tcp:8080', `file:${mitmProxyCertPath}`]});
 
 export const getMitmProxyEnvCerts = () => ({
-  NODE_EXTRA_CA_CERTS: resolve(
-    homedir(),
-    '.mitmproxy',
-    'mitmproxy-ca-cert.pem'
-  ),
+  NODE_EXTRA_CA_CERTS: mitmProxyCertPath,
 });

--- a/packages/cli-e2e/utils/mitmproxy.ts
+++ b/packages/cli-e2e/utils/mitmproxy.ts
@@ -8,11 +8,10 @@ export const startMitmProxy = (
   processManager: ProcessManager,
   terminalDebugName = 'mitmproxy'
 ) => {
-  process.stdout.write(JSON.stringify(process.env));
   const mitmScript = join(__dirname, '..', 'mitmproxy', 'main.py');
   const serverTerminal = new Terminal(
     'python',
-    [mitmScript],
+    [mitmScript, '-p', '8080'],
     undefined,
     processManager,
     terminalDebugName

--- a/packages/cli-e2e/utils/mitmproxy.ts
+++ b/packages/cli-e2e/utils/mitmproxy.ts
@@ -20,6 +20,7 @@ export const startMitmProxy = (
   terminalDebugName = 'mitmproxy'
 ) => {
   const mitmPath = resolveBinary(MITM_BIN_NAME);
+  process.stdout.write(`Starting mitmproxy: ${mitmPath}\n`);
   const serverTerminal = new Terminal(
     mitmPath,
     [],

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -71,7 +71,7 @@
   "peerDependencies": {
     "@angular/cli": "^13.2.4",
     "@vue/cli": "^4.5.11 || ^5.0.0",
-    "create-react-app": "latest"
+    "create-react-app": "*"
   },
   "peerDependenciesMeta": {
     "@angular/cli": {


### PR DESCRIPTION
<!-- For Coveo Employees only. Fill this section.

CDX-885

-->

## Proposed changes

 - Use Python to start `mitmdump`, this bypasses some shenanigans that the .exe does with its embedded Python 3.10. (Or at least this is what I empirically guessed)
 - Install `mitmdump` with pip: This is nice, more caching, hence, speed.
 
## Testing

CI/FT
