### PR TITLE
chore(release): ignore `npm-shim` for snyk

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,13 +25,13 @@ jobs:
           yarn install --no-immutable --mode=skip-build
       - name: Snyk Test
         run: |
-          npx snyk monitor      --dev --yarn-workspaces --exclude="project.json"
-          npx snyk test         --dev --yarn-workspaces --exclude="project.json"
+          npx snyk monitor      --dev --yarn-workspaces --exclude="project.json,npm-shim"
+          npx snyk test         --dev --yarn-workspaces --exclude="project.json,npm-shim"
       - name: Snyk Code
         continue-on-error: true
         run: |
           mkdir -p sarifs
-          npx snyk code test    --dev --all-projects --exclude="project.json" --sarif > ./sarifs/snyk-code.sarif
+          npx snyk code test    --dev --all-projects --exclude="project.json,npm-shim" --sarif > ./sarifs/snyk-code.sarif
       - name: Upload result to GitHub Code Scanning
         uses: github/codeql-action/upload-sarif@v1
         with:


### PR DESCRIPTION
<!-- For Coveo Employees only. Fill this section.

CDX-764

-->

## Proposed changes

Snyk should not scan this package.json.
