### PR TITLE
chore(react): lock other react deps

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -57,7 +57,7 @@
       "description": "Need to migrate E2E to ESM (not easy)"
     },
     {
-      "matchPackageNames": ["react"],
+      "matchPackageNames": ["react", "react-dom"],
       "allowedVersions": "17.x",
       "description": "Need Material UI support for React 18. TODO:CDX-897"
     }

--- a/renovate.json
+++ b/renovate.json
@@ -60,6 +60,11 @@
       "matchPackageNames": ["react", "react-dom"],
       "allowedVersions": "17.x",
       "description": "Need Material UI support for React 18. TODO:CDX-897"
+    },
+    {
+      "matchPackageNames": ["@testing-library/react"],
+      "allowedVersions": "12.x",
+      "description": "Need Material UI support for React 18. TODO:CDX-897"
     }
   ],
   "rangeStrategy": "auto",


### PR DESCRIPTION
<!-- For Coveo Employees only. Fill this section.

CDX-227

-->

## Proposed changes

Other dependencies are marked as a major update because they drop support for React 17. So we locked 'em up.
