### PR TITLE
chore(cd): await when updating versions in workspaces

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,6 +55,8 @@ jobs:
         with:
           node-version: '16'
           registry-url: 'https://registry.npmjs.org'
+      # TODO: Remove later, when `npm 8.5.4` is built in.
+      - run: npm i -g npm@^8.5.4
       - name: Install dependencies
         run: npm ci
       - name: Setup credentials

--- a/scripts/releaseV2/phase2-bump-all-packages.mjs
+++ b/scripts/releaseV2/phase2-bump-all-packages.mjs
@@ -24,7 +24,7 @@ const rootFolder = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..');
   const commits = getCommits(PATH, lastTag)[0];
   const newVersion = getReleaseVersion();
 
-  updateWorkspaceDependencies();
+  await updateWorkspaceDependencies();
   npmBumpVersion(newVersion, PATH);
 
   if (isPrivatePackage()) {
@@ -46,19 +46,7 @@ const rootFolder = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..');
     await writeChangelog(PATH, changelog);
   }
 
-  // TODO: Revert spawnSync to npmPublish.
   npmPublish();
-  const publish = spawnSync(appendCmdIfWindows`npm`, ['publish'], {
-    cwd: undefined,
-  });
-  publish.stdout
-    .toString()
-    .split('\n')
-    .forEach((line) => console.log(line));
-  publish.stderr
-    .toString()
-    .split('\n')
-    .forEach((line) => console.error(line));
 })();
 
 function getReleaseVersion() {
@@ -101,7 +89,6 @@ function updateDependency(packageJson, dependency) {
     `${dependency}@latest`,
     '-E',
     ...npmInstallFlags,
-    '--no-package-lock',
   ]);
 }
 


### PR DESCRIPTION
https://coveord.atlassian.net/browse/CDX-910

<!-- For Coveo Employees only. Fill this section.

CDX-910

-->

## Proposed changes

Node was queuing up the microtask 'update workspace dependencies' but was not awaiting it, so the `npm publish` was occurring before the update was done.
