### PR TITLE
fix: add precondition check on source creation

### DIFF
--- a/packages/cli/src/commands/source/catalog/new.spec.ts
+++ b/packages/cli/src/commands/source/catalog/new.spec.ts
@@ -5,7 +5,7 @@ jest.mock('../../../lib/platform/authenticatedClient');
 
 import {test} from '@oclif/test';
 import {AuthenticatedClient} from '../../../lib/platform/authenticatedClient';
-import {SourceVisibility} from '@coveord/platform-client';
+import {SourceType, SourceVisibility} from '@coveord/platform-client';
 import {Config} from '../../../lib/config/config';
 
 const mockedConfig = jest.mocked(Config);
@@ -49,7 +49,7 @@ const doMockConfig = () => {
   mockedConfig.prototype.get = mockedConfigGet;
 };
 
-describe('source:push:new', () => {
+describe('source:catalog:new', () => {
   beforeAll(() => {
     doMockConfig();
     doMockAuthenticatedClient();
@@ -67,7 +67,7 @@ describe('source:push:new', () => {
     test
       .stdout()
       .stderr()
-      .command(['source:push:new', 'my source'])
+      .command(['source:catalog:new', 'my source'])
       .it('uses source visibility SECURED by default', () => {
         expect(spyCreate).toHaveBeenCalledWith(
           expect.objectContaining({
@@ -80,12 +80,15 @@ describe('source:push:new', () => {
     test
       .stdout()
       .stderr()
-      .command(['source:push:new', 'my source'])
+      .command(['source:catalog:new', 'my source'])
       .it('uses source visibility SECURED by default', () => {
         expect(spyCreate).toHaveBeenCalledWith(
           expect.objectContaining({
             name: 'my source',
             sourceVisibility: SourceVisibility.SECURED,
+            sourceType: SourceType.CATALOG,
+            pushEnabled: true,
+            streamEnabled: true,
           })
         );
       });
@@ -93,7 +96,7 @@ describe('source:push:new', () => {
     test
       .stdout()
       .stderr()
-      .command(['source:push:new', '-v', 'SHARED', 'my source'])
+      .command(['source:catalog:new', '-v', 'SHARED', 'my source'])
       .it('uses source visibility flag when specified', () => {
         expect(spyCreate).toHaveBeenCalledWith(
           expect.objectContaining({
@@ -116,7 +119,7 @@ describe('source:push:new', () => {
     test
       .stdout()
       .stderr()
-      .command(['source:push:new', 'my-source'])
+      .command(['source:catalog:new', 'my-source'])
       .catch(/You are not authorized to edit sources/)
       .it('should return a precondition error');
   });

--- a/packages/cli/src/commands/source/catalog/new.ts
+++ b/packages/cli/src/commands/source/catalog/new.ts
@@ -3,9 +3,11 @@ import {Command} from '@oclif/core';
 import {green} from 'chalk';
 import dedent from 'ts-dedent';
 import {
+  HasNecessaryCoveoPrivileges,
   IsAuthenticated,
   Preconditions,
 } from '../../../lib/decorators/preconditions';
+import {writeSourceContentPrivilege} from '../../../lib/decorators/preconditions/platformPrivilege';
 import {Trackable} from '../../../lib/decorators/preconditions/trackable';
 import {withSourceVisibility} from '../../../lib/flags/sourceCommonFlags';
 import {AuthenticatedClient} from '../../../lib/platform/authenticatedClient';
@@ -27,7 +29,10 @@ export default class SourceCataloghNew extends Command {
   ];
 
   @Trackable()
-  @Preconditions(IsAuthenticated())
+  @Preconditions(
+    IsAuthenticated(),
+    HasNecessaryCoveoPrivileges(writeSourceContentPrivilege)
+  )
   public async run() {
     const {flags, args} = await this.parse(SourceCataloghNew);
     const authenticatedClient = new AuthenticatedClient();
@@ -53,10 +58,6 @@ export default class SourceCataloghNew extends Command {
 
   @Trackable()
   public async catch(err?: Error & {exitCode?: number}) {
-    console.log('*********************');
-    console.log(err);
-    console.log('*********************');
-
     throw err;
   }
 }

--- a/packages/cli/src/commands/source/push/new.ts
+++ b/packages/cli/src/commands/source/push/new.ts
@@ -3,9 +3,11 @@ import {Command} from '@oclif/core';
 import {green} from 'chalk';
 import dedent from 'ts-dedent';
 import {
+  HasNecessaryCoveoPrivileges,
   IsAuthenticated,
   Preconditions,
 } from '../../../lib/decorators/preconditions';
+import {writeSourceContentPrivilege} from '../../../lib/decorators/preconditions/platformPrivilege';
 import {Trackable} from '../../../lib/decorators/preconditions/trackable';
 import {withSourceVisibility} from '../../../lib/flags/sourceCommonFlags';
 import {AuthenticatedClient} from '../../../lib/platform/authenticatedClient';
@@ -27,7 +29,10 @@ export default class SourcePushNew extends Command {
   ];
 
   @Trackable()
-  @Preconditions(IsAuthenticated())
+  @Preconditions(
+    IsAuthenticated(),
+    HasNecessaryCoveoPrivileges(writeSourceContentPrivilege)
+  )
   public async run() {
     const {flags, args} = await this.parse(SourcePushNew);
     const authenticatedClient = new AuthenticatedClient();


### PR DESCRIPTION
<!-- For Coveo Employees only. Fill this section.

CDX-XXX

-->

## Proposed changes

Check if the use has privileges to create a source (Push or Catalog) before sending the request to Coveo



<!--
    Remove this section if the PR does not include any breaking change

    If your changes includes some breaking changes in the code, thoroughly explains:
        - What are the breaking changes programmatically speaking.
        - What is the impact on the end-user (e.g. user cannot do X anymore).
        - What motivates those changes.
-->

## Testing

- [ ] Unit Tests:
<!-- Did you write unit tests for your feature? If not, explains why?  -->
- [ ] Functionnal Tests:
<!-- Did you write functionnal tests for your feature? If not, explains why?  -->
- [ ] Manual Tests:
<!-- How did you test your changeset?  -->
