### PR TITLE
ci(cron): run only on weekdays 

### DIFF
--- a/.github/workflows/daily-e2e.yml
+++ b/.github/workflows/daily-e2e.yml
@@ -1,7 +1,7 @@
 name: Daily test
 on:
   schedule:
-    - cron: '0 0 * * *'
+    - cron: '0 0 * * 1-5'
 
 env:
   E2E_USE_NPM_REGISTRY: true

--- a/.github/workflows/snyk-master.yml
+++ b/.github/workflows/snyk-master.yml
@@ -1,7 +1,7 @@
 name: Snyk
 on:
   schedule:
-    - cron: '0 0 * * *'
+    - cron: '0 0 * * 1-5'
   push:
     branches:
       - master


### PR DESCRIPTION
<!-- For Coveo Employees only. Fill this section.

CDX-940

-->

## Proposed changes

Run the scheduled job only on weekdays, because some resources ain't available on Sunday