### PR TITLE
ci(cleaning): add steps timeout

### DIFF
--- a/.github/workflows/daily-e2e.yml
+++ b/.github/workflows/daily-e2e.yml
@@ -1,7 +1,7 @@
 name: Daily test
 on:
   schedule:
-    - cron: '0 0 * * 1-5'
+    - cron: '0 23 * * 1-5'
 
 env:
   E2E_USE_NPM_REGISTRY: true

--- a/.github/workflows/daily-e2e.yml
+++ b/.github/workflows/daily-e2e.yml
@@ -109,7 +109,7 @@ jobs:
       # pulls all tags (needed for computing the next version)
       - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
       - name: Checkout last tag
-        run: git checkout $(git describe --abbrev=0)
+        run: git checkout $(git describe --abbrev=0 --tags)
       - uses: actions/setup-node@56337c425554a6be30cdef71bf441f15be286854 # tag=v3
         with:
           node-version: ${{matrix.node}}
@@ -177,7 +177,7 @@ jobs:
       # pulls all tags (needed for computing the next version)
       - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
       - name: Checkout last tag
-        run: git checkout $(git describe --abbrev=0)
+        run: git checkout $(git describe --abbrev=0 --tags)
       - uses: actions/setup-node@56337c425554a6be30cdef71bf441f15be286854 # tag=v3
         with:
           node-version: ${{matrix.node}}

--- a/.github/workflows/daily-e2e.yml
+++ b/.github/workflows/daily-e2e.yml
@@ -10,6 +10,7 @@ jobs:
   e2e-setup-login:
     name: End-to-end login
     runs-on: 'ubuntu-latest'
+    timeout-minutes: 30
     outputs:
       cliConfigJson: ${{ steps.setup.outputs.cliConfigJson}}
     env:
@@ -60,6 +61,7 @@ jobs:
     name: End-to-end tests
     runs-on: ${{matrix.os}}
     needs: [e2e-setup-login]
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
@@ -152,6 +154,7 @@ jobs:
     if: ${{ always() }}
     needs: [e2e, e2e-setup-login]
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     env:
       # Platform environment to log into for the e2e tests.
       PLATFORM_ENV: 'qa'
@@ -199,6 +202,7 @@ jobs:
         run: node ./scripts/cleaning/delete-api-keys.js
   e2e-report:
     name: End-to-end status reporter
+    timeout-minutes: 30
     if: ${{ always() }}
     needs: e2e
     runs-on: ubuntu-latest

--- a/.github/workflows/delete-resources.yml
+++ b/.github/workflows/delete-resources.yml
@@ -23,11 +23,11 @@ jobs:
           cache: 'npm'
       - run: npm ci
       - name: Delete test API keys
-        timeout-minutes: 5
+        timeout-minutes: 30
         if: always()
         run: node ./scripts/cleaning/delete-api-keys.js --olderThan 1d
       - name: Delete test orgs
-        timeout-minutes: 5
+        timeout-minutes: 30
         if: always()
         run: |
           Xvfb :1 -screen 0 1024x768x16 & sleep 1

--- a/.github/workflows/delete-resources.yml
+++ b/.github/workflows/delete-resources.yml
@@ -36,6 +36,11 @@ jobs:
           node ./scripts/cleaning/delete-orgs.js     --olderThan 1d
         env:
           DISPLAY: ':1'
+      - uses: actions/upload-artifact@6673cd052c4cd6fcf4b4e6e60ea986c889389535 # tag=v3
+        if: always()
+        with:
+          name: cleaning-artifacts
+          path: ./packages/cli-e2e/artifacts
       - name: Notify in case of failure
         if: failure()
         run: curl --request POST --url ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/delete-resources.yml
+++ b/.github/workflows/delete-resources.yml
@@ -23,11 +23,11 @@ jobs:
           cache: 'npm'
       - run: npm ci
       - name: Delete test API keys
-        timeout-minutes: 30
+        timeout-minutes: 5
         if: always()
         run: node ./scripts/cleaning/delete-api-keys.js --olderThan 1d
       - name: Delete test orgs
-        timeout-minutes: 30
+        timeout-minutes: 5
         if: always()
         run: |
           Xvfb :1 -screen 0 1024x768x16 & sleep 1

--- a/.github/workflows/delete-resources.yml
+++ b/.github/workflows/delete-resources.yml
@@ -23,9 +23,11 @@ jobs:
           cache: 'npm'
       - run: npm ci
       - name: Delete test API keys
+        timeout-minutes: 30
         if: always()
         run: node ./scripts/cleaning/delete-api-keys.js --olderThan 1d
       - name: Delete test orgs
+        timeout-minutes: 30
         if: always()
         run: |
           Xvfb :1 -screen 0 1024x768x16 & sleep 1

--- a/packages/cli-e2e/cleaning.ts
+++ b/packages/cli-e2e/cleaning.ts
@@ -7,11 +7,12 @@ import {loginWithOffice} from './utils/login';
 import {getPlatformHost} from './utils/platform';
 import waitOn from 'wait-on';
 import {ProcessManager} from './utils/processManager';
-import {restoreCliConfig} from './setup/utils';
+import {restoreCliConfig, setCliExecPath} from './setup/utils';
 (async () => {
   if (statSync('decrypted', {throwIfNoEntry: false})) {
     restoreCliConfig();
   } else {
+    setCliExecPath();
     mkdirSync(SCREENSHOTS_PATH, {recursive: true});
     global.processManager = new ProcessManager();
     process.env.PLATFORM_ENV = process.env.PLATFORM_ENV?.toLowerCase() || '';

--- a/packages/cli-e2e/setup/utils.ts
+++ b/packages/cli-e2e/setup/utils.ts
@@ -72,6 +72,10 @@ export function setProcessEnv() {
     process.env.TEST_RUN_ID ?? `id${randomBytes(16).toString('hex')}g`;
   process.env.PLATFORM_ENV = process.env.PLATFORM_ENV?.toLowerCase() || '';
   process.env.PLATFORM_HOST = getPlatformHost(process.env.PLATFORM_ENV);
+  setCliExecPath();
+}
+
+export function setCliExecPath() {
   process.env.CLI_EXEC_PATH = resolve(__dirname, '../../cli/bin/dev');
 }
 


### PR DESCRIPTION
<!-- For Coveo Employees only. Fill this section.

CDX-945

-->

## Proposed changes

- Ensures that the deletion operations are complete in a reasonable time. Otherwise, the whole runner might timeout and we would not receive the notification.
- Do the same for the daily tests while at it.
- Fixed the missing CLI path for the delete resources workflow (oupsie)
- Shifted the CRON for the tests 1h earlier to prevent potential collision between the 2 workflows. (i.e. delete could have deleted resources that daily just created, causing the later to fail)