### PR TITLE
fix(precond): use new flag name

### DIFF
--- a/packages/cli/src/commands/org/resources/pull.ts
+++ b/packages/cli/src/commands/org/resources/pull.ts
@@ -222,7 +222,7 @@ export default class Pull extends Command {
   public async getFlags() {
     const {flags} = await this.parse(Pull);
     if (flags.model) {
-      return {...flags, target: flags.model.orgId};
+      return {...flags, organization: flags.model.orgId};
     }
     return flags;
   }

--- a/packages/cli/src/lib/decorators/preconditions/apiKeyPrivilege.spec.ts
+++ b/packages/cli/src/lib/decorators/preconditions/apiKeyPrivilege.spec.ts
@@ -96,7 +96,7 @@ describe('apiKeyPrivilege', () => {
     fancyIt()('should use it', async () => {
       const fakeCommand = getFakeCommand();
       const getSpy = jest.fn(() => ({
-        target: 'someTarget',
+        organization: 'someTarget',
       }));
       Object.defineProperty(fakeCommand, 'getFlags', {
         value: getSpy,

--- a/packages/cli/src/lib/decorators/preconditions/apiKeyPrivilege.ts
+++ b/packages/cli/src/lib/decorators/preconditions/apiKeyPrivilege.ts
@@ -25,7 +25,7 @@ export function HasNecessaryCoveoPrivileges(
     const authenticatedClient = new AuthenticatedClient();
     const client = await authenticatedClient.getClient();
     const {organization: target, anonymous} = await getConfiguration();
-    const organization = flags.target || target;
+    const organization = flags.organization || target;
 
     const promises = privileges.flatMap((privilege) =>
       privilege.models.map(async (model) => {


### PR DESCRIPTION
https://coveord.atlassian.net/browse/CDX-950

<!-- For Coveo Employees only. Fill this section.

CDX-950

-->

## Proposed changes

#773 renamed target to the organization, this was not reflected here.
Still checking for why this was not flagged up on CI, another PR will be open to addressing the false ✔️.

## Testing

- [x] Unit Tests: adapted
<!-- Did you write unit tests for your feature? If not, explains why?  -->
- [x] Functional Tests: failing on master currently, this pr fix that.
