### PR TITLE
feat: introduce the files flag

### DIFF
--- a/packages/cli/src/commands/source/push/add.spec.ts
+++ b/packages/cli/src/commands/source/push/add.spec.ts
@@ -121,14 +121,14 @@ describe('source:push:add', () => {
       .stdout()
       .stderr()
       .command(['source:push:add', 'mysource'])
-      .catch(/You must minimally set the `file` or the `folder` flag/)
+      .catch(/You must set the `files` flag/)
       .it('throws when no flags are specified');
 
     test
       .stdout()
       .stderr()
       .command(['source:push:add', 'mysource', '-f', 'foo', '-d', 'bar'])
-      .catch(/--folder= cannot also be provided when using --file=/)
+      .catch(/--files= cannot also be provided when using --folder=/)
       .it('throws when incompatible flags for file and folder are passed');
 
     test
@@ -216,6 +216,39 @@ describe('source:push:add', () => {
           expect(ctx.stdout).toContain('Status code: 202 👌');
         }
       );
+
+    test
+      .stdout()
+      .stderr()
+      .command([
+        'source:push:add',
+        'mysource',
+        '-f',
+        join(pathToStub, 'jsondocuments'),
+        join(pathToStub, 'jsondocuments', 'batman.json'),
+      ])
+      .it(
+        'should output feedback message when uploading a file and a directory',
+        (ctx) => {
+          expect(ctx.stdout).toContain(
+            'Success: 2 documents accepted by the Push API from'
+          );
+          expect(ctx.stdout).toContain('Status code: 202 👌');
+        }
+      );
+
+    test
+      .stdout()
+      .stderr()
+      .command([
+        'source:push:add',
+        'mysource',
+        '-d',
+        join(pathToStub, 'jsondocuments'),
+      ])
+      .it('should show deprecated flag warning', (ctx) => {
+        expect(ctx.stdout).toContain('Use the `files` flag instead');
+      });
 
     test
       .stdout()


### PR DESCRIPTION
https://coveord.atlassian.net/browse/CDX-952

<!-- For Coveo Employees only. Fill this section.

CDX-XXX

-->

## Proposed changes

Only use one flag for both JSON files and directories. 
This is not a breaking change since I kept the support for legacy flags even tho they are hidden.

- [ ] Merge before #749

<!--
    Remove this section if the PR does not include any breaking change

    If your changes includes some breaking changes in the code, thoroughly explains:
        - What are the breaking changes programmatically speaking.
        - What is the impact on the end-user (e.g. user cannot do X anymore).
        - What motivates those changes.
-->

## Testing

- [ ] Unit Tests:
<!-- Did you write unit tests for your feature? If not, explains why?  -->
- [ ] Functionnal Tests:
<!-- Did you write functionnal tests for your feature? If not, explains why?  -->
- [ ] Manual Tests:
<!-- How did you test your changeset?  -->
