### PR TITLE
fix(vault): ensure prompt is readable

### DIFF
--- a/packages/cli/src/lib/snapshot/__snapshots__/vaultHandler.spec.ts.snap
+++ b/packages/cli/src/lib/snapshot/__snapshots__/vaultHandler.spec.ts.snap
@@ -19,3 +19,16 @@ Fill all required vault entries to proceed.",
   ],
 }
 `;
+
+exports[`VaultHandler when the vault entries are valid #createEntries should prompt instructions for the user 1`] = `
+Array [
+  "",
+  Object {
+    "prompt": "
+[7mPress any key to continue. Press q to abort[27m
+",
+    "required": false,
+    "type": "single",
+  },
+]
+`;

--- a/packages/cli/src/lib/snapshot/vaultHandler.spec.ts
+++ b/packages/cli/src/lib/snapshot/vaultHandler.spec.ts
@@ -90,6 +90,11 @@ describe('VaultHandler', () => {
       );
     });
 
+    it('#createEntries should prompt instructions for the user', () => {
+      expect(mockedPrompt).toBeCalledTimes(1);
+      expect(mockedPrompt.mock.lastCall).toMatchSnapshot();
+    });
+
     it('#createEntries should send as many requests as there is entries to create', () => {
       expect(mockedCreate).toHaveBeenCalledTimes(2);
     });

--- a/packages/cli/src/lib/snapshot/vaultHandler.ts
+++ b/packages/cli/src/lib/snapshot/vaultHandler.ts
@@ -8,7 +8,7 @@ import {readJsonSync, rmSync, writeJsonSync} from 'fs-extra';
 import open from 'open';
 import {join} from 'path';
 import {cwd} from 'process';
-import {green, bgWhite} from 'chalk';
+import {green, inverse} from 'chalk';
 import {
   InvalidVaultEntryError,
   InvalidVaultFileError,
@@ -45,7 +45,7 @@ export class VaultHandler {
       const key = await CliUx.ux.prompt('', {
         type: 'single',
         required: false,
-        prompt: `\n${bgWhite('Press any key to continue. Press q to abort')}\n`,
+        prompt: `\n${inverse('Press any key to continue. Press q to abort')}\n`,
       });
       if (key === 'q') {
         throw new ProcessAbort();


### PR DESCRIPTION
<!-- For Coveo Employees only. Fill this section.

CDX-991

-->

## Proposed changes

Use chalk inverse to reverse bg and fg instead of just setting bg to white. Result:

![image](https://user-images.githubusercontent.com/12366410/169301950-ca551a41-a867-4c33-a205-f7c6875123de.png)

## Testing

- [x] Unit Tests: yea
<!-- Did you write unit tests for your feature? If not, explains why?  -->
- [ ] Functionnal Tests: nay
<!-- Did you write functionnal tests for your feature? If not, explains why?  -->
- [x] Manual Tests: see pic
<!-- How did you test your changeset?  -->
