### PR TITLE
fix: handle rowid fields in org:search:dump

### DIFF
--- a/packages/cli/src/commands/org/search/dump.spec.ts
+++ b/packages/cli/src/commands/org/search/dump.spec.ts
@@ -175,6 +175,32 @@ describe('org:search:dump', () => {
 
   test
     .do(() => {
+      mockReturnNumberOfResults(0);
+    })
+    .stdout()
+    .stderr()
+    .command([
+      'org:search:dump',
+      '-s',
+      'the_source',
+      '-x',
+      'rowid',
+      '-x',
+      'sysrowid',
+      '-x',
+      'foo',
+    ])
+    .it('should not exclude rowId fields', () =>
+      expect(mockSearch).toHaveBeenCalledWith(
+        expect.objectContaining({
+          numberOfResults: 1000,
+          fieldsToExclude: ['foo'],
+        })
+      )
+    );
+
+  test
+    .do(() => {
       mockReturnNumberOfResults(1234);
       mockReturnNumberOfResults(234);
     })

--- a/packages/cli/src/commands/org/search/dump.spec.ts
+++ b/packages/cli/src/commands/org/search/dump.spec.ts
@@ -1,22 +1,32 @@
 jest.mock('@coveord/platform-client');
 jest.mock('fs-extra');
+jest.mock('json2csv');
 jest.mock('../../../lib/platform/authenticatedClient');
 jest.mock('../../../lib/config/config');
 jest.mock('../../../hooks/analytics/analytics');
 jest.mock('../../../hooks/prerun/prerun');
 
 import {test} from '@oclif/test';
+import {Parser} from 'json2csv';
 import {Config} from '../../../lib/config/config';
 import {AuthenticatedClient} from '../../../lib/platform/authenticatedClient';
 const mockedAuthenticatedClient = jest.mocked(AuthenticatedClient);
 const mockedConfig = jest.mocked(Config);
 const mockSearch = jest.fn();
+const mockedParser = jest.mocked(Parser);
 
 mockedAuthenticatedClient.mockImplementation(
   () =>
     ({
       getClient: () => Promise.resolve({search: {query: mockSearch}}),
     } as unknown as AuthenticatedClient)
+);
+
+mockedParser.mockImplementation(
+  () =>
+    ({
+      parse: jest.fn(),
+    } as unknown as Parser<unknown>)
 );
 
 mockedConfig.mockImplementation(
@@ -197,6 +207,32 @@ describe('org:search:dump', () => {
           fieldsToExclude: ['foo'],
         })
       )
+    );
+
+  test
+    .do(() => {
+      mockReturnNumberOfResults(10);
+    })
+    .stdout()
+    .stderr()
+    .command(['org:search:dump', '-s', 'the_source'])
+    .it('should include rowid field in output', () =>
+      expect(mockedParser).toHaveBeenCalledWith({
+        fields: expect.arrayContaining(['rowid']),
+      })
+    );
+
+  test
+    .do(() => {
+      mockReturnNumberOfResults(10);
+    })
+    .stdout()
+    .stderr()
+    .command(['org:search:dump', '-s', 'the_source', '-x', 'rowid'])
+    .it('should exclude rowid field from output', () =>
+      expect(mockedParser).toHaveBeenCalledWith({
+        fields: expect.not.arrayContaining(['rowid']),
+      })
     );
 
   test

--- a/packages/cli/src/commands/org/search/dump.ts
+++ b/packages/cli/src/commands/org/search/dump.ts
@@ -121,11 +121,11 @@ export default class Dump extends Command {
     while (allResults.length) {
       const chunk = allResults.splice(0, flags.chunkSize);
       const data = chunk.map((r) => r.raw);
-      const fieldsToRender = without(
+      const fields = without(
         Object.keys(chunk[0].raw),
-        flags.fieldsToExclude
+        flags.fieldsToExclude || []
       );
-      const parser = new Parser({fields: fieldsToRender});
+      const parser = new Parser({fields});
       await writeFile(
         `${flags.destination}/${flags.name}${
           currentChunk > 0 ? `_${currentChunk + 1}` : ''

--- a/packages/cli/src/commands/org/search/dump.ts
+++ b/packages/cli/src/commands/org/search/dump.ts
@@ -11,6 +11,7 @@ import {Parser} from 'json2csv';
 // eslint-disable-next-line node/no-extraneous-import
 import {SingleBar} from 'cli-progress';
 import {Trackable} from '../../../lib/decorators/preconditions/trackable';
+import {bold} from 'chalk';
 
 interface SearchResult {
   raw: {rowid: string};
@@ -115,7 +116,15 @@ export default class Dump extends Command {
   }
 
   private ensureMandatoryFields(fields: string[]) {
-    return fields.filter((field) => !Dump.mandatoryFields.includes(field));
+    return fields.filter((field) => {
+      const includeMandatoryField = Dump.mandatoryFields.includes(field);
+      if (includeMandatoryField) {
+        CliUx.ux.warn(
+          `Cannot exclude required field ${bold(field)} from the data dump`
+        );
+      }
+      return !includeMandatoryField;
+    });
   }
 
   private async writeChunks(allResults: SearchResult[]) {

--- a/packages/cli/src/lib/utils/list.spec.ts
+++ b/packages/cli/src/lib/utils/list.spec.ts
@@ -1,0 +1,29 @@
+import {without} from './list';
+
+describe('listUtils', () => {
+  describe('#without', () => {
+    const array = ['foo', 'bar', 'baz'];
+    it('should exclude one value from array', () => {
+      const result = without(array, ['bar']);
+      expect(result).toEqual(['foo', 'baz']);
+    });
+
+    it('should exclude multiple values from array', () => {
+      const valuesToExclude = ['bar', 'baz'];
+      const result = without(array, valuesToExclude);
+      expect(result).toEqual(['foo']);
+    });
+
+    it('should exclude no values from array', () => {
+      const result = without(array, []);
+      expect(result).toEqual(['foo', 'bar', 'baz']);
+    });
+
+    describe('when values to exclude are not part of the array', () => {
+      it('should return the initial array', () => {
+        const result = without(array, ['dummy']);
+        expect(result).toEqual(['foo', 'bar', 'baz']);
+      });
+    });
+  });
+});

--- a/packages/cli/src/lib/utils/list.ts
+++ b/packages/cli/src/lib/utils/list.ts
@@ -1,0 +1,3 @@
+export function without<T>(array: T[], values: T[]): T[] {
+  return array.filter((field) => !values.includes(field));
+}


### PR DESCRIPTION
## Proposed changes

Never exclude `rowid` and `sysrowid` fields from the search query.
They will still be excluded from CSV output if the user adds them to the command.
 

<!--
    Remove this section if the PR does not include any breaking change

    If your changes includes some breaking changes in the code, thoroughly explains:
        - What are the breaking changes programmatically speaking.
        - What is the impact on the end-user (e.g. user cannot do X anymore).
        - What motivates those changes.
-->

## Testing

- [x] Unit Tests:
<!-- Did you write unit tests for your feature? If not, explains why?  -->
- [ ] Functionnal Tests:
<!-- Did you write functionnal tests for your feature? If not, explains why?  -->
- [x] Manual Tests:
