### PR TITLE
try automatic catalog configuration detection

### DIFF
--- a/packages/cli/src/commands/commerce/catalog/create.ts
+++ b/packages/cli/src/commands/commerce/catalog/create.ts
@@ -1,6 +1,5 @@
 import {bold} from 'chalk';
 import {
-  CreateCatalogConfigurationModel,
   CatalogConfigurationModel,
   PlatformClient,
   SourceType,

--- a/packages/cli/src/lib/catalog/detect.ts
+++ b/packages/cli/src/lib/catalog/detect.ts
@@ -1,0 +1,227 @@
+import {
+  DocumentBuilder,
+  Metadata,
+  MetadataValue,
+  parseAndGetDocumentBuilderFromJSONDocument,
+} from '@coveo/push-api-client';
+import {PathLike} from 'fs';
+import {containsDuplicates} from '../utils/list';
+import {setAreEqual} from '../utils/set';
+import {PartialCatalogConfigurationModel} from './interfaces';
+
+type MapValue = string | number | null;
+type MetadataValueMap = Map<string, MapValue[]>;
+
+interface CatalogFieldStrutureValue {
+  possibleIdFields: string[];
+  objectType: MetadataValue;
+}
+interface CatalogFieldStruture {
+  product: CatalogFieldStrutureValue;
+  variant?: CatalogFieldStrutureValue;
+  // TODO: implement availabilities
+}
+
+export async function getCatalogPartialConfiguration(
+  filePaths: PathLike[]
+): Promise<PartialCatalogConfigurationModel> {
+  const structure = await getCatalogFieldStructure(filePaths);
+  return convertToCatalogModel(structure);
+}
+
+async function getCatalogFieldStructure(
+  filePaths: PathLike[]
+): Promise<CatalogFieldStruture> {
+  const maps = await getMaps(filePaths);
+
+  switch (maps.size) {
+    case 1:
+      const [firstMapValue] = maps.values();
+      return get1ChannelCatalogFieldStructure(firstMapValue);
+    case 2:
+      return get2ChannelsCatalogFieldStructure(maps);
+    case 3:
+      // TODO: similar to 2 channel catalog structure but need to create a matrix for availabilities and compare with variant matrix
+      throw new Error('Not implemented yet');
+
+    default:
+      // Human intervention needed as the complexity significantly increases with the number of object distincts types
+      throw new Error('Unable to compute catalog configuration');
+  }
+}
+
+function convertToCatalogModel(
+  structure: CatalogFieldStruture
+): PartialCatalogConfigurationModel {
+  const {product, variant} = structure;
+  if (
+    !catalogChannelHasSingleMatch(product) ||
+    !catalogChannelHasSingleMatch(variant)
+    // TODO: should also check availabilities
+  ) {
+    throw new Error('Multiple field matches');
+  } else {
+    return {
+      product: {
+        idField: product.possibleIdFields[0],
+        objectType: product.objectType.toString(),
+      },
+      variant: {
+        idField: variant.possibleIdFields[0],
+        objectType: variant.objectType.toString(),
+      },
+    };
+  }
+}
+
+async function get1ChannelCatalogFieldStructure(
+  map: MetadataValueMap
+): Promise<CatalogFieldStruture> {
+  const possibleIdFields: string[] = findUniqueMetadataKeysInMap(map);
+  const [objectType] = map.keys();
+
+  return {
+    product: {
+      possibleIdFields,
+      objectType,
+    },
+  };
+}
+
+async function get2ChannelsCatalogFieldStructure(
+  maps: Map<MetadataValue, MetadataValueMap>
+) {
+  const uniqueMetadataKeys: string[][] = [];
+  maps.forEach((map) => {
+    uniqueMetadataKeys.push(findUniqueMetadataKeysInMap(map));
+  });
+  let objectTypes = Array.from(maps.keys());
+  let catalogIdFields = findCatalogIdFields(maps.values(), uniqueMetadataKeys);
+
+  if (catalogIdFields.productIdFields.length === 0) {
+    // Change the product / variant order and try again
+    objectTypes = objectTypes.reverse();
+    catalogIdFields = findCatalogIdFields(
+      maps.values(),
+      uniqueMetadataKeys.reverse()
+    );
+  }
+
+  return {
+    product: {
+      possibleIdFields: catalogIdFields.productIdFields,
+      objectType: objectTypes[0],
+    },
+    variant: {
+      possibleIdFields: catalogIdFields.variantIdFields,
+      objectType: objectTypes[1],
+    },
+  };
+}
+
+function sanitizeMetadataValue(value: MetadataValue): MapValue {
+  switch (typeof value) {
+    case 'number':
+      return value;
+    case 'string':
+      return value;
+    default:
+      // If metadata value is not a string or a number, there is "almost" 0 chance it can be used as an id Field.
+      // That being said, we replace that field by null so it can take less space in memory
+      return null;
+  }
+}
+
+function addToMap(map: MetadataValueMap, metadata: Metadata) {
+  for (const [key, value] of Object.entries(metadata)) {
+    let mapValue = map.get(key);
+    if (mapValue === undefined) {
+      mapValue = [];
+    }
+    mapValue.push(sanitizeMetadataValue(value));
+    map.set(key, mapValue);
+  }
+}
+
+/**
+ * TODO: what are these maps
+ *
+ * @param {PathLike[]} filePaths
+ * @return {*}  {Promise<Map<MetadataValue, MetadataValueMap>>}
+ */
+async function getMaps(
+  filePaths: PathLike[]
+): Promise<Map<MetadataValue, MetadataValueMap>> {
+  const objectTypeMap: Map<MetadataValue, MetadataValueMap> = new Map();
+  const mapBuilderCallback = async (docBuilder: DocumentBuilder) => {
+    const {metadata} = docBuilder.build();
+    if (metadata?.objecttype === undefined) {
+      return;
+    }
+    let metadataValueMap = objectTypeMap.get(metadata?.objecttype);
+    if (metadataValueMap === undefined) {
+      metadataValueMap = new Map();
+      objectTypeMap.set(metadata?.objecttype, metadataValueMap);
+    }
+    addToMap(metadataValueMap, metadata);
+  };
+
+  for (const filePath of filePaths) {
+    parseAndGetDocumentBuilderFromJSONDocument(filePath, {
+      callback: mapBuilderCallback,
+    });
+  }
+
+  return objectTypeMap;
+}
+
+/**
+ * TODO: explain what are maps and uniqueKeys matrix...as well as what this function does
+ *
+ * @param {IterableIterator<MetadataValueMap>} maps
+ * @param {string[][]} uniqueMetadataKeys
+ * @return {*}
+ */
+function findCatalogIdFields(
+  maps: IterableIterator<MetadataValueMap>,
+  uniqueMetadataKeys: string[][]
+) {
+  // TODO: can be optimized
+  const [mapA, mapB] = maps;
+  const [uniqueObjectTypeAMetadataKeys, uniqueObjectTypeBMetadataKeys] =
+    uniqueMetadataKeys;
+
+  const productIdCandidates: string[] = [];
+  for (const metdataKey of uniqueObjectTypeAMetadataKeys) {
+    const objectTypeASet = new Set(mapA.get(metdataKey));
+    const objectTypeBSet = new Set(mapB.get(metdataKey));
+    if (setAreEqual(objectTypeASet, objectTypeBSet)) {
+      productIdCandidates.push(metdataKey);
+    }
+  }
+  return {
+    productIdFields: productIdCandidates,
+    variantIdFields: uniqueObjectTypeBMetadataKeys,
+  };
+}
+
+function findUniqueMetadataKeysInMap(map: MetadataValueMap): string[] {
+  const metadataKeyCandidates: string[] = [];
+  for (const [key, values] of map.entries()) {
+    if (!containsDuplicates(values)) {
+      continue;
+    }
+    metadataKeyCandidates.push(key);
+  }
+
+  return metadataKeyCandidates;
+}
+
+function catalogChannelHasSingleMatch(
+  channel?: CatalogFieldStrutureValue
+): channel is CatalogFieldStrutureValue {
+  if (!Array.isArray(channel)) {
+    return false;
+  }
+  return channel.possibleIdFields.length === 1;
+}

--- a/packages/cli/src/lib/catalog/detect.ts
+++ b/packages/cli/src/lib/catalog/detect.ts
@@ -7,20 +7,13 @@ import {
 import {PathLike} from 'fs';
 import {containsDuplicates} from '../utils/list';
 import {setAreEqual} from '../utils/set';
-import {PartialCatalogConfigurationModel} from './interfaces';
-
-type MapValue = string | number | null;
-type MetadataValueMap = Map<string, MapValue[]>;
-
-interface CatalogFieldStrutureValue {
-  possibleIdFields: string[];
-  objectType: MetadataValue;
-}
-interface CatalogFieldStruture {
-  product: CatalogFieldStrutureValue;
-  variant?: CatalogFieldStrutureValue;
-  // TODO: implement availabilities
-}
+import {
+  CatalogFieldStruture,
+  CatalogFieldStrutureValue,
+  MapValue,
+  MetadataValueMap,
+  PartialCatalogConfigurationModel,
+} from './interfaces';
 
 export async function getCatalogPartialConfiguration(
   filePaths: PathLike[]
@@ -45,7 +38,8 @@ async function getCatalogFieldStructure(
       throw new Error('Not implemented yet');
 
     default:
-      // Human intervention needed as the complexity significantly increases with the number of object distincts types
+      // Human intervention needed as the complexity significantly increases with the number of object distincts types.
+      // If we reach this condition, it probably means the documents have not been given the correct object type
       throw new Error('Unable to compute catalog configuration');
   }
 }
@@ -53,11 +47,11 @@ async function getCatalogFieldStructure(
 function convertToCatalogModel(
   structure: CatalogFieldStruture
 ): PartialCatalogConfigurationModel {
-  const {product, variant} = structure;
+  const {product, variant, availabilities} = structure;
   if (
     !catalogChannelHasSingleMatch(product) ||
-    !catalogChannelHasSingleMatch(variant)
-    // TODO: should also check availabilities
+    !catalogChannelHasSingleMatch(variant) ||
+    !catalogChannelHasSingleMatch(availabilities)
   ) {
     throw new Error('Multiple field matches');
   } else {
@@ -70,6 +64,7 @@ function convertToCatalogModel(
         idField: variant.possibleIdFields[0],
         objectType: variant.objectType.toString(),
       },
+      availability: undefined,
     };
   }
 }

--- a/packages/cli/src/lib/catalog/detect.ts
+++ b/packages/cli/src/lib/catalog/detect.ts
@@ -47,11 +47,11 @@ async function getCatalogFieldStructure(
 function convertToCatalogModel(
   structure: CatalogFieldStruture
 ): PartialCatalogConfigurationModel {
-  const {product, variant, availabilities} = structure;
+  const {product, variant, availability} = structure;
   if (
     !catalogChannelHasSingleMatch(product) ||
     !catalogChannelHasSingleMatch(variant) ||
-    !catalogChannelHasSingleMatch(availabilities)
+    !catalogChannelHasSingleMatch(availability)
   ) {
     throw new Error('Multiple field matches');
   } else {
@@ -60,11 +60,19 @@ function convertToCatalogModel(
         idField: product.possibleIdFields[0],
         objectType: product.objectType.toString(),
       },
-      variant: {
-        idField: variant.possibleIdFields[0],
-        objectType: variant.objectType.toString(),
-      },
-      availability: undefined,
+      ...(variant && {
+        variant: {
+          idField: variant.possibleIdFields[0],
+          objectType: variant.objectType.toString(),
+        },
+      }),
+      ...(availability && {
+        availability: {
+          idField: availability.possibleIdFields[0],
+          objectType: availability.objectType.toString(),
+          availableSkusField: availability.availableSkusField.toString(),
+        },
+      }),
     };
   }
 }

--- a/packages/cli/src/lib/catalog/interfaces.ts
+++ b/packages/cli/src/lib/catalog/interfaces.ts
@@ -1,11 +1,16 @@
 import {MetadataValue} from '@coveo/push-api-client';
 import {CreateCatalogConfigurationModel} from '@coveord/platform-client';
 
+export type MetadataKey = string;
 export type MapValue = string | number | null;
-export type MetadataValueMap = Map<string, MapValue[]>;
+
+/**
+ * A map which stores the medata key as well as all the possible values for that metada
+ */
+export type MetadataValueMap = Map<MetadataKey, MapValue[]>;
 
 export interface CatalogFieldStrutureValue {
-  possibleIdFields: string[];
+  possibleIdFields: MetadataKey[];
   objectType: MetadataValue;
 }
 

--- a/packages/cli/src/lib/catalog/interfaces.ts
+++ b/packages/cli/src/lib/catalog/interfaces.ts
@@ -12,7 +12,9 @@ export interface CatalogFieldStrutureValue {
 export interface CatalogFieldStruture {
   product: CatalogFieldStrutureValue;
   variant?: CatalogFieldStrutureValue;
-  availabilities?: CatalogFieldStrutureValue;
+  availability?: CatalogFieldStrutureValue & {
+    availableSkusField: MetadataValue;
+  };
 }
 
 export type PartialCatalogConfigurationModel = Pick<

--- a/packages/cli/src/lib/catalog/interfaces.ts
+++ b/packages/cli/src/lib/catalog/interfaces.ts
@@ -1,4 +1,19 @@
+import {MetadataValue} from '@coveo/push-api-client';
 import {CreateCatalogConfigurationModel} from '@coveord/platform-client';
+
+export type MapValue = string | number | null;
+export type MetadataValueMap = Map<string, MapValue[]>;
+
+export interface CatalogFieldStrutureValue {
+  possibleIdFields: string[];
+  objectType: MetadataValue;
+}
+
+export interface CatalogFieldStruture {
+  product: CatalogFieldStrutureValue;
+  variant?: CatalogFieldStrutureValue;
+  availabilities?: CatalogFieldStrutureValue;
+}
 
 export type PartialCatalogConfigurationModel = Pick<
   CreateCatalogConfigurationModel,

--- a/packages/cli/src/lib/catalog/interfaces.ts
+++ b/packages/cli/src/lib/catalog/interfaces.ts
@@ -1,0 +1,6 @@
+import {CreateCatalogConfigurationModel} from '@coveord/platform-client';
+
+export type PartialCatalogConfigurationModel = Pick<
+  CreateCatalogConfigurationModel,
+  'product' | 'variant' | 'availability'
+>;

--- a/packages/cli/src/lib/utils/list.ts
+++ b/packages/cli/src/lib/utils/list.ts
@@ -1,3 +1,8 @@
 export function without<T>(array: T[], values: T[]): T[] {
   return array.filter((field) => !values.includes(field));
 }
+
+export function containsDuplicates<T>(values: T[]): boolean {
+  const set = new Set(values);
+  return set.size === values.length;
+}

--- a/packages/cli/src/lib/utils/set.ts
+++ b/packages/cli/src/lib/utils/set.ts
@@ -1,0 +1,13 @@
+export function setAreEqual<T>(setA: Set<T>, setB: Set<T>) {
+  if (setA.size !== setB.size) {
+    return false;
+  }
+
+  for (const a of setA) {
+    if (!setB.has(a)) {
+      return false;
+    }
+  }
+
+  return true;
+}


### PR DESCRIPTION
<!-- For Coveo Employees only. Fill this section.

CDX-XXX

-->

## Proposed changes
Try to automatically generate a catalog configuration without user inputs. 
If the detection logic unexpectedly throw or is unable to find a valid configuration model, it will return a warning and ask the user to answer questions.

The idea is to quickly check if we could generate a valid catalog for the user without any using any prompts.
Otherwise, the user has to go through an unnecessary step, specially if his/her data is already following the Coveo catalog standards.

### Screenshot
Example where the automatic catalog configuration detection returned a valid configuration.
![image](https://user-images.githubusercontent.com/12199712/171729972-854c84de-e1bf-4800-a709-8323654c941f.png)


Right now it only works for the following catalog configurations:
- [x] Products
- [x] Products x Variants
- [ ] Products x Availabilities
- [ ] Products x Variants x Availabilities

## Performance
Tested with a set of 18,424 variants and 3,339 products (24 MB)
**Total amount of time** : ~940ms
**Total Heap allocated**: ~125 MB (_Don't know why it takes that much space_)

## Funny story
I tried using a combinatorial optimization approach to solve this problem but failed in building a model that could return a solution in a reasonable amount of time... I don't think this approach would be better than a plain ol' algorithm like the one from this PR. [Here](https://github.com/y-lakhdar/catalog-id-field-solver/blob/master/scenarios/product-variant/productVariant.mzn) is the source code if you are interested.

## Testing

- [ ] Unit Tests:
<!-- Did you write unit tests for your feature? If not, explains why?  -->
- [ ] Functionnal Tests:
<!-- Did you write functionnal tests for your feature? If not, explains why?  -->
- [ ] Manual Tests:
<!-- How did you test your changeset?  -->
