### PR TITLE
feat(dump): add automatic request size backoff

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41330,7 +41330,7 @@
         "@types/json2csv": "5.0.3",
         "@types/node": "17.0.38",
         "@types/semver": "7.3.9",
-        "@types/tmp": "*",
+        "@types/tmp": "^0.2.3",
         "abortcontroller-polyfill": "^1.7.1",
         "archiver": "^5.3.0",
         "async-retry": "^1.3.1",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -172,7 +172,7 @@
   "repository": "coveo/cli",
   "scripts": {
     "build": "rimraf lib && tsc -p tsconfig.json",
-    "test": "jest --colors --detectOpenHandles --forceExit",
+    "test": "jest --colors",
     "lint": "prettier --config ../../.prettierrc.js --check . && eslint .",
     "release:phase2": "node --experimental-specifier-resolution=node ../../scripts/releaseV2/phase2-bump-all-packages.mjs",
     "postpack": "rimraf oclif.manifest.json",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -172,7 +172,7 @@
   "repository": "coveo/cli",
   "scripts": {
     "build": "rimraf lib && tsc -p tsconfig.json",
-    "test": "jest --colors",
+    "test": "jest --colors --detectOpenHandles --forceExit",
     "lint": "prettier --config ../../.prettierrc.js --check . && eslint .",
     "release:phase2": "node --experimental-specifier-resolution=node ../../scripts/releaseV2/phase2-bump-all-packages.mjs",
     "postpack": "rimraf oclif.manifest.json",

--- a/packages/cli/src/commands/org/search/dump.spec.ts
+++ b/packages/cli/src/commands/org/search/dump.spec.ts
@@ -12,13 +12,13 @@ import {Config} from '../../../lib/config/config';
 import {AuthenticatedClient} from '../../../lib/platform/authenticatedClient';
 const mockedAuthenticatedClient = jest.mocked(AuthenticatedClient);
 const mockedConfig = jest.mocked(Config);
-const mockSearch = jest.fn();
+const mockedSearch = jest.fn();
 const mockedParser = jest.mocked(Parser);
 
 mockedAuthenticatedClient.mockImplementation(
   () =>
     ({
-      getClient: () => Promise.resolve({search: {query: mockSearch}}),
+      getClient: () => Promise.resolve({search: {query: mockedSearch}}),
     } as unknown as AuthenticatedClient)
 );
 
@@ -36,29 +36,45 @@ mockedConfig.mockImplementation(
     } as unknown as Config)
 );
 
+const mockFailedSearch = (err: Object, always: boolean) => {
+  const implementation = () => Promise.reject(err);
+
+  if (always) {
+    mockedSearch.mockImplementation(implementation);
+  } else {
+    mockedSearch.mockImplementationOnce(implementation);
+  }
+};
+
 const mockReturnNumberOfResults = (
   numberOfResults: number,
   additionalRaw: Record<string, unknown> = {}
 ) => {
   if (numberOfResults === 0) {
-    mockSearch.mockReturnValueOnce({totalCount: 0, results: []});
+    mockedSearch.mockImplementationOnce(() =>
+      Promise.resolve({totalCount: 0, results: []})
+    );
   } else {
-    mockSearch.mockReturnValueOnce({
-      totalCount: numberOfResults,
-      results: [...Array(Math.min(1000, numberOfResults)).keys()].map((i) => ({
-        raw: {
-          a_field: 'a_value',
-          rowid: i,
-          ...additionalRaw,
-        },
-      })),
-    });
+    mockedSearch.mockImplementationOnce(() =>
+      Promise.resolve({
+        totalCount: numberOfResults,
+        results: [...Array(Math.min(1000, numberOfResults)).keys()].map(
+          (i) => ({
+            raw: {
+              a_field: 'a_value',
+              rowid: i,
+              ...additionalRaw,
+            },
+          })
+        ),
+      })
+    );
   }
 };
 
 describe('org:search:dump', () => {
   beforeEach(() => {
-    mockSearch.mockReset();
+    mockedSearch.mockReset();
   });
 
   test
@@ -69,7 +85,7 @@ describe('org:search:dump', () => {
     .stderr()
     .command(['org:search:dump', '-s', 'the_source'])
     .it('should pass the source as a search filter', () =>
-      expect(mockSearch).toHaveBeenCalledWith(
+      expect(mockedSearch).toHaveBeenCalledWith(
         expect.objectContaining({
           aq: expect.stringContaining('@source=="the_source"'),
         })
@@ -84,7 +100,7 @@ describe('org:search:dump', () => {
     .stderr()
     .command(['org:search:dump', '-s', 'the_source_1', '-s', 'the_source_2'])
     .it('should pass multiple sources as a search filter', () =>
-      expect(mockSearch).toHaveBeenCalledWith(
+      expect(mockedSearch).toHaveBeenCalledWith(
         expect.objectContaining({
           aq: expect.stringContaining(
             '( @source=="the_source_1" ) OR ( @source=="the_source_2" )'
@@ -101,7 +117,7 @@ describe('org:search:dump', () => {
     .stderr()
     .command(['org:search:dump', '-s', 'the_source_1', '-p', 'mypipeline'])
     .it('should pass pipeline as a search parameter', () =>
-      expect(mockSearch).toHaveBeenCalledWith(
+      expect(mockedSearch).toHaveBeenCalledWith(
         expect.objectContaining({
           pipeline: 'mypipeline',
         })
@@ -124,7 +140,7 @@ describe('org:search:dump', () => {
       'bar',
     ])
     .it('should pass fieldsToExclude as a search parameter', () =>
-      expect(mockSearch).toHaveBeenCalledWith(
+      expect(mockedSearch).toHaveBeenCalledWith(
         expect.objectContaining({
           fieldsToExclude: ['foo', 'bar'],
         })
@@ -139,7 +155,7 @@ describe('org:search:dump', () => {
     .stderr()
     .command(['org:search:dump', '-s', 'the_source', '-f', 'my-filter'])
     .it('should pass additional filter as a search filter', () =>
-      expect(mockSearch).toHaveBeenCalledWith(
+      expect(mockedSearch).toHaveBeenCalledWith(
         expect.objectContaining({
           aq: expect.stringContaining('my-filter'),
         })
@@ -154,7 +170,7 @@ describe('org:search:dump', () => {
     .stderr()
     .command(['org:search:dump', '-s', 'the_source'])
     .it('should do only one query when no results are returned', () =>
-      expect(mockSearch).toHaveBeenCalledTimes(1)
+      expect(mockedSearch).toHaveBeenCalledTimes(1)
     );
 
   test
@@ -165,7 +181,7 @@ describe('org:search:dump', () => {
     .stderr()
     .command(['org:search:dump', '-s', 'the_source'])
     .it('should sort by rowid', () =>
-      expect(mockSearch).toHaveBeenCalledWith(
+      expect(mockedSearch).toHaveBeenCalledWith(
         expect.objectContaining({
           sortCriteria: '@rowid ascending',
         })
@@ -180,7 +196,7 @@ describe('org:search:dump', () => {
     .stderr()
     .command(['org:search:dump', '-s', 'the_source'])
     .it('should request 1000 results', () =>
-      expect(mockSearch).toHaveBeenCalledWith(
+      expect(mockedSearch).toHaveBeenCalledWith(
         expect.objectContaining({
           numberOfResults: 1000,
         })
@@ -205,7 +221,7 @@ describe('org:search:dump', () => {
       'foo',
     ])
     .it('should not exclude rowId fields', () =>
-      expect(mockSearch).toHaveBeenCalledWith(
+      expect(mockedSearch).toHaveBeenCalledWith(
         expect.objectContaining({
           numberOfResults: 1000,
           fieldsToExclude: ['foo'],
@@ -248,8 +264,8 @@ describe('org:search:dump', () => {
     .stderr()
     .command(['org:search:dump', '-s', 'the_source'])
     .it('should perform subsequent query with rowid filter', () => {
-      expect(mockSearch).toHaveBeenCalledTimes(2);
-      expect(mockSearch).toHaveBeenCalledWith(
+      expect(mockedSearch).toHaveBeenCalledTimes(2);
+      expect(mockedSearch).toHaveBeenCalledWith(
         expect.objectContaining({
           aq: expect.stringContaining('@rowid>999'),
         })
@@ -271,5 +287,81 @@ describe('org:search:dump', () => {
           fields: expect.arrayContaining(['someField']),
         });
       }
+    );
+
+  test
+    .do(() => {
+      mockFailedSearch({type: 'ResponseExceededMaximumSizeException'}, false);
+      mockReturnNumberOfResults(20);
+    })
+    .stdout()
+    .stderr()
+    .command(['org:search:dump', '-s', 'the_source'])
+    .it(
+      'should query less results if the API returns a ResponseExceededMaximumSizeException',
+      () => {
+        expect(mockedSearch).toHaveBeenNthCalledWith(
+          1,
+          expect.objectContaining({
+            numberOfResults: 1000,
+          })
+        );
+        expect(mockedSearch).toHaveBeenNthCalledWith(
+          2,
+          expect.objectContaining({
+            numberOfResults: 500,
+          })
+        );
+      }
+    );
+
+  test
+    .do(() => {
+      mockFailedSearch({type: 'ResponseExceededMaximumSizeException'}, false);
+      mockReturnNumberOfResults(20);
+    })
+    .stdout()
+    .stderr()
+    .command(['org:search:dump', '-s', 'the_source'])
+    .it(
+      'should query less results if the API returns a ResponseExceededMaximumSizeException',
+      () => {
+        expect(mockedSearch).toHaveBeenNthCalledWith(
+          1,
+          expect.objectContaining({
+            numberOfResults: 1000,
+          })
+        );
+        expect(mockedSearch).toHaveBeenNthCalledWith(
+          2,
+          expect.objectContaining({
+            numberOfResults: 500,
+          })
+        );
+      }
+    );
+
+  test
+    .do(() => {
+      mockFailedSearch({type: 'ResponseExceededMaximumSizeException'}, true);
+    })
+    .stdout()
+    .stderr()
+    .command(['org:search:dump', '-s', 'the_source'])
+    .catch(/Cannot query a single result, please exclude some\/more fields/)
+    .it(
+      'should throw a well formated error if even a single result is too much'
+    );
+
+  test
+    .do(() => {
+      mockFailedSearch(new Error('someError'), false);
+    })
+    .stdout()
+    .stderr()
+    .command(['org:search:dump', '-s', 'the_source'])
+    .catch('someError')
+    .it(
+      'should bubble up the error if another error than `ResponseExceededMaximumSizeException` is thrown'
     );
 });

--- a/packages/cli/src/commands/org/search/dump.ts
+++ b/packages/cli/src/commands/org/search/dump.ts
@@ -207,9 +207,7 @@ export default class Dump extends Command {
       progress.increment(response.results.length);
 
       lastResultsLength = response.results.length;
-      await this.aggregateResults(
-        response.results.map((result: {raw: any}) => result.raw)
-      );
+      await this.aggregateResults(response.results.map((result) => result.raw));
       if (lastResultsLength < this.numberOfResultPerQuery) {
         break;
       }

--- a/packages/cli/src/commands/org/search/dump.ts
+++ b/packages/cli/src/commands/org/search/dump.ts
@@ -44,8 +44,11 @@ export default class Dump extends Command {
   private static readonly DefaultNumberOfResultPerQuery = 1000;
   private static mandatoryFields = ['rowid', 'sysrowid'];
 
-  public static description =
-    'Dump the content of one or more sources in CSV format.';
+  public static description = dedent`
+      Dump the content of one or more sources in CSV format.
+    
+      Note: DictionnaryFields/Values are experimentally supported. In case of failure, you should exclude them using the \`-x\` flag.
+    `;
 
   public static flags = {
     source: Flags.string({


### PR DESCRIPTION
<!-- For Coveo Employees only. Fill this section.

CDX-986

-->

## Proposed changes

Add a mechanism to reduce automatically the amount of results per query if the API throws a `ResponseExceededMaximumSizeException` error.
If we reach 0 results in the query to be sent, we exit with an error and ask the user to exclude fields (that's pretty much the best we can do at this stage)
If another error occurs, we bubble it up, like before.

## Testing

- [X] Unit Tests: yep
- [X] Manual Tests: nope, corner case
