### PR TITLE
fix(snapshot): use `/apply` URL for error

### DIFF
--- a/packages/cli/src/lib/errors/snapshotErrors.ts
+++ b/packages/cli/src/lib/errors/snapshotErrors.ts
@@ -130,7 +130,7 @@ export class SnapshotGenericError
     super(SeverityLevel.Error);
     const report = snapshot.latestReport;
     const urlBuilder = new SnapshotUrlBuilder(cfg);
-    const snapshotUrl = urlBuilder.getSnapshotPage(snapshot);
+    const snapshotUrl = urlBuilder.getSnapshotApplyPage(snapshot);
 
     this.message = dedent`Invalid snapshot - ${report.resultCode}.
       You can also use this link to view the snapshot in the Coveo Admin Console

--- a/packages/cli/src/lib/platform/url.spec.ts
+++ b/packages/cli/src/lib/platform/url.spec.ts
@@ -5,6 +5,7 @@ jest.mock('./environment');
 import {PlatformEnvironment, platformUrl} from './environment';
 import {
   createSnapshotUrl,
+  snapshotApplyUrl,
   snapshotSynchronizationUrl,
   snapshotUrl,
 } from './url';
@@ -37,7 +38,25 @@ describe('url', () => {
     });
   });
 
-  describe('#snapshotSyncrhonizationUrl', () => {
+  describe('#snapshotApplyUrl', () => {
+    fancyIt()('should build the URL properly', () => {
+      expect(
+        snapshotApplyUrl('some-org', 'some-snapshot', {
+          environment: PlatformEnvironment.Stg,
+          region: Region.AU,
+        })
+      ).toBe(
+        'https://foo.test/admin/#some-org/organization/resource-snapshots/some-snapshot/apply'
+      );
+
+      expect(platformUrl).toBeCalledWith({
+        environment: PlatformEnvironment.Stg,
+        region: Region.AU,
+      });
+    });
+  });
+
+  describe('#snapshotSynchronizationUrl', () => {
     fancyIt()('should build the URL properly', () => {
       expect(
         snapshotSynchronizationUrl('some-org', 'some-snapshot', {

--- a/packages/cli/src/lib/platform/url.ts
+++ b/packages/cli/src/lib/platform/url.ts
@@ -9,6 +9,15 @@ export function snapshotUrl(
   return `${url}/admin/#${targetOrgId}/organization/resource-snapshots/${snapshotId}`;
 }
 
+export function snapshotApplyUrl(
+  targetOrgId: string,
+  snapshotId: string,
+  options: Partial<PlatformUrlOptions>
+) {
+  const url = snapshotUrl(targetOrgId, snapshotId, options);
+  return `${url}/apply`;
+}
+
 export function snapshotSynchronizationUrl(
   targetOrgId: string,
   snapshotId: string,

--- a/packages/cli/src/lib/snapshot/snapshotUrlBuilder.spec.ts
+++ b/packages/cli/src/lib/snapshot/snapshotUrlBuilder.spec.ts
@@ -52,8 +52,8 @@ describe('SnapshotUrlBuilder', () => {
   });
 
   fancyIt()('#createSnapshotPage should return the snapshot URL', () => {
-    expect(snapshotUrlBuilder.getSnapshotPage(snapshot)).toEqual(
-      'https://platform.cloud.coveo.com/admin/#foo/organization/resource-snapshots/my-snapshot'
+    expect(snapshotUrlBuilder.getSnapshotApplyPage(snapshot)).toEqual(
+      'https://platform.cloud.coveo.com/admin/#foo/organization/resource-snapshots/my-snapshot/apply'
     );
   });
 

--- a/packages/cli/src/lib/snapshot/snapshotUrlBuilder.ts
+++ b/packages/cli/src/lib/snapshot/snapshotUrlBuilder.ts
@@ -1,15 +1,15 @@
 import {Configuration} from '../config/config';
 import {Snapshot} from './snapshot';
-import {snapshotSynchronizationUrl, snapshotUrl} from '../platform/url';
+import {snapshotSynchronizationUrl, snapshotApplyUrl} from '../platform/url';
 import {PlatformUrlOptions} from '../platform/environment';
 
 export class SnapshotUrlBuilder {
   public constructor(private config: Configuration) {}
 
-  public getSnapshotPage(snapshot: Snapshot) {
+  public getSnapshotApplyPage(snapshot: Snapshot) {
     const {options, targetOrgId, snapshotId} =
       this.getSnapshotUrlOptions(snapshot);
-    return snapshotUrl(targetOrgId, snapshotId, options);
+    return snapshotApplyUrl(targetOrgId, snapshotId, options);
   }
 
   public getSynchronizationPage(snapshot: Snapshot) {


### PR DESCRIPTION
<!-- For Coveo Employees only. Fill this section.

CDX-1002

-->

## Proposed changes

The link to the failed snapshot is no longer valid. This happens when the snapshot validation fails and when the CLI returns the link to the snapshot.

## Testing

- [x] Unit Tests:
