### PR TITLE
fix(snapshot): ignore error if file is already unexisting

### DIFF
--- a/packages/cli/src/lib/snapshot/expandedPreviewer/filesDiffProcessor.spec.ts
+++ b/packages/cli/src/lib/snapshot/expandedPreviewer/filesDiffProcessor.spec.ts
@@ -65,7 +65,8 @@ describe('#recursiveDirectoryDiff', () => {
         recursiveDirectoryDiff('currentDir', 'nextDir', true);
 
         expect(mockedRm).toHaveBeenCalledWith(
-          join('currentDir', 'someFile.json')
+          join('currentDir', 'someFile.json'),
+          {force: true}
         );
       }
     );

--- a/packages/cli/src/lib/snapshot/expandedPreviewer/filesDiffProcessor.ts
+++ b/packages/cli/src/lib/snapshot/expandedPreviewer/filesDiffProcessor.ts
@@ -38,7 +38,9 @@ export function recursiveDirectoryDiff(
   });
 
   if (deleteMissingResources) {
-    currentFilePaths.forEach((filePath) => rmSync(join(currentDir, filePath)));
+    currentFilePaths.forEach((filePath) =>
+      rmSync(join(currentDir, filePath), {force: true})
+    );
   }
 }
 


### PR DESCRIPTION
https://coveord.atlassian.net/browse/CDX-926

<!-- For Coveo Employees only. Fill this section.

CDX-926

-->

## Proposed changes

The error was occurring on `rmSync` because the file was missing. We don't really care that it's not there, so we just have to ignore the error using force: true, which silences the error.

## Testing

- [x] Unit Tests:
- [x] Manual Tests:
