### PR TITLE
fix: correctly support `--snapshotId` flag

### DIFF
--- a/packages/cli/src/commands/org/resources/preview.spec.ts
+++ b/packages/cli/src/commands/org/resources/preview.spec.ts
@@ -82,17 +82,21 @@ const mockUserNotHavingAllRequiredPlatformPrivileges = () => {
 };
 
 const mockSnapshotFactory = async () => {
+  const dummySnapshot = {
+    validate: mockedValidateSnapshot,
+    preview: mockedPreviewSnapshot,
+    delete: mockedDeleteSnapshot,
+    saveDetailedReport: mockedSaveDetailedReport,
+    areResourcesInError: mockedAreResourcesInError,
+    latestReport: mockedLastReport,
+    id: 'banana-snapshot',
+    targetId: 'potato-org',
+  } as unknown as Snapshot;
   mockedSnapshotFactory.createFromZip.mockReturnValue(
-    Promise.resolve({
-      validate: mockedValidateSnapshot,
-      preview: mockedPreviewSnapshot,
-      delete: mockedDeleteSnapshot,
-      saveDetailedReport: mockedSaveDetailedReport,
-      areResourcesInError: mockedAreResourcesInError,
-      latestReport: mockedLastReport,
-      id: 'banana-snapshot',
-      targetId: 'potato-org',
-    } as unknown as Snapshot)
+    Promise.resolve(dummySnapshot)
+  );
+  mockedSnapshotFactory.createFromExistingSnapshot.mockReturnValue(
+    Promise.resolve(dummySnapshot)
   );
 };
 
@@ -206,6 +210,20 @@ describe('org:resources:preview', () => {
     test
       .stdout()
       .stderr()
+      .command(['org:resources:preview', '-s', 'some-snapshot-id'])
+      .it('should work with specified snapshot id', () => {
+        expect(
+          mockedSnapshotFactory.createFromExistingSnapshot
+        ).toHaveBeenCalledWith(
+          'some-snapshot-id',
+          'foo',
+          expect.objectContaining({})
+        );
+      });
+
+    test
+      .stdout()
+      .stderr()
       .command(['org:resources:preview'])
       .it('should set a 60 seconds wait', () => {
         expect(mockedSnapshotFactory.createFromZip).toHaveBeenCalledWith(
@@ -276,9 +294,9 @@ describe('org:resources:preview', () => {
     test
       .stdout()
       .stderr()
-      .command(['org:resources:preview'])
-      .it('should delete the snapshot', () => {
-        expect(mockedDeleteSnapshot).toHaveBeenCalledTimes(1);
+      .command(['org:resources:preview', '-s', 'some-snapshot-id'])
+      .it('should no delete the snapshot', () => {
+        expect(mockedDeleteSnapshot).not.toHaveBeenCalled();
       });
 
     test

--- a/packages/cli/src/commands/org/resources/preview.ts
+++ b/packages/cli/src/commands/org/resources/preview.ts
@@ -100,8 +100,13 @@ export default class Preview extends Command {
     return flags.previewLevel === PreviewLevelValue.Detailed;
   }
 
+  private async shouldDeleteSnapshot() {
+    return !(await this.parse(Preview)).flags.snapshotId;
+  }
   private async cleanup(snapshot: Snapshot, project: Project) {
-    await snapshot.delete();
+    if (await this.shouldDeleteSnapshot()) {
+      await snapshot.delete();
+    }
     project.deleteTemporaryZipFile();
   }
 
@@ -117,7 +122,7 @@ export default class Preview extends Command {
 
           Once the snapshot is created, you can preview it with the following command:
 
-            ${blueBright`coveo org:resources:preview -t ${target} -s ${snapshot.id}`}
+            ${blueBright`coveo org:resources:preview -o ${target} -s ${snapshot.id}`}
 
             `
       );
@@ -129,6 +134,7 @@ export default class Preview extends Command {
     return {
       deleteMissingResources: flags.showMissingResources,
       waitUntilDone: {wait: flags.wait},
+      ...(flags.snapshotId && {snapshotId: flags.snapshotId}),
     };
   }
 


### PR DESCRIPTION
https://coveord.atlassian.net/browse/CDX-1078

<!-- For Coveo Employees only. Fill this section.

CDX-XXX

-->

## Proposed changes

* Enable preview for existing snapshot
* Make sure to not delete the snapshot if it was already present in the organzation

<!--
    Remove this section if the PR does not include any breaking change

    If your changes includes some breaking changes in the code, thoroughly explains:
        - What are the breaking changes programmatically speaking.
        - What is the impact on the end-user (e.g. user cannot do X anymore).
        - What motivates those changes.
-->

## Testing

- [ ] Unit Tests:
<!-- Did you write unit tests for your feature? If not, explains why?  -->
- [ ] Functionnal Tests:
<!-- Did you write functionnal tests for your feature? If not, explains why?  -->
- [ ] Manual Tests:
<!-- How did you test your changeset?  -->
