### PR TITLE
chore: ensure JF is not the only atomic owner

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,2 @@
 *               @olamothe @y-lakhdar @louis-bompart
-packages/atomic @ThibodeauJF
+packages/atomic @ThibodeauJF @olamothe @y-lakhdar @louis-bompart


### PR DESCRIPTION
CDX-1026

<!-- For Coveo Employees only. Fill this section.

CDX-XXX

-->

## Proposed changes

Currently, if some changes occurred on atomic, JF review is mandatory. This was not the goal, but to add him instead in the pool (not to be the pool 😂 )