### PR TITLE
chore(e2e): ignore changelog.md from atomic snapshot

### DIFF
--- a/packages/cli-e2e/__tests__/__snapshots__/atomic.specs.linux.ts.snap
+++ b/packages/cli-e2e/__tests__/__snapshots__/atomic.specs.linux.ts.snap
@@ -129,10 +129,6 @@ HashedFolder {
   "children": Array [
     HashedFolder {
       "children": Array [
-        HashedFile {
-          "hash": "oMzLrQ0u8uwDzLajoZLupFotyOQ=",
-          "name": "CHANGELOG.md",
-        },
         HashedFolder {
           "children": Array [
             HashedFolder {
@@ -186,7 +182,7 @@ HashedFolder {
           "name": "tsconfig.json",
         },
       ],
-      "hash": "dxEhebxuiDm8NbRcK3lqssqPtWU=",
+      "hash": "+KwGXoBYHN/h/8rjUzPoPaNNiLY=",
       "name": "lambda",
     },
     HashedFile {
@@ -292,7 +288,7 @@ HashedFolder {
       "name": "tsconfig.json",
     },
   ],
-  "hash": "EqZ2vxdC4+HqoJB89387OQJQ0Fk=",
+  "hash": "sRaQAOco8Pzn0RCeXZ1Bhu7CSMI=",
   "name": "normalizedDir",
 }
 `;

--- a/packages/cli-e2e/__tests__/__snapshots__/atomic.specs.windows.ts.snap
+++ b/packages/cli-e2e/__tests__/__snapshots__/atomic.specs.windows.ts.snap
@@ -129,10 +129,6 @@ HashedFolder {
   "children": Array [
     HashedFolder {
       "children": Array [
-        HashedFile {
-          "hash": "oMzLrQ0u8uwDzLajoZLupFotyOQ=",
-          "name": "CHANGELOG.md",
-        },
         HashedFolder {
           "children": Array [
             HashedFolder {
@@ -186,7 +182,7 @@ HashedFolder {
           "name": "tsconfig.json",
         },
       ],
-      "hash": "2eCTirFc6UVwmzSBQITDgx3YXTo=",
+      "hash": "776V3GqWzlsyynghk8UZd8AYrGs=",
       "name": "lambda",
     },
     HashedFile {
@@ -292,7 +288,7 @@ HashedFolder {
       "name": "tsconfig.json",
     },
   ],
-  "hash": "2cL3jmFvUoEXwJae6h28W1Ejtvk=",
+  "hash": "ixXmbFO4LWb8Y74mgS2HgT0OpII=",
   "name": "normalizedDir",
 }
 `;

--- a/packages/cli-e2e/__tests__/atomic.specs.os.ts
+++ b/packages/cli-e2e/__tests__/atomic.specs.os.ts
@@ -226,6 +226,7 @@ describe('ui:create:atomic', () => {
               exclude: [
                 '**.env',
                 '**package-lock.json',
+                '**CHANGELOG.md',
                 '**package.json',
                 'stencil.config.ts',
                 '**index.html',


### PR DESCRIPTION
<!-- For Coveo Employees only. Fill this section.

CDX-1101

-->

## Proposed changes

lambda/changelog.md changes after a release and this causes havoc. This fixes that.

## Testing

CI/CD