### PR TITLE
fix(dump): remove recursion

### DIFF
--- a/packages/cli/src/commands/org/search/dump.ts
+++ b/packages/cli/src/commands/org/search/dump.ts
@@ -219,9 +219,6 @@ export default class Dump extends Command {
       indexToken = response.indexToken;
       rowId = response.results[lastResultsLength - 1].raw.rowid;
     } while (lastResultsLength >= this.numberOfResultPerQuery);
-    if (this.aggregatedResults.length > 0) {
-      this.dumpAggregatedResults();
-    }
     this.progressBar.stop();
     return this.progressBar.getTotal() > 0;
   }
@@ -279,19 +276,18 @@ export default class Dump extends Command {
     }) as SingleBar;
   }
 
-  private async aggregateResults(newResults: RawResult[]) {
+  private async aggregateResults(results: RawResult[]) {
     const maxAggregatedResults = (await this.parse(Dump)).flags.chunkSize;
-    const amountOfNewResultsToExtract =
-      maxAggregatedResults - this.aggregatedResults.length;
-    this.aggregatedResults.push(
-      ...newResults.splice(
-        0,
-        Math.min(amountOfNewResultsToExtract, newResults.length)
-      )
-    );
-    if (newResults.length > 0) {
+    while (results.length > 0) {
+      const amountOfNewResultsToExtract =
+        maxAggregatedResults - this.aggregatedResults.length;
+      this.aggregatedResults.push(
+        ...results.splice(
+          0,
+          Math.min(amountOfNewResultsToExtract, results.length)
+        )
+      );
       this.dumpAggregatedResults();
-      await this.aggregateResults(newResults);
     }
   }
 


### PR DESCRIPTION
CDX-1117

## Proposed changes
![image](https://user-images.githubusercontent.com/12366410/185490136-bb6c8ed2-a66c-44c9-b164-3ea826229238.png)
This is often due to recursion that goes too far.
The only recursion in the search dump is the one removed in this PR.

## Testing

Corner case, so no automated tests.
`@coveo/cli@1.34.3-0` was released as alpha for validation on customer organization by support. waiting for confirmation from them.