### PR TITLE
chore: add debug option on CI/CD

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,11 @@ on:
         description: '⚠ be sure of yourself ⚠'
         required: false
         default: ''
+      debug:
+        description: 'Add DEBUG=* to the env if true'
+        type: boolean
+        default: false
+        required: false
 
 jobs:
   snyk:
@@ -82,3 +87,4 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           VERSION: ${{ inputs.version }}
+          DEBUG: ${{ inputs.debug && 'true' || '' }}


### PR DESCRIPTION
<!-- For Coveo Employees only. Fill this section.

CDX-1126

-->

## Proposed changes

`@coveo/semantic-monorepo-tools` leverage the DEBUG=* for logging purpose, which can give plenty info on what the heck is going on.

It's a pain to do a PR guess, rince and repeat each time, this should allow me to gather more informations without having to do two PR (one for enabling debug, another for disabling it)


Ternary does not exist on GHA, so: http://rickluna.com/wp/tag/fake-ternary/