### PR TITLE
Automated PR to compare tgf version update - cli

### DIFF
--- a/terraform/.tgf.config
+++ b/terraform/.tgf.config
@@ -1,1 +1,1 @@
-docker-image-version: 3.13
+docker-image-version: 3.25


### PR DESCRIPTION
### [CA-281: Data asset classification](https://coveord.atlassian.net/browse/CA-281)
### Context
In order to implement the ISO27001 asset tagging solution we need to be at least at TGF 3.23, but as the 3.25 version is available and works with your repository, I bumped it to the latest version. Another PR will come with preset asset assignation.
Note: This version is automatically adding 3 tags to all project resources: `coveo_product`, `coveo_repository_url` and `coveo_team_name`
✅ Your repository has been identified as a no risk update as the only changes are to attributes known to be harmless

### Solution
Bump to required version

### Check list
- [x] Tests ([You can review the plan before/after changes](https://github.com/coveo/tgf-plan-compare/pull/568/files))