### PR TITLE
chore: refresh e2e snapshot

### DIFF
--- a/packages/cli-e2e/__tests__/__snapshots__/atomic.specs.ts.snap
+++ b/packages/cli-e2e/__tests__/__snapshots__/atomic.specs.ts.snap
@@ -325,7 +325,7 @@ HashedFolder {
             HashedFolder {
               "children": Array [
                 HashedFile {
-                  "hash": "5mAP6qJ62EPO1+YNm7mjtIh30tw=",
+                  "hash": "FbFAlbbU61PNBy42vBHbowLIywU=",
                   "name": "results-manager.tsx",
                 },
                 HashedFile {
@@ -333,7 +333,7 @@ HashedFolder {
                   "name": "template-1.html",
                 },
               ],
-              "hash": "IT2AXZnEDOxm24f6UAC5e6sRZpc=",
+              "hash": "Gev92dWPI2/TkmLatrRENpX29vM=",
               "name": "results-manager",
             },
             HashedFolder {
@@ -365,7 +365,7 @@ HashedFolder {
               "name": "sample-result-component",
             },
           ],
-          "hash": "VAP0t0LvchaSfOYfLeJ1Y3BGlWM=",
+          "hash": "SP/0uVxiIVbmbhKtbghyoR79Lok=",
           "name": "components",
         },
         HashedFile {
@@ -396,7 +396,7 @@ HashedFolder {
           "name": "style",
         },
       ],
-      "hash": "bTliJaanZh0La4ykGHAcoc7jwwc=",
+      "hash": "qpJvG2/8fJczbD7GLXmCL1nsX2s=",
       "name": "src",
     },
     HashedFile {
@@ -408,7 +408,7 @@ HashedFolder {
       "name": "tsconfig.json",
     },
   ],
-  "hash": "8l43gdGyItser4cMLjQOqgqNSQA=",
+  "hash": "JEEkYckHZojgOQFBwmsdDVNAMF8=",
   "name": "normalizedDir",
 }
 `;


### PR DESCRIPTION
<!-- For Coveo Employees only. Fill this section.

CDX-764

-->

## Proposed changes

Something changed on qaregression2 making one of the cli interaction not use the same hosted search page.

This is OK, but impacted the snapshot of the e2e.

I refreshed the snapshot

## Testing

CI/CD
