### PR TITLE
chore: build all projects when building binaries

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -42,7 +42,6 @@ jobs:
       - name: Get commit short hash
         run: node ./scripts/get-commit-short-hash.mjs
       - name: Build
-        working-directory: ./packages/cli/core
         run: npm run build
       - name: Create install kits
         working-directory: ./packages/cli/core


### PR DESCRIPTION
<!-- For Coveo Employees only. Fill this section.

CDX-764

-->

## Proposed changes

Now that we have a composite project for `@coveo/cli`, we need to build the reference first (or use `tsc --build`).

I chose the later to just reuse what's already there