### PR TITLE
chore(analytics): add ft users email domain to internalusers

### DIFF
--- a/packages/cli/commons/src/analytics/identifier.ts
+++ b/packages/cli/commons/src/analytics/identifier.ts
@@ -73,9 +73,13 @@ export class Identifier {
     };
   }
 
+  private isEmailInternal(email: string) {
+    return /@(?:coveo|devcoveo\.onmicrosoft)\.com$/.test(email);
+  }
+
   private async getUserInfo(platformClient: PlatformClient) {
     const {email} = await platformClient.user.get();
-    const isInternalUser = email.match(/@coveo\.com$/) !== null;
+    const isInternalUser = this.isEmailInternal(email);
 
     return {
       userId: isInternalUser ? email : this.hash(email),


### PR DESCRIPTION
<!-- For Coveo Employees only. Fill this section.

CDX-1160

-->

## Proposed changes

This will allow us to ignore with certitude the test user from our analytics reports