### PR TITLE
tests(e2e): add package fallback to npm

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "@nrwl/cli": "latest",
         "@nrwl/workspace": "latest",
         "@types/node": "16.11.59",
+        "@types/pacote": "^11.1.5",
         "@typescript-eslint/eslint-plugin": "5.38.0",
         "@typescript-eslint/parser": "5.38.0",
         "abortcontroller-polyfill": "1.7.3",
@@ -320,7 +321,6 @@
       "version": "14.2.3",
       "resolved": "https://registry.npmjs.org/@angular/core/-/core-14.2.3.tgz",
       "integrity": "sha512-neW2n5Ts2purYEVh0Lf207otZbhYH4C4lwwu8ffxdRiXahQiTCbmyM3IQFrQZbLDb/ZeD2KhoCl6p0hlyg14cA==",
-      "dev": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -3379,7 +3379,7 @@
       "version": "28.1.3",
       "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-28.1.3.tgz",
       "integrity": "sha512-/l/VWsdt/aBXgjshLWOFyFt3IVdYypu5y2Wn2rOO1un6nkqIn8SLXzgIMYXFyYsRWDyF5EthmKJMIdJvk08grg==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@sinclair/typebox": "^0.24.1"
       },
@@ -7023,11 +7023,72 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.59.tgz",
       "integrity": "sha512-6u+36Dj3aDzhfBVUf/mfmc92OEdzQ2kx2jcXGdigfl70E/neV21ZHE6UCz4MDzTRcVqGAM27fk+DLXvyDsn3Jw=="
     },
+    "node_modules/@types/node-fetch": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.2.tgz",
+      "integrity": "sha512-DHqhlq5jeESLy19TYhLakJ07kNumXWjcDdxXsLUMJZ6ue8VZJj4kLPQVE/2mdHh3xZziNF1xppu5lwmS53HR+A==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*",
+        "form-data": "^3.0.0"
+      }
+    },
+    "node_modules/@types/node-fetch/node_modules/form-data": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
+      "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
+      "dev": true,
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz",
       "integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==",
       "dev": true
+    },
+    "node_modules/@types/npm-package-arg": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@types/npm-package-arg/-/npm-package-arg-6.1.1.tgz",
+      "integrity": "sha512-452/1Kp9IdM/oR10AyqAgZOxUt7eLbm+EMJ194L6oarMYdZNiFIFAOJ7IIr0OrZXTySgfHjJezh2oiyk2kc3ag==",
+      "dev": true
+    },
+    "node_modules/@types/npm-registry-fetch": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/@types/npm-registry-fetch/-/npm-registry-fetch-8.0.4.tgz",
+      "integrity": "sha512-R9yEj6+NDmXLpKNS19cIaMyaHfV0aHjy/1qbo8K9jiHyjyaYg0CEmuOV/L0Q91DZDi3SuxlYY+2XYwh9TbB+eQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*",
+        "@types/node-fetch": "*",
+        "@types/npm-package-arg": "*",
+        "@types/npmlog": "*",
+        "@types/ssri": "*"
+      }
+    },
+    "node_modules/@types/npmlog": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@types/npmlog/-/npmlog-4.1.4.tgz",
+      "integrity": "sha512-WKG4gTr8przEZBiJ5r3s8ZIAoMXNbOgQ+j/d5O4X3x6kZJRLNvyUJuUK/KoG3+8BaOHPhp2m7WC6JKKeovDSzQ==",
+      "dev": true
+    },
+    "node_modules/@types/pacote": {
+      "version": "11.1.5",
+      "resolved": "https://registry.npmjs.org/@types/pacote/-/pacote-11.1.5.tgz",
+      "integrity": "sha512-kMsfmhP2G45ngnpvH0LKd1celWnjgdiws1FHu3vMmYuoElGdqnd0ydf1ucZzeXamYnLe0NvSzGP2gYiETOEiQA==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*",
+        "@types/npm-registry-fetch": "*",
+        "@types/npmlog": "*",
+        "@types/ssri": "*"
+      }
     },
     "node_modules/@types/parse-json": {
       "version": "4.0.0",
@@ -7190,6 +7251,15 @@
       "version": "8.1.2",
       "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-8.1.2.tgz",
       "integrity": "sha512-9GcLXF0/v3t80caGs5p2rRfkB+a8VBGLJZVih6CNFkx8IZ994wiKKLSRs9nuFwk1HevWs/1mnUmkApGrSGsShA=="
+    },
+    "node_modules/@types/ssri": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@types/ssri/-/ssri-7.1.1.tgz",
+      "integrity": "sha512-DPP/jkDaqGiyU75MyMURxLWyYLwKSjnAuGe9ZCsLp9QZOpXmDfuevk769F0BS86TmRuD5krnp06qw9nSoNO+0g==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/stack-utils": {
       "version": "2.0.1",
@@ -8599,7 +8669,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
       "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=8"
       }
@@ -9107,7 +9177,7 @@
       "version": "3.5.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
       "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "individual",
@@ -10868,7 +10938,6 @@
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
       "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
-      "optional": true,
       "dependencies": {
         "iconv-lite": "^0.6.2"
       }
@@ -14064,7 +14133,6 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
       "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "optional": true,
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
@@ -14304,7 +14372,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
       "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "binary-extensions": "^2.0.0"
       },
@@ -15404,7 +15472,7 @@
       "version": "28.1.3",
       "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-28.1.3.tgz",
       "integrity": "sha512-3S+RQWDXccXDKSWnkHa/dPwt+2qwA8CJzR61w3FoYCvoo3Pn8tvGcysmMF0Bj0EX5RYvAI2EIvC57OmotfdtKA==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@jest/types": "^28.1.3",
         "@types/graceful-fs": "^4.1.3",
@@ -15429,7 +15497,7 @@
       "version": "28.1.3",
       "resolved": "https://registry.npmjs.org/@jest/types/-/types-28.1.3.tgz",
       "integrity": "sha512-RyjiyMUZrKz/c+zlMFO1pm70DcIlST8AeWTkoUdZevew44wcNZQHsEVOiCVtgVnlFFD82FPaXycys58cf2muVQ==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@jest/schemas": "^28.1.3",
         "@types/istanbul-lib-coverage": "^2.0.0",
@@ -15446,7 +15514,7 @@
       "version": "28.1.3",
       "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-28.1.3.tgz",
       "integrity": "sha512-XdqfpHwpcSRko/C35uLYFM2emRAltIIKZiJ9eAmhjsj0CqZMa0p1ib0R5fWIqGhn1a103DebTbpqIaP1qCQ6tQ==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@jest/types": "^28.1.3",
         "@types/node": "*",
@@ -15587,7 +15655,7 @@
       "version": "28.0.2",
       "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-28.0.2.tgz",
       "integrity": "sha512-4s0IgyNIy0y9FK+cjoVYoxamT7Zeo7MhzqRGx7YDYmaQn1wucY9rotiGkBzzcMXTtjrCAP/f7f+E0F7+fxPNdw==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
       }
@@ -15596,7 +15664,7 @@
       "version": "28.1.1",
       "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-28.1.1.tgz",
       "integrity": "sha512-/d1UbyUkf9nvsgdBildLe6LAD4DalgkgZcKd0nZ8XUGPyA/7fsnaQIlKVnDiuUXv/IeZhPEDrRJubVSulxrShA==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "chalk": "^4.0.0",
         "graceful-fs": "^4.2.9",
@@ -15636,7 +15704,7 @@
       "version": "28.1.3",
       "resolved": "https://registry.npmjs.org/@jest/types/-/types-28.1.3.tgz",
       "integrity": "sha512-RyjiyMUZrKz/c+zlMFO1pm70DcIlST8AeWTkoUdZevew44wcNZQHsEVOiCVtgVnlFFD82FPaXycys58cf2muVQ==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@jest/schemas": "^28.1.3",
         "@types/istanbul-lib-coverage": "^2.0.0",
@@ -15653,7 +15721,7 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=10"
       },
@@ -15665,7 +15733,7 @@
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
       "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=10"
       },
@@ -15677,7 +15745,7 @@
       "version": "28.0.2",
       "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-28.0.2.tgz",
       "integrity": "sha512-ioj2w9/DxSYHfOm5lJKCdcAmPJzQXmbM/Url3rhlghrPvT3tt+7a/+oXc9azkKmLvoiXjtV83bEWqi+vs5nlPA==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
       }
@@ -15686,7 +15754,7 @@
       "version": "28.1.3",
       "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-28.1.3.tgz",
       "integrity": "sha512-SZbOGBWEsaTxBGCOpsRWlXlvNkvTkY0XxRfh7zYmvd8uL5Qzyg0CHAXiXKROflh801quA6+/DsT4ODDthOC/OA==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@jest/types": "^28.1.3",
         "camelcase": "^6.2.0",
@@ -15703,7 +15771,7 @@
       "version": "28.1.3",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-28.1.3.tgz",
       "integrity": "sha512-8gFb/To0OmxHR9+ZTb14Df2vNxdGCX8g1xWGUTqUw5TiZvcQf5sHKObd5UcPyLLyowNwDAMTF3XWOG1B6mxl1Q==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@jest/schemas": "^28.1.3",
         "ansi-regex": "^5.0.1",
@@ -15718,7 +15786,7 @@
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
       "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/jest-runner": {
       "version": "29.0.3",
@@ -16273,7 +16341,7 @@
       "version": "28.1.1",
       "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-28.1.1.tgz",
       "integrity": "sha512-FktOu7ca1DZSyhPAxgxB6hfh2+9zMoJ7aEQA759Z6p45NuO8mWcqujH+UdHlCm/V6JTWwDztM2ITCzU1ijJAfw==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@jest/types": "^28.1.1",
         "@types/node": "*",
@@ -16290,7 +16358,7 @@
       "version": "28.1.3",
       "resolved": "https://registry.npmjs.org/@jest/types/-/types-28.1.3.tgz",
       "integrity": "sha512-RyjiyMUZrKz/c+zlMFO1pm70DcIlST8AeWTkoUdZevew44wcNZQHsEVOiCVtgVnlFFD82FPaXycys58cf2muVQ==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@jest/schemas": "^28.1.3",
         "@types/istanbul-lib-coverage": "^2.0.0",
@@ -16417,7 +16485,7 @@
       "version": "28.1.3",
       "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-28.1.3.tgz",
       "integrity": "sha512-CqRA220YV/6jCo8VWvAt1KKx6eek1VIHMPeLEbpcfSfkEeWyBNppynM/o6q+Wmw+sOhos2ml34wZbSX3G13//g==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@types/node": "*",
         "merge-stream": "^2.0.0",
@@ -18325,7 +18393,6 @@
       "version": "3.3.4",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
       "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==",
-      "dev": true,
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },
@@ -22799,7 +22866,9 @@
       "version": "1.19.2",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.2.tgz",
       "integrity": "sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==",
-      "extraneous": true,
+      "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@types/connect": "*",
         "@types/node": "*"
@@ -22821,7 +22890,9 @@
       "version": "3.4.35",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.35.tgz",
       "integrity": "sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==",
-      "extraneous": true,
+      "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -22850,7 +22921,9 @@
       "version": "4.17.13",
       "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.13.tgz",
       "integrity": "sha512-6bSZTPaTIACxn48l50SR+axgrqm6qXFIxrdAKaG6PaJk3+zuUr35hBlgT7vOmJcum+OEaIBLtHV/qloEAFITeA==",
-      "extraneous": true,
+      "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "^4.17.18",
@@ -22862,7 +22935,9 @@
       "version": "4.17.28",
       "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.28.tgz",
       "integrity": "sha512-P1BJAEAW3E2DJUlkgq4tOL3RyMunoWXqbSCygWo5ZIWTjUgN1YnaXWW4VWl/oc8vs/XoYibEGBKP0uZyF4AHig==",
-      "extraneous": true,
+      "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@types/node": "*",
         "@types/qs": "*",
@@ -22967,7 +23042,9 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz",
       "integrity": "sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw==",
-      "extraneous": true
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "node_modules/netlify-cli/node_modules/@types/minimatch": {
       "version": "3.0.5",
@@ -23027,13 +23104,17 @@
       "version": "6.9.7",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
       "integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==",
-      "extraneous": true
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "node_modules/netlify-cli/node_modules/@types/range-parser": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz",
       "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==",
-      "extraneous": true
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "node_modules/netlify-cli/node_modules/@types/responselike": {
       "version": "1.0.0",
@@ -23060,7 +23141,9 @@
       "version": "1.13.10",
       "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.10.tgz",
       "integrity": "sha512-nCkHGI4w7ZgAdNkrEu0bv+4xNV/XDqW+DydknebMOQwkpDGx8G+HTlj7R7ABI8i8nKxVw0wtKPi1D+lPOkh4YQ==",
-      "extraneous": true,
+      "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@types/mime": "^1",
         "@types/node": "*"
@@ -44448,7 +44531,6 @@
       "version": "8.4.16",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.16.tgz",
       "integrity": "sha512-ipHE1XBvKzm5xI7hiHCZJCSugxvsdq2mPnsq5+UF+VHCjiBvtDrlxJfMBToWaP9D5XlgNmcFGqoHmUn0EYEaRQ==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -45676,7 +45758,7 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
       "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "picomatch": "^2.2.1"
       },
@@ -46663,7 +46745,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
       "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -49881,6 +49962,7 @@
         "folder-hash": "4.0.2",
         "is-running": "2.1.0",
         "open": "8.4.0",
+        "pacote": "^13.6.2",
         "tmp": "0.2.1",
         "ts-node": "10.9.1",
         "verdaccio": "5.15.3",
@@ -51034,7 +51116,6 @@
       "version": "14.2.3",
       "resolved": "https://registry.npmjs.org/@angular/core/-/core-14.2.3.tgz",
       "integrity": "sha512-neW2n5Ts2purYEVh0Lf207otZbhYH4C4lwwu8ffxdRiXahQiTCbmyM3IQFrQZbLDb/ZeD2KhoCl6p0hlyg14cA==",
-      "dev": true,
       "requires": {
         "tslib": "^2.3.0"
       }
@@ -52543,7 +52624,7 @@
         "@babel/core": "7.19.1",
         "@babel/preset-env": "7.19.1",
         "@babel/preset-typescript": "7.18.6",
-        "@coveo/cli": "^1.34.2",
+        "@coveo/cli": "1.36.0",
         "@coveord/platform-client": "34.13.0",
         "@types/async-retry": "1.4.5",
         "@types/folder-hash": "4.0.2",
@@ -52569,6 +52650,7 @@
         "isomorphic-fetch": "3.0.0",
         "jest": "29.0.3",
         "open": "8.4.0",
+        "pacote": "^13.6.2",
         "puppeteer": "18.0.4",
         "strip-ansi": "6.0.1",
         "tmp": "0.2.1",
@@ -53278,7 +53360,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.0.0.tgz",
       "integrity": "sha512-1eEgUGmkaljiBnRMTdksDV1W4kUnmwgp7X9G8B++9GYwl1lUdqSndSriIrTJ0N7LQaoauY9JJ2yhiOYK5+NI4A==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@emotion/utils": {
       "version": "1.2.0",
@@ -53908,7 +53991,7 @@
       "version": "28.1.3",
       "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-28.1.3.tgz",
       "integrity": "sha512-/l/VWsdt/aBXgjshLWOFyFt3IVdYypu5y2Wn2rOO1un6nkqIn8SLXzgIMYXFyYsRWDyF5EthmKJMIdJvk08grg==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "@sinclair/typebox": "^0.24.1"
       }
@@ -54209,7 +54292,8 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.2.0.tgz",
       "integrity": "sha512-lGXtFKe5lp3UxTBGqKI1l7G8sE2xBik8qCfrLHD5olwP/YU0/ReWoWT7Lp1//ri32dK39oPMrJN8TgbkCSbsNA==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@mui/utils": {
       "version": "5.10.6",
@@ -56209,7 +56293,8 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-1.0.4.tgz",
       "integrity": "sha512-mLUsMkgP7K/cnFEw07kWqXGF5LKrOkD+lhCrKvPHXWDywAwuDUeDwWBpc69XK3pNX0uKiVt8g5z96PJ6z9xCFA==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@octokit/plugin-rest-endpoint-methods": {
       "version": "5.16.2",
@@ -56413,7 +56498,8 @@
     "@salesforce-ux/design-system": {
       "version": "2.19.0",
       "resolved": "https://registry.npmjs.org/@salesforce-ux/design-system/-/design-system-2.19.0.tgz",
-      "integrity": "sha512-WmMzB7eqZ67OZ9sS5A6MI3BKmyOevjwZCuizg43ahukzc7lsvlQheHX0TKuHvL8oVaZSrChFIz6gmMQk9+mmSw=="
+      "integrity": "sha512-WmMzB7eqZ67OZ9sS5A6MI3BKmyOevjwZCuizg43ahukzc7lsvlQheHX0TKuHvL8oVaZSrChFIz6gmMQk9+mmSw==",
+      "requires": {}
     },
     "@schematics/angular": {
       "version": "14.2.3",
@@ -56475,7 +56561,8 @@
     "@stencil/store": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@stencil/store/-/store-1.5.0.tgz",
-      "integrity": "sha512-fe5fCF6dgVlDM1iLRkkJUyUh0Tfx305asVGgMAJjIs7Q+x/b1pGgTLROm9Ibr53PZuFwr5Kg+4h9p4FLbYqHgA=="
+      "integrity": "sha512-fe5fCF6dgVlDM1iLRkkJUyUh0Tfx305asVGgMAJjIs7Q+x/b1pGgTLROm9Ibr53PZuFwr5Kg+4h9p4FLbYqHgA==",
+      "requires": {}
     },
     "@testing-library/dom": {
       "version": "8.18.1",
@@ -56927,11 +57014,71 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.59.tgz",
       "integrity": "sha512-6u+36Dj3aDzhfBVUf/mfmc92OEdzQ2kx2jcXGdigfl70E/neV21ZHE6UCz4MDzTRcVqGAM27fk+DLXvyDsn3Jw=="
     },
+    "@types/node-fetch": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.2.tgz",
+      "integrity": "sha512-DHqhlq5jeESLy19TYhLakJ07kNumXWjcDdxXsLUMJZ6ue8VZJj4kLPQVE/2mdHh3xZziNF1xppu5lwmS53HR+A==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*",
+        "form-data": "^3.0.0"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
+          "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
+          "dev": true,
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        }
+      }
+    },
     "@types/normalize-package-data": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz",
       "integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==",
       "dev": true
+    },
+    "@types/npm-package-arg": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@types/npm-package-arg/-/npm-package-arg-6.1.1.tgz",
+      "integrity": "sha512-452/1Kp9IdM/oR10AyqAgZOxUt7eLbm+EMJ194L6oarMYdZNiFIFAOJ7IIr0OrZXTySgfHjJezh2oiyk2kc3ag==",
+      "dev": true
+    },
+    "@types/npm-registry-fetch": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/@types/npm-registry-fetch/-/npm-registry-fetch-8.0.4.tgz",
+      "integrity": "sha512-R9yEj6+NDmXLpKNS19cIaMyaHfV0aHjy/1qbo8K9jiHyjyaYg0CEmuOV/L0Q91DZDi3SuxlYY+2XYwh9TbB+eQ==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*",
+        "@types/node-fetch": "*",
+        "@types/npm-package-arg": "*",
+        "@types/npmlog": "*",
+        "@types/ssri": "*"
+      }
+    },
+    "@types/npmlog": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@types/npmlog/-/npmlog-4.1.4.tgz",
+      "integrity": "sha512-WKG4gTr8przEZBiJ5r3s8ZIAoMXNbOgQ+j/d5O4X3x6kZJRLNvyUJuUK/KoG3+8BaOHPhp2m7WC6JKKeovDSzQ==",
+      "dev": true
+    },
+    "@types/pacote": {
+      "version": "11.1.5",
+      "resolved": "https://registry.npmjs.org/@types/pacote/-/pacote-11.1.5.tgz",
+      "integrity": "sha512-kMsfmhP2G45ngnpvH0LKd1celWnjgdiws1FHu3vMmYuoElGdqnd0ydf1ucZzeXamYnLe0NvSzGP2gYiETOEiQA==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*",
+        "@types/npm-registry-fetch": "*",
+        "@types/npmlog": "*",
+        "@types/ssri": "*"
+      }
     },
     "@types/parse-json": {
       "version": "4.0.0",
@@ -57094,6 +57241,15 @@
       "version": "8.1.2",
       "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-8.1.2.tgz",
       "integrity": "sha512-9GcLXF0/v3t80caGs5p2rRfkB+a8VBGLJZVih6CNFkx8IZ994wiKKLSRs9nuFwk1HevWs/1mnUmkApGrSGsShA=="
+    },
+    "@types/ssri": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@types/ssri/-/ssri-7.1.1.tgz",
+      "integrity": "sha512-DPP/jkDaqGiyU75MyMURxLWyYLwKSjnAuGe9ZCsLp9QZOpXmDfuevk769F0BS86TmRuD5krnp06qw9nSoNO+0g==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "@types/stack-utils": {
       "version": "2.0.1",
@@ -57500,7 +57656,8 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "acorn-walk": {
       "version": "8.2.0",
@@ -58139,7 +58296,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
       "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
-      "dev": true
+      "devOptional": true
     },
     "binaryextensions": {
       "version": "4.18.0",
@@ -58524,7 +58681,7 @@
       "version": "3.5.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
       "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "anymatch": "~3.1.2",
         "braces": "~3.0.2",
@@ -59242,7 +59399,8 @@
       "resolved": "https://registry.npmjs.org/cosmiconfig-typescript-loader/-/cosmiconfig-typescript-loader-4.1.0.tgz",
       "integrity": "sha512-HbWIuR5O+XO5Oj9SZ5bzgrD4nN+rfhrm2PMb0FVx+t+XIvC45n8F0oTNnztXtspWGw0i2IzHaUWFD5LzV1JB4A==",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "requires": {}
     },
     "coveo-styleguide": {
       "version": "9.34.4",
@@ -59875,7 +60033,6 @@
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
       "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
-      "optional": true,
       "requires": {
         "iconv-lite": "^0.6.2"
       }
@@ -60272,7 +60429,8 @@
       "version": "8.5.0",
       "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.5.0.tgz",
       "integrity": "sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "eslint-import-resolver-node": {
       "version": "0.3.6",
@@ -61694,7 +61852,8 @@
           "version": "7.2.0",
           "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-7.2.0.tgz",
           "integrity": "sha512-rV4Qu0C3nfJKPOAhFujFxB7RMP+URFyQqqOZW9DMRD7ZDTFyjaIlETU3xzHELt++4ugC0+Jm084HQYkkJe+Ivg==",
-          "dev": true
+          "dev": true,
+          "requires": {}
         },
         "eslint-plugin-prettier": {
           "version": "3.4.1",
@@ -62286,7 +62445,6 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
       "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "optional": true,
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       }
@@ -62461,7 +62619,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
       "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "binary-extensions": "^2.0.0"
       }
@@ -63266,7 +63424,7 @@
       "version": "28.1.3",
       "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-28.1.3.tgz",
       "integrity": "sha512-3S+RQWDXccXDKSWnkHa/dPwt+2qwA8CJzR61w3FoYCvoo3Pn8tvGcysmMF0Bj0EX5RYvAI2EIvC57OmotfdtKA==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "@jest/types": "^28.1.3",
         "@types/graceful-fs": "^4.1.3",
@@ -63286,7 +63444,7 @@
           "version": "28.1.3",
           "resolved": "https://registry.npmjs.org/@jest/types/-/types-28.1.3.tgz",
           "integrity": "sha512-RyjiyMUZrKz/c+zlMFO1pm70DcIlST8AeWTkoUdZevew44wcNZQHsEVOiCVtgVnlFFD82FPaXycys58cf2muVQ==",
-          "dev": true,
+          "devOptional": true,
           "requires": {
             "@jest/schemas": "^28.1.3",
             "@types/istanbul-lib-coverage": "^2.0.0",
@@ -63300,7 +63458,7 @@
           "version": "28.1.3",
           "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-28.1.3.tgz",
           "integrity": "sha512-XdqfpHwpcSRko/C35uLYFM2emRAltIIKZiJ9eAmhjsj0CqZMa0p1ib0R5fWIqGhn1a103DebTbpqIaP1qCQ6tQ==",
-          "dev": true,
+          "devOptional": true,
           "requires": {
             "@jest/types": "^28.1.3",
             "@types/node": "*",
@@ -63401,19 +63559,20 @@
     "jest-pnp-resolver": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz",
-      "integrity": "sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w=="
+      "integrity": "sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w==",
+      "requires": {}
     },
     "jest-regex-util": {
       "version": "28.0.2",
       "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-28.0.2.tgz",
       "integrity": "sha512-4s0IgyNIy0y9FK+cjoVYoxamT7Zeo7MhzqRGx7YDYmaQn1wucY9rotiGkBzzcMXTtjrCAP/f7f+E0F7+fxPNdw==",
-      "dev": true
+      "devOptional": true
     },
     "jest-resolve": {
       "version": "28.1.1",
       "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-28.1.1.tgz",
       "integrity": "sha512-/d1UbyUkf9nvsgdBildLe6LAD4DalgkgZcKd0nZ8XUGPyA/7fsnaQIlKVnDiuUXv/IeZhPEDrRJubVSulxrShA==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "chalk": "^4.0.0",
         "graceful-fs": "^4.2.9",
@@ -63430,7 +63589,7 @@
           "version": "28.1.3",
           "resolved": "https://registry.npmjs.org/@jest/types/-/types-28.1.3.tgz",
           "integrity": "sha512-RyjiyMUZrKz/c+zlMFO1pm70DcIlST8AeWTkoUdZevew44wcNZQHsEVOiCVtgVnlFFD82FPaXycys58cf2muVQ==",
-          "dev": true,
+          "devOptional": true,
           "requires": {
             "@jest/schemas": "^28.1.3",
             "@types/istanbul-lib-coverage": "^2.0.0",
@@ -63444,25 +63603,25 @@
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
           "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-          "dev": true
+          "devOptional": true
         },
         "camelcase": {
           "version": "6.3.0",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
           "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
-          "dev": true
+          "devOptional": true
         },
         "jest-get-type": {
           "version": "28.0.2",
           "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-28.0.2.tgz",
           "integrity": "sha512-ioj2w9/DxSYHfOm5lJKCdcAmPJzQXmbM/Url3rhlghrPvT3tt+7a/+oXc9azkKmLvoiXjtV83bEWqi+vs5nlPA==",
-          "dev": true
+          "devOptional": true
         },
         "jest-validate": {
           "version": "28.1.3",
           "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-28.1.3.tgz",
           "integrity": "sha512-SZbOGBWEsaTxBGCOpsRWlXlvNkvTkY0XxRfh7zYmvd8uL5Qzyg0CHAXiXKROflh801quA6+/DsT4ODDthOC/OA==",
-          "dev": true,
+          "devOptional": true,
           "requires": {
             "@jest/types": "^28.1.3",
             "camelcase": "^6.2.0",
@@ -63476,7 +63635,7 @@
           "version": "28.1.3",
           "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-28.1.3.tgz",
           "integrity": "sha512-8gFb/To0OmxHR9+ZTb14Df2vNxdGCX8g1xWGUTqUw5TiZvcQf5sHKObd5UcPyLLyowNwDAMTF3XWOG1B6mxl1Q==",
-          "dev": true,
+          "devOptional": true,
           "requires": {
             "@jest/schemas": "^28.1.3",
             "ansi-regex": "^5.0.1",
@@ -63488,7 +63647,7 @@
           "version": "18.2.0",
           "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
           "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
-          "dev": true
+          "devOptional": true
         }
       }
     },
@@ -63971,7 +64130,7 @@
       "version": "28.1.1",
       "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-28.1.1.tgz",
       "integrity": "sha512-FktOu7ca1DZSyhPAxgxB6hfh2+9zMoJ7aEQA759Z6p45NuO8mWcqujH+UdHlCm/V6JTWwDztM2ITCzU1ijJAfw==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "@jest/types": "^28.1.1",
         "@types/node": "*",
@@ -63985,7 +64144,7 @@
           "version": "28.1.3",
           "resolved": "https://registry.npmjs.org/@jest/types/-/types-28.1.3.tgz",
           "integrity": "sha512-RyjiyMUZrKz/c+zlMFO1pm70DcIlST8AeWTkoUdZevew44wcNZQHsEVOiCVtgVnlFFD82FPaXycys58cf2muVQ==",
-          "dev": true,
+          "devOptional": true,
           "requires": {
             "@jest/schemas": "^28.1.3",
             "@types/istanbul-lib-coverage": "^2.0.0",
@@ -64091,7 +64250,7 @@
       "version": "28.1.3",
       "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-28.1.3.tgz",
       "integrity": "sha512-CqRA220YV/6jCo8VWvAt1KKx6eek1VIHMPeLEbpcfSfkEeWyBNppynM/o6q+Wmw+sOhos2ml34wZbSX3G13//g==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "@types/node": "*",
         "merge-stream": "^2.0.0",
@@ -64242,7 +64401,8 @@
           "version": "7.5.9",
           "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
           "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
-          "dev": true
+          "dev": true,
+          "requires": {}
         }
       }
     },
@@ -65577,8 +65737,7 @@
     "nanoid": {
       "version": "3.3.4",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
-      "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==",
-      "dev": true
+      "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw=="
     },
     "natural-compare": {
       "version": "1.4.0",
@@ -66672,7 +66831,8 @@
               "version": "3.0.0",
               "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-3.0.0.tgz",
               "integrity": "sha512-V3wD15YHfHz6y0KdhYFjyy9vWtEVALT9UrxfN3zqlI6dMioHnJrqOYfyPKol3oqrnCM9uwkcdCwkJ0WUcbLMTQ==",
-              "dev": true
+              "dev": true,
+              "requires": {}
             },
             "ansi-regex": {
               "version": "6.0.1",
@@ -68420,7 +68580,8 @@
           "version": "1.0.4",
           "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-1.0.4.tgz",
           "integrity": "sha512-mLUsMkgP7K/cnFEw07kWqXGF5LKrOkD+lhCrKvPHXWDywAwuDUeDwWBpc69XK3pNX0uKiVt8g5z96PJ6z9xCFA==",
-          "dev": true
+          "dev": true,
+          "requires": {}
         },
         "@octokit/plugin-rest-endpoint-methods": {
           "version": "5.13.0",
@@ -68621,7 +68782,9 @@
           "version": "1.19.2",
           "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.2.tgz",
           "integrity": "sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==",
-          "extraneous": true,
+          "dev": true,
+          "optional": true,
+          "peer": true,
           "requires": {
             "@types/connect": "*",
             "@types/node": "*"
@@ -68643,7 +68806,9 @@
           "version": "3.4.35",
           "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.35.tgz",
           "integrity": "sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==",
-          "extraneous": true,
+          "dev": true,
+          "optional": true,
+          "peer": true,
           "requires": {
             "@types/node": "*"
           }
@@ -68669,9 +68834,12 @@
           }
         },
         "@types/express": {
-          "version": "https://registry.npmjs.org/@types/express/-/express-4.17.13.tgz",
+          "version": "4.17.13",
+          "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.13.tgz",
           "integrity": "sha512-6bSZTPaTIACxn48l50SR+axgrqm6qXFIxrdAKaG6PaJk3+zuUr35hBlgT7vOmJcum+OEaIBLtHV/qloEAFITeA==",
-          "extraneous": true,
+          "dev": true,
+          "optional": true,
+          "peer": true,
           "requires": {
             "@types/body-parser": "*",
             "@types/express-serve-static-core": "^4.17.18",
@@ -68683,7 +68851,9 @@
           "version": "4.17.28",
           "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.28.tgz",
           "integrity": "sha512-P1BJAEAW3E2DJUlkgq4tOL3RyMunoWXqbSCygWo5ZIWTjUgN1YnaXWW4VWl/oc8vs/XoYibEGBKP0uZyF4AHig==",
-          "extraneous": true,
+          "dev": true,
+          "optional": true,
+          "peer": true,
           "requires": {
             "@types/node": "*",
             "@types/qs": "*",
@@ -68788,7 +68958,9 @@
           "version": "1.3.2",
           "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz",
           "integrity": "sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw==",
-          "extraneous": true
+          "dev": true,
+          "optional": true,
+          "peer": true
         },
         "@types/minimatch": {
           "version": "3.0.5",
@@ -68847,13 +69019,17 @@
           "version": "6.9.7",
           "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
           "integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==",
-          "extraneous": true
+          "dev": true,
+          "optional": true,
+          "peer": true
         },
         "@types/range-parser": {
           "version": "1.2.4",
           "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz",
           "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==",
-          "extraneous": true
+          "dev": true,
+          "optional": true,
+          "peer": true
         },
         "@types/responselike": {
           "version": "1.0.0",
@@ -68880,7 +69056,9 @@
           "version": "1.13.10",
           "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.10.tgz",
           "integrity": "sha512-nCkHGI4w7ZgAdNkrEu0bv+4xNV/XDqW+DydknebMOQwkpDGx8G+HTlj7R7ABI8i8nKxVw0wtKPi1D+lPOkh4YQ==",
-          "extraneous": true,
+          "dev": true,
+          "optional": true,
+          "peer": true,
           "requires": {
             "@types/mime": "^1",
             "@types/node": "*"
@@ -69172,7 +69350,8 @@
           "version": "5.3.2",
           "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
           "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-          "extraneous": true
+          "extraneous": true,
+          "requires": {}
         },
         "acorn-walk": {
           "version": "8.2.0",
@@ -73401,13 +73580,15 @@
           "version": "8.5.0",
           "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.5.0.tgz",
           "integrity": "sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==",
-          "extraneous": true
+          "extraneous": true,
+          "requires": {}
         },
         "eslint-config-standard": {
           "version": "17.0.0-1",
           "resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-17.0.0-1.tgz",
           "integrity": "sha512-aqRG58dqoBNfOLN+PsitasxmW+W9Os4oQrx081B16T4E4WogsSbpUL6hnKSnyv35sSRYA2XjBtKMOrUboL6jgw==",
-          "extraneous": true
+          "extraneous": true,
+          "requires": {}
         },
         "eslint-formatter-codeframe": {
           "version": "7.32.1",
@@ -73758,7 +73939,8 @@
           "version": "6.0.0",
           "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-6.0.0.tgz",
           "integrity": "sha512-7GPezalm5Bfi/E22PnQxDWH2iW9GTvAlUNTztemeHb6c1BniSyoeTrM87JkC0wYdi6aQrZX9p2qEiAno8aTcbw==",
-          "extraneous": true
+          "extraneous": true,
+          "requires": {}
         },
         "eslint-plugin-react": {
           "version": "7.29.4",
@@ -83656,7 +83838,8 @@
           "version": "7.5.9",
           "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
           "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
-          "extraneous": true
+          "extraneous": true,
+          "requires": {}
         },
         "xdg-basedir": {
           "version": "4.0.0",
@@ -85325,7 +85508,6 @@
       "version": "8.4.16",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.16.tgz",
       "integrity": "sha512-ipHE1XBvKzm5xI7hiHCZJCSugxvsdq2mPnsq5+UF+VHCjiBvtDrlxJfMBToWaP9D5XlgNmcFGqoHmUn0EYEaRQ==",
-      "dev": true,
       "requires": {
         "nanoid": "^3.3.4",
         "picocolors": "^1.0.0",
@@ -85616,7 +85798,8 @@
         "ws": {
           "version": "8.8.1",
           "resolved": "https://registry.npmjs.org/ws/-/ws-8.8.1.tgz",
-          "integrity": "sha512-bGy2JzvzkPowEJV++hF07hAD6niYSr0JzBNo/J29WsB57A2r7Wlc1UFcTR9IzrPvuNVO4B8LGqF8qcpsVOhJCA=="
+          "integrity": "sha512-bGy2JzvzkPowEJV++hF07hAD6niYSr0JzBNo/J29WsB57A2r7Wlc1UFcTR9IzrPvuNVO4B8LGqF8qcpsVOhJCA==",
+          "requires": {}
         }
       }
     },
@@ -86257,7 +86440,7 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
       "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "picomatch": "^2.2.1"
       }
@@ -86307,7 +86490,8 @@
     "redux-thunk": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.4.1.tgz",
-      "integrity": "sha512-OOYGNY5Jy2TWvTL1KgAlVy6dcx3siPJ1wTq741EPyUKfn6W6nChdICjZwCd0p8AZBs5kWpZlbkXW2nE/zjUa+Q=="
+      "integrity": "sha512-OOYGNY5Jy2TWvTL1KgAlVy6dcx3siPJ1wTq741EPyUKfn6W6nChdICjZwCd0p8AZBs5kWpZlbkXW2nE/zjUa+Q==",
+      "requires": {}
     },
     "regenerate": {
       "version": "1.4.2",
@@ -87025,8 +87209,7 @@
     "source-map-js": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
-      "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
-      "dev": true
+      "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw=="
     },
     "source-map-support": {
       "version": "0.5.13",
@@ -88369,7 +88552,8 @@
       "version": "9.1.2",
       "resolved": "https://registry.npmjs.org/vue-property-decorator/-/vue-property-decorator-9.1.2.tgz",
       "integrity": "sha512-xYA8MkZynPBGd/w5QFJ2d/NM0z/YeegMqYTphy7NJQXbZcuU6FC6AOdUAcy4SXP+YnkerC6AfH+ldg7PDk9ESQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "vue-router": {
       "version": "3.6.5",

--- a/packages/cli-e2e/package.json
+++ b/packages/cli-e2e/package.json
@@ -51,6 +51,7 @@
     "folder-hash": "4.0.2",
     "is-running": "2.1.0",
     "open": "8.4.0",
+    "pacote": "13.6.2",
     "tmp": "0.2.1",
     "ts-node": "10.9.1",
     "verdaccio": "5.15.3",

--- a/packages/cli-e2e/setup/ci-verdaccio.ts
+++ b/packages/cli-e2e/setup/ci-verdaccio.ts
@@ -3,12 +3,12 @@ import {ProcessManager} from '../utils/processManager';
 import 'dotenv/config';
 
 import {npmLogin} from '../utils/npmLogin';
+import {startVerdaccio, shimNpm} from './utils/utils';
 import {
-  startVerdaccio,
-  publishPackages,
-  shimNpm,
   scaffoldDummyPackages,
-} from './utils';
+  publishPackages,
+  uplinkMissingPackages,
+} from './utils/verdaccio';
 
 async function main() {
   global.processManager = new ProcessManager();
@@ -17,6 +17,7 @@ async function main() {
   await npmLogin();
   scaffoldDummyPackages();
   await publishPackages();
+  await uplinkMissingPackages();
   await global.processManager.killAllProcesses();
 }
 

--- a/packages/cli-e2e/setup/ci.ts
+++ b/packages/cli-e2e/setup/ci.ts
@@ -9,7 +9,7 @@ import {
   restoreCliConfig,
   shimNpm,
   installCli,
-} from './utils';
+} from './utils/utils';
 
 export default async function () {
   shimNpm();

--- a/packages/cli-e2e/setup/local.ts
+++ b/packages/cli-e2e/setup/local.ts
@@ -11,11 +11,14 @@ import {
   setProcessEnv,
   createUiProjectDirectory,
   startVerdaccio,
-  publishPackages,
   shimNpm,
-  scaffoldDummyPackages,
-} from './utils';
+} from './utils/utils';
 import {join} from 'path';
+import {
+  scaffoldDummyPackages,
+  publishPackages,
+  uplinkMissingPackages,
+} from './utils/verdaccio';
 
 export default async function () {
   shimNpm();
@@ -30,4 +33,5 @@ export default async function () {
   await npmLogin();
   scaffoldDummyPackages();
   await publishPackages();
+  await uplinkMissingPackages();
 }

--- a/packages/cli-e2e/setup/utils/utils.ts
+++ b/packages/cli-e2e/setup/utils/utils.ts
@@ -3,15 +3,15 @@ import {dirSync as tmpDirSync} from 'tmp';
 import {randomBytes} from 'crypto';
 import {launch as launchChrome} from 'chrome-launcher';
 import type {Browser} from 'puppeteer';
-import {captureScreenshots, connectToChromeBrowser} from '../utils/browser';
-import {clearAccessTokenFromConfig, loginWithOffice} from '../utils/login';
-import {getPlatformHost} from '../utils/platform';
-import {getConfig as getCliConfig, getConfigFilePath} from '../utils/cli';
+import {captureScreenshots, connectToChromeBrowser} from '../../utils/browser';
+import {clearAccessTokenFromConfig, loginWithOffice} from '../../utils/login';
+import {getPlatformHost} from '../../utils/platform';
+import {getConfig as getCliConfig, getConfigFilePath} from '../../utils/cli';
 import waitOn from 'wait-on';
 import 'dotenv/config';
-import {Terminal} from '../utils/terminal/terminal';
+import {Terminal} from '../../utils/terminal/terminal';
 import {join, resolve, dirname} from 'path';
-import {npm, npmCachePathEnvVar, npmPathEnvVar} from '../utils/npm';
+import {npm, npmCachePathEnvVar, npmPathEnvVar} from '../../utils/npm';
 import {spawnSync} from 'child_process';
 
 async function clearChromeBrowsingData(browser: Browser) {
@@ -76,33 +76,6 @@ export function setProcessEnv() {
 
 export function setCliExecPath() {
   process.env.CLI_EXEC_PATH = resolve(__dirname, '../../cli/core/bin/dev');
-}
-
-export async function publishPackages() {
-  for (const phase of ['nx:graph', 'release:phase1']) {
-    const args = [...npm(), 'run', phase];
-    const publishTerminal = new Terminal(
-      args.shift()!,
-      args,
-      {
-        cwd: resolve(join(__dirname, '..', '..', '..')),
-        env: {
-          ...process.env,
-          npm_config_registry: 'http://localhost:4873',
-          DEBUG: '*',
-        },
-      },
-      global.processManager!,
-      'npmPublish'
-    );
-    publishTerminal.orchestrator.process.stdout.on('data', (data) => {
-      console.log(data.toString());
-    });
-    publishTerminal.orchestrator.process.stderr.on('data', (data) => {
-      console.log(data.toString());
-    });
-    await publishTerminal.when('exit').on('process').do().once();
-  }
 }
 
 export async function startVerdaccio() {
@@ -241,37 +214,7 @@ export function getCleanEnv(): Record<string, string> {
   return env;
 }
 
-export function scaffoldDummyPackages() {
-  const packagesToScaffold = [
-    '@coveo/angular',
-    '@coveo/vue-cli-plugin-typescript',
-    '@coveo/cra-template',
-    '@coveo/search-token-server',
-    '@coveo/create-atomic',
-    '@coveo/search-token-lambda',
-    '@coveo/cli-commons-dev',
-    '@coveo/cli-commons',
-    '@coveo/cli',
-  ];
-
-  for (const packageToScaffold of packagesToScaffold) {
-    spawnSync(
-      appendCmdIfWindows`npm`,
-      [
-        'publish',
-        `-w=${packageToScaffold}`,
-        '--ignore-scripts',
-        '--registry=http://localhost:4873',
-      ],
-      {
-        cwd: resolve(join(__dirname, '..', '..', '..')),
-        stdio: 'inherit',
-      }
-    );
-  }
-}
-
-const appendCmdIfWindows = (cmd: TemplateStringsArray) =>
+export const appendCmdIfWindows = (cmd: TemplateStringsArray) =>
   `${cmd}${process.platform === 'win32' ? '.cmd' : ''}`;
 
 function isParent(parent: string, potentialChild: string) {

--- a/packages/cli-e2e/setup/utils/verdaccio.ts
+++ b/packages/cli-e2e/setup/utils/verdaccio.ts
@@ -45,7 +45,15 @@ export async function publishPackages() {
     publishTerminal.orchestrator.process.stderr.on('data', (data) => {
       console.log(data.toString());
     });
-    await publishTerminal.when('exit').on('process').do().once();
+    await publishTerminal
+      .when('exit')
+      .on('process')
+      .do((process) => {
+        if (process.exitCode) {
+          throw new Error('Error while publishing packages');
+        }
+      })
+      .once();
   }
 }
 

--- a/packages/cli-e2e/setup/utils/verdaccio.ts
+++ b/packages/cli-e2e/setup/utils/verdaccio.ts
@@ -75,7 +75,7 @@ export async function uplinkMissingPackages() {
     });
     spawnSync(
       appendCmdIfWindows`npm`,
-      ['publish', tarballName, '--registry=http://localhost:4873'],
+      ['publish', tarballName, `--registry=${verdaccioRegistry}`],
       {
         cwd: tmpdir,
         stdio: 'inherit',
@@ -96,7 +96,7 @@ export function scaffoldDummyPackages() {
     );
     spawnSync(
       appendCmdIfWindows`npm`,
-      ['publish', '--registry=http://localhost:4873'],
+      ['publish', `--registry=${verdaccioRegistry}`],
       {
         cwd: tmpdir,
         stdio: 'inherit',

--- a/packages/cli-e2e/setup/utils/verdaccio.ts
+++ b/packages/cli-e2e/setup/utils/verdaccio.ts
@@ -1,0 +1,98 @@
+import {spawnSync} from 'node:child_process';
+import {join, resolve} from 'node:path';
+import {npm} from '../../utils/npm';
+import {Terminal} from '../../utils/terminal/terminal';
+import {appendCmdIfWindows} from './utils';
+import {manifest as getManifest, tarball as getTarball} from 'pacote';
+import {dirSync} from 'tmp';
+import {writeFileSync} from 'node:fs';
+
+const npmRegistry = 'https://registry.npmjs.org/';
+const verdaccioRegistry = 'http://localhost:4873';
+
+const verdaccioedPackages = [
+  '@coveo/angular',
+  '@coveo/vue-cli-plugin-typescript',
+  '@coveo/cra-template',
+  '@coveo/search-token-server',
+  '@coveo/create-atomic',
+  '@coveo/search-token-lambda',
+  '@coveo/cli-commons-dev',
+  '@coveo/cli-commons',
+  '@coveo/cli',
+];
+
+export async function publishPackages() {
+  for (const phase of ['nx:graph', 'release:phase1']) {
+    const args = [...npm(), 'run', phase];
+    const publishTerminal = new Terminal(
+      args.shift()!,
+      args,
+      {
+        cwd: resolve(join(__dirname, '..', '..', '..')),
+        env: {
+          ...process.env,
+          npm_config_registry: verdaccioRegistry,
+          DEBUG: '*',
+        },
+      },
+      global.processManager!,
+      'npmPublish'
+    );
+    publishTerminal.orchestrator.process.stdout.on('data', (data) => {
+      console.log(data.toString());
+    });
+    publishTerminal.orchestrator.process.stderr.on('data', (data) => {
+      console.log(data.toString());
+    });
+    await publishTerminal.when('exit').on('process').do().once();
+  }
+}
+
+export async function uplinkMissingPackages() {
+  const tmpdir = dirSync().name;
+  for (const packageToCheck of verdaccioedPackages) {
+    const manifest = await getManifest(packageToCheck, {
+      registry: verdaccioRegistry,
+    });
+    if (manifest.version !== '0.0.0') {
+      continue;
+    }
+    const tarballBytes = await getTarball(packageToCheck, {
+      registry: npmRegistry,
+    });
+    const tarballName = 'package.tgz';
+    writeFileSync(join(tmpdir, tarballName), tarballBytes, {
+      encoding: 'binary',
+    });
+    spawnSync(
+      appendCmdIfWindows`npm`,
+      ['publish', tarballName, '--registry=http://localhost:4873'],
+      {
+        cwd: tmpdir,
+        stdio: 'inherit',
+      }
+    );
+  }
+}
+
+const getDummyPackageJson = (packageName: string) =>
+  JSON.stringify({packageName, version: '0.0.0'});
+
+export function scaffoldDummyPackages() {
+  const tmpdir = dirSync().name;
+  for (const packageToScaffold of verdaccioedPackages) {
+    writeFileSync(
+      join(tmpdir, 'package.json'),
+      getDummyPackageJson(packageToScaffold)
+    );
+    spawnSync(
+      appendCmdIfWindows`npm`,
+      ['publish', '--registry=http://localhost:4873'],
+      {
+        cwd: tmpdir,
+        stdio: 'inherit',
+      }
+    );
+  }
+}


### PR DESCRIPTION
<!-- For Coveo Employees only. Fill this section.

CDX-1162

-->

## Proposed changes

Now that we release a package only if it changes, we can end up in a situation where a package is not published on verdaccio, which in turn causes the E2E that needs this package to fail. Oups.

This is actually working as intended; eventually, we want to not run the tests if no changes occur.
But we're not there yet, so in the meantime, if a package is not published, I'll pull it up from npm and push it back on verdaccio.

## Testing

CI