### PR TITLE
feat(cli/cli-commons): remove message from stopSpinner

### DIFF
--- a/packages/cli-e2e/__tests__/orgResources.specs.ts
+++ b/packages/cli-e2e/__tests__/orgResources.specs.ts
@@ -114,18 +114,21 @@ describe('org:resources', () => {
       debugName
     );
 
-    const pullTerminalExitPromise = pullTerminal
+    const pullTerminalExitPromise = async () => {
       // TODO: CDX-744: understand why cannot use process.on('exit')
-      .when(/Project updated/)
-      .on('stderr')
-      .do()
-      .once();
+      await pullTerminal
+        .when(/Updating project with Snapshot/)
+        .on('stderr')
+        .do()
+        .once();
+      await pullTerminal.when(/✔/).on('stderr').do().once();
+    };
 
     await pullTerminal
       .when(isGenericYesNoPrompt)
       .on('stderr')
       .do(answerPrompt(`y${EOL}`))
-      .until(pullTerminalExitPromise);
+      .until(pullTerminalExitPromise());
   };
 
   beforeAll(async () => {

--- a/packages/cli/commons/src/utils/ux.ts
+++ b/packages/cli/commons/src/utils/ux.ts
@@ -8,14 +8,14 @@ export function startSpinner(task: string, status?: string) {
   CliUx.ux.action.start(task, status);
 }
 
-export function stopSpinner(options?: {success?: boolean; message?: string}) {
+export function stopSpinner(options?: {success?: boolean}) {
   if (!CliUx.ux.action.running) {
     return;
   }
-  const defaultOptions = {success: true, message: ''};
-  const {success, message} = {...defaultOptions, ...options};
+  const defaultOptions = {success: true};
+  const {success} = {...defaultOptions, ...options};
   const symbol = success ? green('✔') : red.bold('!');
-  CliUx.ux.action.stop(`${symbol} ${message}`.trimEnd());
+  CliUx.ux.action.stop(`${symbol}`.trimEnd());
 }
 
 export const formatOrgId = (orgId: TemplateStringsArray | string) =>

--- a/packages/cli/core/src/commands/org/resources/pull.ts
+++ b/packages/cli/core/src/commands/org/resources/pull.ts
@@ -122,7 +122,7 @@ export default class Pull extends CLICommand {
     if (await this.shouldDeleteSnapshot()) {
       await snapshot.delete();
     }
-    stopSpinner({message: 'Project updated'});
+    stopSpinner();
   }
 
   private async shouldDeleteSnapshot() {


### PR DESCRIPTION
<!-- For Coveo Employees only. Fill this section.

[CDX-1115](https://coveord.atlassian.net/browse/CDX-1115)

-->

## Proposed changes

- Remove `message` from the options of `stopSpinner`
- Remove the only usage
- Adapt E2E
- Fix the FIXME: `fancyIt` should not be used if no commands is instanciated. Instead, stderr-stdout should be used directly.

Motivation: From a UX perspective, the spinner in the CLI is used for 'Doing X, please wait'.
We don't need to say 'We've done X' after that, just to communicate the status of the operation. ✔️ and ❌ are perfect for that, so let's just use that and exclusively that.

## Breaking changes

Removed `message` from the options of `stopSpinner`.
It's technically a breaking change, sure we can consider that `@coveo/cli-commons` is so early that no one would be impacted. What I see here is the perfect excuse to test that the independent release works nice and proper ;)

## Testing

- [x] Unit Tests: adapted
- [x] Functional Tests: adapted


-----

⚠️  Should be merged with rebase strategy. ⚠️ 

