### PR TITLE
test(e2e): uplink all packages then publish

### DIFF
--- a/packages/cli-e2e/setup/ci-verdaccio.ts
+++ b/packages/cli-e2e/setup/ci-verdaccio.ts
@@ -4,20 +4,15 @@ import 'dotenv/config';
 
 import {npmLogin} from '../utils/npmLogin';
 import {startVerdaccio, shimNpm} from './utils/utils';
-import {
-  scaffoldDummyPackages,
-  publishPackages,
-  uplinkMissingPackages,
-} from './utils/verdaccio';
+import {scaffoldDummyPackages, publishPackages} from './utils/verdaccio';
 
 async function main() {
   global.processManager = new ProcessManager();
   shimNpm();
   await startVerdaccio();
   await npmLogin();
-  scaffoldDummyPackages();
+  await scaffoldDummyPackages();
   await publishPackages();
-  await uplinkMissingPackages();
   await global.processManager.killAllProcesses();
 }
 

--- a/packages/cli-e2e/setup/local.ts
+++ b/packages/cli-e2e/setup/local.ts
@@ -14,11 +14,7 @@ import {
   shimNpm,
 } from './utils/utils';
 import {join} from 'path';
-import {
-  scaffoldDummyPackages,
-  publishPackages,
-  uplinkMissingPackages,
-} from './utils/verdaccio';
+import {scaffoldDummyPackages, publishPackages} from './utils/verdaccio';
 
 export default async function () {
   shimNpm();
@@ -31,7 +27,6 @@ export default async function () {
   global.processManager = new ProcessManager();
   await startVerdaccio();
   await npmLogin();
-  scaffoldDummyPackages();
+  await scaffoldDummyPackages();
   await publishPackages();
-  await uplinkMissingPackages();
 }


### PR DESCRIPTION
<!-- For Coveo Employees only. Fill this section.

CDX-1162

-->

## Proposed changes

### Uplink first, publish changed packages after that
I thought that 'any' version of the package published prior would satisfy `npm version`, but no it need exactly the previous one.

To allow this, I changed how the scaffolding work: it now do what uplink was doing: copying all the existing packages into verdaccio.
This may seems counter-intuitive and one might think that we're not testing our code but the published packages, but that would not be the case, because only the unchanged packages will be untouched. The other will have a new package version published

### Ensure we published packages that are changed 'transitively'

Let's say I have a PR or release that only affects `@coveo/cli-commons`, in the current state, `@coveo/cli`would not be released/published on verdaccio. This changes that by checking if the `package.json`has been modified if there's been no commits affecting the package directory