### PR TITLE
build: skip changelog gen when no commits is semantic

### DIFF
--- a/scripts/releaseV2/phase1-bump-all-packages.mjs
+++ b/scripts/releaseV2/phase1-bump-all-packages.mjs
@@ -64,17 +64,19 @@ const rootFolder = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..');
     return;
   }
 
-  const changelog = await generateChangelog(
-    parsedCommits,
-    newVersion,
-    {
-      host: 'https://github.com',
-      owner: 'coveo',
-      repository: 'cli',
-    },
-    convention.writerOpts
-  );
-  await writeChangelog(PATH, changelog);
+  if (parsedCommits.length > 0) {
+    const changelog = await generateChangelog(
+      parsedCommits,
+      newVersion,
+      {
+        host: 'https://github.com',
+        owner: 'coveo',
+        repository: 'cli',
+      },
+      convention.writerOpts
+    );
+    await writeChangelog(PATH, changelog);
+  }
 
   await npmPublish();
 


### PR DESCRIPTION
<!-- For Coveo Employees only. Fill this section.

CDX-764

-->

## Proposed changes

Some `release:phase1` fails currently on the changelog generation when the parsedCommits array is empty.
When the array is empty, this means that there are no 'conventional commits'. We should not generate a changelog when that is the case.

## Testing

<!-- Did you write functionnal tests for your feature? If not, explains why?  -->
- [x] Manual Tests: ci/cd on https://github.com/coveo/cli/pull/964
