### PR TITLE
chore(release): better prefix

### DIFF
--- a/scripts/releaseV2/phase1-bump-all-packages.mjs
+++ b/scripts/releaseV2/phase1-bump-all-packages.mjs
@@ -41,7 +41,7 @@ const rootFolder = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..');
   const packageJson = JSON.parse(
     readFileSync('package.json', {encoding: 'utf-8'})
   );
-  const versionPrefix = packageJson.name;
+  const versionPrefix = `${packageJson.name}@`;
   const convention = await angularChangelogConvention;
   // TODO: CDX-1147 Remove catch
   const lastTag = await getLastTag(versionPrefix).catch(() =>


### PR DESCRIPTION
CDX-764

<!-- For Coveo Employees only. Fill this section.

CDX-764

-->

## Proposed changes

This is required to make sure:
 - `@coveo/cli` does not resolve on `@coveo/cli-commons` etc
 - Somehow it fixes angular/vue/react. No clue why if I'm honest.
