### PR TITLE
chore(release): just use checkout

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -103,8 +103,6 @@ jobs:
         with:
           # pulls all commits (needed for computing the next version)
           fetch-depth: 0
-      # pulls all tags (needed for computing the next version)
-      - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
       - uses: actions/setup-node@2fddd8803e2f5c9604345a0b591c3020ee971a93 # tag=v3
         with:
           node-version: ${{matrix.node}}

--- a/.github/workflows/daily-e2e.yml
+++ b/.github/workflows/daily-e2e.yml
@@ -77,8 +77,6 @@ jobs:
         with:
           # pulls all commits (needed for computing the next version)
           fetch-depth: 0
-      # pulls all tags (needed for computing the next version)
-      - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
       - name: Checkout last tag
         run: git checkout $(git describe --abbrev=0 --tags)
       - name: Install Coveo CLI

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,9 +64,6 @@ jobs:
         run: |
           git config --global user.email action@github.com
           git config --global user.name GitHub Action
-      # actions/checkout do a shallow clone, we need to unshallow the tags
-      - name: Get all tags
-        run: git fetch --prune --unshallow --tags
       - name: Setup git SSH remote
         env:
           DEPLOY_KEY: ${{ secrets.DEPLOY_KEY }}


### PR DESCRIPTION
<!-- For Coveo Employees only. Fill this section.

CDX-764

-->

## Proposed changes

#983 seems to worked because `git fetch --unshallow` and `git fetch --depth=1 origin +refs/tags/*:refs/tags/*` cancelled each other.
But when you check, using neither of them is working. Just don't use one alone.
https://github.com/coveo/cli/actions/runs/3252358715/jobs/5338480219

