### PR TITLE
chore(release): fix jenkins artifacting

### DIFF
--- a/scripts/get-release-artifact-and-commit-sha.mjs
+++ b/scripts/get-release-artifact-and-commit-sha.mjs
@@ -51,10 +51,10 @@ async function main() {
     );
   }
   // https://stackoverflow.com/a/1862542
-  const tagCommitPs = spawnSync('git', ['rev-list', '-n', '1', tag], {
+  const tagCommit = spawnSync('git', ['rev-list', '-n', '1', tag], {
     encoding: 'utf-8',
-  });
-  writeFileSync('latest-commit', tagCommitPs.stdout.trim());
+  }).stdout.trim();
+  writeFileSync('latest-commit', tagCommit);
 
   readdirSync(topLevelDirectory, {withFileTypes: true}).forEach((file) => {
     const match = binariesMatcher.exec(file.name);

--- a/scripts/get-release-artifact-and-commit-sha.mjs
+++ b/scripts/get-release-artifact-and-commit-sha.mjs
@@ -1,32 +1,28 @@
-import {getReleaseAssetsMetadata, getLastCliTag} from './github-client.js';
 import {
-  existsSync,
-  mkdirSync,
-  writeFileSync,
-  readdirSync,
-  copyFileSync,
-} from 'fs';
-import {resolve} from 'path';
+  getAssetsMetadataFromRelease,
+  getLastCliRelease,
+  getTagFromRelease,
+} from './github-client.js';
+import {mkdirSync, writeFileSync, readdirSync, copyFileSync} from 'fs';
+import {resolve, join} from 'path';
 import {execSync} from 'node:child_process';
+import {spawnSync} from 'child_process';
 
 async function main() {
-  const tag = await getLastCliTag();
+  const release = await getLastCliRelease();
+  const tag = getTagFromRelease(release);
   // This folder structure needs to be respected in order for the CLI update plugin to
   // be able to do it's job properly.
   const topLevelDirectory = './artifacts';
   const getSubDirectoryForTarball = ({version, commitSHA}) =>
-    [topLevelDirectory, 'versions', version, commitSHA].join('/');
-  const subDirectoryForManifest = [
-    topLevelDirectory,
-    'channels',
-    'stable',
-  ].join('/');
+    join(topLevelDirectory, 'versions', version, commitSHA);
+  const subDirectoryForManifest = join(topLevelDirectory, 'channels', 'stable');
   const binariesMatcher =
     /^coveo[_-]{1}(?<version>v?\d+\.\d+\.\d+(-\d+)?)[_.-]{1}(?<commitSHA>\w+)[_-]?(\d+_)?(?<longExt>.*\.(exe|deb|pkg))$/;
   const manifestMatcher =
-    /^coveo-(?<_version>v?\d+\.\d+\.\d+(-\d+)?)-(?<commitSHA>\w+)-(?<targetSignature>.*-buildmanifest)$/;
+    /^coveo-(?<version>v?\d+\.\d+\.\d+(-\d+)?)-(?<commitSHA>\w+)-(?<targetSignature>.*-buildmanifest)$/;
   const tarballMatcher =
-    /^coveo-(?<_version>v?\d+\.\d+\.\d+(-\d+)?)-(?<commitSHA>\w+)-(?<targetSignature>[\w-]+).tar\.[gx]z$/;
+    /^coveo-v?(?<version>\d+\.\d+\.\d+(-\d+)?)-(?<commitSHA>\w+)-(?<targetSignature>[\w-]+).tar\.[gx]z$/;
 
   const determineAssetLocation = (assetName) => {
     if (assetName.match(tarballMatcher)) {
@@ -43,26 +39,22 @@ async function main() {
     }
   };
 
-  [topLevelDirectory, subDirectoryForManifest, subDirectoryForTarball].forEach(
-    (dir) => {
-      if (!existsSync(dir)) {
-        mkdirSync(dir, {recursive: true});
-      }
-    }
-  );
-
-  const assets = await getReleaseAssetsMetadata(tag);
+  const assets = await getAssetsMetadataFromRelease(release);
   for (const asset of assets) {
     console.info(
       `Downloading asset ${asset.name} from ${asset.browser_download_url}.\nSize: ${asset.size} ...`
     );
     const directory = determineAssetLocation(asset.name);
+    mkdirSync(directory, {recursive: true});
     execSync(
       `curl -L ${asset.browser_download_url} --output ${directory}/${asset.name}`
     );
   }
-
-  writeFileSync('latest-commit', tagCommit);
+  // https://stackoverflow.com/a/1862542
+  const tagCommitPs = spawnSync('git', ['rev-list', '-n', '1', tag], {
+    encoding: 'utf-8',
+  });
+  writeFileSync('latest-commit', tagCommitPs.stdout.trim());
 
   readdirSync(topLevelDirectory, {withFileTypes: true}).forEach((file) => {
     const match = binariesMatcher.exec(file.name);

--- a/scripts/get-release-artifact-and-commit-sha.mjs
+++ b/scripts/get-release-artifact-and-commit-sha.mjs
@@ -1,4 +1,4 @@
-import {downloadReleaseAssets} from './github-client';
+import {downloadReleaseAssets} from './github-client.js';
 import {getLastTag} from '@coveo/semantic-monorepo-tools';
 import {
   existsSync,

--- a/scripts/github-client.js
+++ b/scripts/github-client.js
@@ -75,18 +75,19 @@ const createOrUpdateReleaseDescription = async (tag, body) => {
   }
 };
 
-const getLastCliTag = async () => {
-  return (await octokit.rest.repos.getLatestRelease({repo, owner})).data
-    .tag_name;
-};
+const getLastCliRelease = () =>
+  octokit.rest.repos.getLatestRelease({repo, owner});
 
-const getReleaseAssetsMetadata = async (tag) => {
-  const release = await octokit.rest.repos.getReleaseByTag({repo, owner, tag});
-  return octokit.rest.repos.listReleaseAssets({
-    owner,
-    repo,
-    release_id: release.data.id,
-  });
+const getTagFromRelease = (release) => release.data.tag_name;
+
+const getAssetsMetadataFromRelease = async (release) => {
+  return (
+    await octokit.rest.repos.listReleaseAssets({
+      owner,
+      repo,
+      release_id: release.data.id,
+    })
+  ).data;
 };
 
 const getSnykCodeAlerts = () => {
@@ -108,7 +109,8 @@ module.exports = {
   getBaseBranchName,
   getLatestTag,
   createOrUpdateReleaseDescription,
-  getReleaseAssetsMetadata,
+  getAssetsMetadataFromRelease,
   getSnykCodeAlerts,
-  getLastCliTag,
+  getLastCliRelease,
+  getTagFromRelease,
 };

--- a/scripts/github-client.js
+++ b/scripts/github-client.js
@@ -1,6 +1,5 @@
 /** @type {import("@actions/github")} */
 const github = require('@actions/github');
-const {execSync} = require('child_process');
 const octokit = github.getOctokit(process.env.GITHUB_CREDENTIALS);
 const owner = 'coveo';
 const repo = 'cli';
@@ -81,22 +80,12 @@ const getLastCliTag = async () => {
     .tag_name;
 };
 
-const downloadReleaseAssets = async (tag, determineAssetLocation) => {
+const getReleaseAssetsMetadata = async (tag) => {
   const release = await octokit.rest.repos.getReleaseByTag({repo, owner, tag});
-  const assets = await octokit.rest.repos.listReleaseAssets({
+  return octokit.rest.repos.listReleaseAssets({
     owner,
     repo,
     release_id: release.data.id,
-  });
-
-  assets.data.forEach((asset) => {
-    console.info(
-      `Downloading asset ${asset.name} from ${asset.browser_download_url}.\nSize: ${asset.size} ...`
-    );
-    const directory = determineAssetLocation(asset.name);
-    execSync(
-      `curl -L ${asset.browser_download_url} --output ${directory}/${asset.name}`
-    );
   });
 };
 
@@ -119,7 +108,7 @@ module.exports = {
   getBaseBranchName,
   getLatestTag,
   createOrUpdateReleaseDescription,
-  downloadReleaseAssets,
+  getReleaseAssetsMetadata,
   getSnykCodeAlerts,
   getLastCliTag,
 };

--- a/scripts/github-client.js
+++ b/scripts/github-client.js
@@ -76,6 +76,11 @@ const createOrUpdateReleaseDescription = async (tag, body) => {
   }
 };
 
+const getLastCliTag = async () => {
+  return (await octokit.rest.repos.getLatestRelease({repo, owner})).data
+    .tag_name;
+};
+
 const downloadReleaseAssets = async (tag, determineAssetLocation) => {
   const release = await octokit.rest.repos.getReleaseByTag({repo, owner, tag});
   const assets = await octokit.rest.repos.listReleaseAssets({
@@ -116,4 +121,5 @@ module.exports = {
   createOrUpdateReleaseDescription,
   downloadReleaseAssets,
   getSnykCodeAlerts,
+  getLastCliTag,
 };


### PR DESCRIPTION
<!-- For Coveo Employees only. Fill this section.

CDX-764

-->

## Proposed changes

- Fix ESM import (need file-ext)
- Recover tag from release (simpler)
- Infer file architecture from filename instead of 'redoing' oclif logic

## Testing

- [x] Manual Tests: Created a PAT and run it on my machine, checked the artifacts folder.