### PR TITLE
chore(release): fix release creation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "@commitlint/config-conventional": "17.1.0",
         "@commitlint/lint": "17.1.0",
         "@coveo/platform-client": "35.0.0",
-        "@coveo/semantic-monorepo-tools": "1.3.6",
+        "@coveo/semantic-monorepo-tools": "1.3.15",
         "@npmcli/arborist": "5.6.2",
         "@nrwl/cli": "latest",
         "@nrwl/workspace": "latest",
@@ -2406,9 +2406,9 @@
       "link": true
     },
     "node_modules/@coveo/semantic-monorepo-tools": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/@coveo/semantic-monorepo-tools/-/semantic-monorepo-tools-1.3.6.tgz",
-      "integrity": "sha512-GgNFqmAzrmzOzydxFEhCsJ2ru5/hK/zeGJcleKi73XoXleY18JWu4wbU1+h8Dmyrjeu4hayqkJmghl/1yjIUGQ==",
+      "version": "1.3.15",
+      "resolved": "https://registry.npmjs.org/@coveo/semantic-monorepo-tools/-/semantic-monorepo-tools-1.3.15.tgz",
+      "integrity": "sha512-rtAyy8jFR8Zvi9vwKpmSPnk+yWTRym97FC91GAXYi2FDD136E/F7Op6GdwX+W0ob1pkE7exZKfJQohNrDDPcLQ==",
       "dev": true,
       "dependencies": {
         "conventional-changelog-writer": "^5.0.1",
@@ -49911,53 +49911,6 @@
         "node": ">=14.16.1"
       }
     },
-    "packages/cli-e2e/node_modules/@coveo/cli-commons": {
-      "version": "1.36.0",
-      "resolved": "https://registry.npmjs.org/@coveo/cli-commons/-/cli-commons-1.36.0.tgz",
-      "integrity": "sha512-3DypenB9c+SUx+8zh0ias29Z8gLuf2VuQd0kxdEFYjNaq00a/71q6pFo2sO5BtVyoHWFZdVQ1mrCTFeyybXwRw==",
-      "dependencies": {
-        "@amplitude/node": "1.10.2",
-        "@coveord/platform-client": "34.13.0",
-        "@oclif/core": "1.16.3",
-        "abortcontroller-polyfill": "1.7.3",
-        "chalk": "4.1.2",
-        "fs-extra": "10.1.0",
-        "https-proxy-agent": "5.0.1",
-        "isomorphic-fetch": "3.0.0",
-        "semver": "7.3.7",
-        "ts-dedent": "2.2.0"
-      }
-    },
-    "packages/cli-e2e/node_modules/@coveo/cli-plugin-source": {
-      "version": "1.36.0",
-      "resolved": "https://registry.npmjs.org/@coveo/cli-plugin-source/-/cli-plugin-source-1.36.0.tgz",
-      "integrity": "sha512-RsoIhsWxV7/WaSv9hmFyJdkvOdTdraahMI13HE+2uqbqnd7vo9fvSS/Qob2to/j5pRmLENcBlhr6bYAfyqu9MQ==",
-      "dependencies": {
-        "@coveo/cli-commons": "1.36.0",
-        "@coveo/push-api-client": "2.5.15",
-        "@coveord/platform-client": "34.13.0",
-        "@oclif/core": "1.16.3",
-        "@oclif/plugin-help": "5.1.12",
-        "@oclif/plugin-plugins": "2.1.0",
-        "chalk": "4.1.2",
-        "jsonschema": "1.4.1",
-        "ts-dedent": "2.2.0"
-      },
-      "engines": {
-        "node": ">=14.15.1 <18"
-      }
-    },
-    "packages/cli-e2e/node_modules/@coveord/platform-client": {
-      "version": "34.13.0",
-      "resolved": "https://registry.npmjs.org/@coveord/platform-client/-/platform-client-34.13.0.tgz",
-      "integrity": "sha512-KqSDw+U4Jwb0p9i0HY3FZTOWe6vQEOEIU0/Myc+rL70s+LGPresBE55ac44maCP+xVZ5mE3YhABOfpvxNZ8BLw==",
-      "deprecated": "@coveord/platform-client has been replaced by @coveo/platform-client.",
-      "dependencies": {
-        "exponential-backoff": "^3.1.0",
-        "form-data": "^4.0.0",
-        "query-string": "^7.0.0"
-      }
-    },
     "packages/cli/commons": {
       "name": "@coveo/cli-commons",
       "version": "2.0.2",
@@ -52644,50 +52597,6 @@
         "typescript": "4.8.3",
         "verdaccio": "5.15.3",
         "wait-on": "6.0.1"
-      },
-      "dependencies": {
-        "@coveo/cli-commons": {
-          "version": "1.36.0",
-          "resolved": "https://registry.npmjs.org/@coveo/cli-commons/-/cli-commons-1.36.0.tgz",
-          "integrity": "sha512-3DypenB9c+SUx+8zh0ias29Z8gLuf2VuQd0kxdEFYjNaq00a/71q6pFo2sO5BtVyoHWFZdVQ1mrCTFeyybXwRw==",
-          "requires": {
-            "@amplitude/node": "1.10.2",
-            "@coveord/platform-client": "34.13.0",
-            "@oclif/core": "1.16.3",
-            "abortcontroller-polyfill": "1.7.3",
-            "chalk": "4.1.2",
-            "fs-extra": "10.1.0",
-            "https-proxy-agent": "5.0.1",
-            "isomorphic-fetch": "3.0.0",
-            "semver": "7.3.7",
-            "ts-dedent": "2.2.0"
-          }
-        },
-        "@coveo/cli-plugin-source": {
-          "version": "https://registry.npmjs.org/@coveo/cli-plugin-source/-/cli-plugin-source-1.36.0.tgz",
-          "integrity": "sha512-RsoIhsWxV7/WaSv9hmFyJdkvOdTdraahMI13HE+2uqbqnd7vo9fvSS/Qob2to/j5pRmLENcBlhr6bYAfyqu9MQ==",
-          "requires": {
-            "@coveo/cli-commons": "1.36.0",
-            "@coveo/push-api-client": "2.5.15",
-            "@coveord/platform-client": "34.13.0",
-            "@oclif/core": "1.16.3",
-            "@oclif/plugin-help": "5.1.12",
-            "@oclif/plugin-plugins": "2.1.0",
-            "chalk": "4.1.2",
-            "jsonschema": "1.4.1",
-            "ts-dedent": "2.2.0"
-          }
-        },
-        "@coveord/platform-client": {
-          "version": "34.13.0",
-          "resolved": "https://registry.npmjs.org/@coveord/platform-client/-/platform-client-34.13.0.tgz",
-          "integrity": "sha512-KqSDw+U4Jwb0p9i0HY3FZTOWe6vQEOEIU0/Myc+rL70s+LGPresBE55ac44maCP+xVZ5mE3YhABOfpvxNZ8BLw==",
-          "requires": {
-            "exponential-backoff": "^3.1.0",
-            "form-data": "^4.0.0",
-            "query-string": "^7.0.0"
-          }
-        }
       }
     },
     "@coveo/cli-plugin-source": {
@@ -53225,9 +53134,9 @@
       }
     },
     "@coveo/semantic-monorepo-tools": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/@coveo/semantic-monorepo-tools/-/semantic-monorepo-tools-1.3.6.tgz",
-      "integrity": "sha512-GgNFqmAzrmzOzydxFEhCsJ2ru5/hK/zeGJcleKi73XoXleY18JWu4wbU1+h8Dmyrjeu4hayqkJmghl/1yjIUGQ==",
+      "version": "1.3.15",
+      "resolved": "https://registry.npmjs.org/@coveo/semantic-monorepo-tools/-/semantic-monorepo-tools-1.3.15.tgz",
+      "integrity": "sha512-rtAyy8jFR8Zvi9vwKpmSPnk+yWTRym97FC91GAXYi2FDD136E/F7Op6GdwX+W0ob1pkE7exZKfJQohNrDDPcLQ==",
       "dev": true,
       "requires": {
         "conventional-changelog-writer": "^5.0.1",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@commitlint/config-conventional": "17.1.0",
     "@commitlint/lint": "17.1.0",
     "@coveo/platform-client": "35.0.0",
-    "@coveo/semantic-monorepo-tools": "1.3.6",
+    "@coveo/semantic-monorepo-tools": "1.3.15",
     "@npmcli/arborist": "5.6.2",
     "@nrwl/cli": "latest",
     "@nrwl/workspace": "latest",


### PR DESCRIPTION
<!-- For Coveo Employees only. Fill this section.

CDX-1208

-->

## Proposed changes

 - Extract the release from the '.git-message': fewer processes, more reliable.
 - Extract the changelog from the generated changelog of the CLI and only the CLI.
 - Update semantic-monorepo-tools for emoji support (very important)
 - Nothing changes for the 'compare to': GitHub API is not ready. See: https://github.com/community/community/discussions/13434

## Testing

- [x] Manual Tests: checked the values of the variables prior to call GH, they had proper values.