### PR TITLE
fix(gha): replace set-output

### DIFF
--- a/.github/actions/e2e-login/action.yml
+++ b/.github/actions/e2e-login/action.yml
@@ -42,4 +42,4 @@ runs:
       id: setup
       run: |
         echo "${{ env.E2E_TOKEN_PASSPHRASE }}" | gpg -a --batch --passphrase-fd 0 --symmetric --cipher-algo AES256 --output encodedConfig $CLI_CONFIG_PATH
-        echo "::set-output name=cliConfigJson::$(base64 -w 0 encodedConfig)"
+        echo "cliConfigJson=$(base64 -w 0 encodedConfig)" >> $GITHUB_OUTPUT


### PR DESCRIPTION
<!-- For Coveo Employees only. Fill this section.

CDX-1224

-->

## Proposed changes

https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

Testing: CI/CD, if it works, :shipit: 