### PR TITLE
test(e2e): increase timeout for `openNewPage`

### DIFF
--- a/packages/cli-e2e/__tests__/angular.specs.ts
+++ b/packages/cli-e2e/__tests__/angular.specs.ts
@@ -177,7 +177,7 @@ describe('ui:create:angular', () => {
     jest.resetModules();
     process.env = {...oldEnv};
     page = await openNewPage(browser, page);
-  });
+  }, 30e3);
 
   afterEach(async () => {
     await captureScreenshots(browser);

--- a/packages/cli-e2e/__tests__/atomic.specs.ts
+++ b/packages/cli-e2e/__tests__/atomic.specs.ts
@@ -224,7 +224,7 @@ describe('ui:create:atomic', () => {
         if (!skipBrowser) {
           page = await openNewPage(browser, page);
         }
-      });
+      }, 30e3);
 
       afterEach(async () => {
         if (!skipBrowser) {

--- a/packages/cli-e2e/__tests__/react.specs.ts
+++ b/packages/cli-e2e/__tests__/react.specs.ts
@@ -118,7 +118,7 @@ describe('ui:create:react', () => {
     jest.resetModules();
     process.env = {...oldEnv};
     page = await openNewPage(browser, page);
-  });
+  }, 30e3);
 
   afterEach(async () => {
     await captureScreenshots(browser);

--- a/packages/cli-e2e/__tests__/vue.specs.ts
+++ b/packages/cli-e2e/__tests__/vue.specs.ts
@@ -118,7 +118,7 @@ describe('ui:create:vue', () => {
     jest.resetModules();
     process.env = {...oldEnv};
     page = await openNewPage(browser, page);
-  });
+  }, 30e3);
 
   afterEach(async () => {
     await captureScreenshots(browser);


### PR DESCRIPTION


<!-- For Coveo Employees only. Fill this section.
https://coveord.atlassian.net/browse/CDX-1225
-->

## Proposed changes

Currently, the default timeout is 5 seconds. It's quite easy to hit recently with Windows and create silly instability. So let's bump it up.

## Testing

E2E CI/CD