### PR TITLE
docs(core): fix links

### DIFF
--- a/packages/cli/core/README.md
+++ b/packages/cli/core/README.md
@@ -96,7 +96,7 @@ EXAMPLES
   $ coveo auth:login
 ```
 
-_See code: [src/commands/auth/login.ts](https://github.com/coveo/cli/blob/v1.37.2/packages/cli/core/src/commands/auth/login.ts)_
+_See code: [src/commands/auth/login.ts](https://github.com/coveo/cli/blob/@coveo/cli@1.37.2/packages/cli/core/src/commands/auth/login.ts)_
 
 ## `coveo auth:token`
 
@@ -122,7 +122,7 @@ EXAMPLES
   $ coveo auth:token
 ```
 
-_See code: [src/commands/auth/token.ts](https://github.com/coveo/cli/blob/v1.37.2/packages/cli/core/src/commands/auth/token.ts)_
+_See code: [src/commands/auth/token.ts](https://github.com/coveo/cli/blob/@coveo/cli@1.37.2/packages/cli/core/src/commands/auth/token.ts)_
 
 ## `coveo config:get [KEY]`
 
@@ -152,7 +152,7 @@ EXAMPLES
     $ coveo config:get accessToken
 ```
 
-_See code: [src/commands/config/get.ts](https://github.com/coveo/cli/blob/v1.37.2/packages/cli/core/src/commands/config/get.ts)_
+_See code: [src/commands/config/get.ts](https://github.com/coveo/cli/blob/@coveo/cli@1.37.2/packages/cli/core/src/commands/config/get.ts)_
 
 ## `coveo config:set`
 
@@ -175,7 +175,7 @@ EXAMPLES
     $ coveo config:set --organization myOrgId
 ```
 
-_See code: [src/commands/config/set.ts](https://github.com/coveo/cli/blob/v1.37.2/packages/cli/core/src/commands/config/set.ts)_
+_See code: [src/commands/config/set.ts](https://github.com/coveo/cli/blob/@coveo/cli@1.37.2/packages/cli/core/src/commands/config/set.ts)_
 
 ## `coveo help [COMMAND]`
 
@@ -215,7 +215,7 @@ DESCRIPTION
   Create a new test Coveo organization.
 ```
 
-_See code: [src/commands/org/create.ts](https://github.com/coveo/cli/blob/v1.37.2/packages/cli/core/src/commands/org/create.ts)_
+_See code: [src/commands/org/create.ts](https://github.com/coveo/cli/blob/@coveo/cli@1.37.2/packages/cli/core/src/commands/org/create.ts)_
 
 ## `coveo org:list`
 
@@ -241,7 +241,7 @@ DESCRIPTION
   List Coveo organizations.
 ```
 
-_See code: [src/commands/org/list.ts](https://github.com/coveo/cli/blob/v1.37.2/packages/cli/core/src/commands/org/list.ts)_
+_See code: [src/commands/org/list.ts](https://github.com/coveo/cli/blob/@coveo/cli@1.37.2/packages/cli/core/src/commands/org/list.ts)_
 
 ## `coveo org:resources:list`
 
@@ -272,7 +272,7 @@ EXAMPLES
   $ coveo org:resources:list -o=myOrgId
 ```
 
-_See code: [src/commands/org/resources/list.ts](https://github.com/coveo/cli/blob/v1.37.2/packages/cli/core/src/commands/org/resources/list.ts)_
+_See code: [src/commands/org/resources/list.ts](https://github.com/coveo/cli/blob/@coveo/cli@1.37.2/packages/cli/core/src/commands/org/resources/list.ts)_
 
 ## `coveo org:resources:model:create`
 
@@ -286,7 +286,7 @@ DESCRIPTION
   Create a Snapshot Pull Model
 ```
 
-_See code: [src/commands/org/resources/model/create.ts](https://github.com/coveo/cli/blob/v1.37.2/packages/cli/core/src/commands/org/resources/model/create.ts)_
+_See code: [src/commands/org/resources/model/create.ts](https://github.com/coveo/cli/blob/@coveo/cli@1.37.2/packages/cli/core/src/commands/org/resources/model/create.ts)_
 
 ## `coveo org:resources:monitor SNAPSHOTID`
 
@@ -315,7 +315,7 @@ EXAMPLES
     $ coveo org:resources:monitor --organization myorgid --snapshotId mysnapshotid
 ```
 
-_See code: [src/commands/org/resources/monitor.ts](https://github.com/coveo/cli/blob/v1.37.2/packages/cli/core/src/commands/org/resources/monitor.ts)_
+_See code: [src/commands/org/resources/monitor.ts](https://github.com/coveo/cli/blob/@coveo/cli@1.37.2/packages/cli/core/src/commands/org/resources/monitor.ts)_
 
 ## `coveo org:resources:preview`
 
@@ -351,7 +351,7 @@ EXAMPLES
   $ coveo org:resources:preview -o=myOrgId -d
 ```
 
-_See code: [src/commands/org/resources/preview.ts](https://github.com/coveo/cli/blob/v1.37.2/packages/cli/core/src/commands/org/resources/preview.ts)_
+_See code: [src/commands/org/resources/preview.ts](https://github.com/coveo/cli/blob/@coveo/cli@1.37.2/packages/cli/core/src/commands/org/resources/preview.ts)_
 
 ## `coveo org:resources:pull`
 
@@ -406,7 +406,7 @@ EXAMPLES
     $ coveo org:resources:pull --resourceTypes QUERY_PIPELINE FIELD,
 ```
 
-_See code: [src/commands/org/resources/pull.ts](https://github.com/coveo/cli/blob/v1.37.2/packages/cli/core/src/commands/org/resources/pull.ts)_
+_See code: [src/commands/org/resources/pull.ts](https://github.com/coveo/cli/blob/@coveo/cli@1.37.2/packages/cli/core/src/commands/org/resources/pull.ts)_
 
 ## `coveo org:resources:push`
 
@@ -450,7 +450,7 @@ EXAMPLES
     $ coveo org:resources:push --deleteMissingResources
 ```
 
-_See code: [src/commands/org/resources/push.ts](https://github.com/coveo/cli/blob/v1.37.2/packages/cli/core/src/commands/org/resources/push.ts)_
+_See code: [src/commands/org/resources/push.ts](https://github.com/coveo/cli/blob/@coveo/cli@1.37.2/packages/cli/core/src/commands/org/resources/push.ts)_
 
 ## `coveo org:search:dump`
 
@@ -495,7 +495,7 @@ EXAMPLES
     $ coveo org:search:dump --fieldsToExclude ec_description ec_summary
 ```
 
-_See code: [src/commands/org/search/dump.ts](https://github.com/coveo/cli/blob/v1.37.2/packages/cli/core/src/commands/org/search/dump.ts)_
+_See code: [src/commands/org/search/dump.ts](https://github.com/coveo/cli/blob/@coveo/cli@1.37.2/packages/cli/core/src/commands/org/search/dump.ts)_
 
 ## `coveo plugins`
 
@@ -785,7 +785,7 @@ DESCRIPTION
   Index a JSON document into a Coveo Catalog source. See https://docs.coveo.com/en/2956 for more information.
 ```
 
-_See code: [@coveo/cli-plugin-source](https://github.com/coveo/cli/blob/v1.37.2/packages/cli/source/src/commands/source/catalog/add.ts)_
+_See code: [@coveo/cli-plugin-source](https://github.com/coveo/cli/blob/@coveo/cli@1.37.2/packages/cli/source/src/commands/source/catalog/add.ts)_
 
 ## `coveo source:catalog:new NAME`
 
@@ -807,7 +807,7 @@ DESCRIPTION
   Create a new catalog source in a Coveo organization
 ```
 
-_See code: [@coveo/cli-plugin-source](https://github.com/coveo/cli/blob/v1.37.2/packages/cli/source/src/commands/source/catalog/new.ts)_
+_See code: [@coveo/cli-plugin-source](https://github.com/coveo/cli/blob/@coveo/cli@1.37.2/packages/cli/source/src/commands/source/catalog/new.ts)_
 
 ## `coveo source:list`
 
@@ -833,7 +833,7 @@ DESCRIPTION
   List all available push sources in your Coveo organization
 ```
 
-_See code: [@coveo/cli-plugin-source](https://github.com/coveo/cli/blob/v1.37.2/packages/cli/source/src/commands/source/list.ts)_
+_See code: [@coveo/cli-plugin-source](https://github.com/coveo/cli/blob/@coveo/cli@1.37.2/packages/cli/source/src/commands/source/list.ts)_
 
 ## `coveo source:push:add SOURCEID`
 
@@ -864,7 +864,7 @@ DESCRIPTION
   https://github.com/coveo/cli/wiki/Pushing-JSON-Files-with-the-Coveo-CLI for more information.
 ```
 
-_See code: [@coveo/cli-plugin-source](https://github.com/coveo/cli/blob/v1.37.2/packages/cli/source/src/commands/source/push/add.ts)_
+_See code: [@coveo/cli-plugin-source](https://github.com/coveo/cli/blob/@coveo/cli@1.37.2/packages/cli/source/src/commands/source/push/add.ts)_
 
 ## `coveo source:push:delete SOURCEID`
 
@@ -896,7 +896,7 @@ DESCRIPTION
   <https://docs.coveo.com/en/131>
 ```
 
-_See code: [@coveo/cli-plugin-source](https://github.com/coveo/cli/blob/v1.37.2/packages/cli/source/src/commands/source/push/delete.ts)_
+_See code: [@coveo/cli-plugin-source](https://github.com/coveo/cli/blob/@coveo/cli@1.37.2/packages/cli/source/src/commands/source/push/delete.ts)_
 
 ## `coveo source:push:new NAME`
 
@@ -918,7 +918,7 @@ DESCRIPTION
   Create a new push source in a Coveo organization
 ```
 
-_See code: [@coveo/cli-plugin-source](https://github.com/coveo/cli/blob/v1.37.2/packages/cli/source/src/commands/source/push/new.ts)_
+_See code: [@coveo/cli-plugin-source](https://github.com/coveo/cli/blob/@coveo/cli@1.37.2/packages/cli/source/src/commands/source/push/new.ts)_
 
 ## `coveo ui:create:angular NAME`
 
@@ -940,7 +940,7 @@ DESCRIPTION
   <https://angular.io/>.
 ```
 
-_See code: [src/commands/ui/create/angular.ts](https://github.com/coveo/cli/blob/v1.37.2/packages/cli/core/src/commands/ui/create/angular.ts)_
+_See code: [src/commands/ui/create/angular.ts](https://github.com/coveo/cli/blob/@coveo/cli@1.37.2/packages/cli/core/src/commands/ui/create/angular.ts)_
 
 ## `coveo ui:create:atomic NAME`
 
@@ -965,7 +965,7 @@ EXAMPLES
   $ coveo ui:create:atomic myapp
 ```
 
-_See code: [src/commands/ui/create/atomic.ts](https://github.com/coveo/cli/blob/v1.37.2/packages/cli/core/src/commands/ui/create/atomic.ts)_
+_See code: [src/commands/ui/create/atomic.ts](https://github.com/coveo/cli/blob/@coveo/cli@1.37.2/packages/cli/core/src/commands/ui/create/atomic.ts)_
 
 ## `coveo ui:create:react NAME`
 
@@ -991,7 +991,7 @@ EXAMPLES
   $ coveo ui:create:react --help
 ```
 
-_See code: [src/commands/ui/create/react.ts](https://github.com/coveo/cli/blob/v1.37.2/packages/cli/core/src/commands/ui/create/react.ts)_
+_See code: [src/commands/ui/create/react.ts](https://github.com/coveo/cli/blob/@coveo/cli@1.37.2/packages/cli/core/src/commands/ui/create/react.ts)_
 
 ## `coveo ui:create:vue NAME`
 
@@ -1021,7 +1021,7 @@ EXAMPLES
   $ coveo ui:create:vue --help
 ```
 
-_See code: [src/commands/ui/create/vue.ts](https://github.com/coveo/cli/blob/v1.37.2/packages/cli/core/src/commands/ui/create/vue.ts)_
+_See code: [src/commands/ui/create/vue.ts](https://github.com/coveo/cli/blob/@coveo/cli@1.37.2/packages/cli/core/src/commands/ui/create/vue.ts)_
 
 ## `coveo update [CHANNEL]`
 


### PR DESCRIPTION
<!-- For Coveo Employees only. Fill this section.

CDX-1216 https://coveord.atlassian.net/browse/CDX-1216

-->

## Proposed changes

We are using `@coveo/cli@X.Y.Z` for tags. not `vX.Y.Z`.

This fix the readme for now, will fix the gen on another PR

## Testing

Just click a link.
