### PR TITLE
fix: abort pending requests

### DIFF
--- a/packages/cli/core/src/lib/snapshot/snapshot.spec.ts
+++ b/packages/cli/core/src/lib/snapshot/snapshot.spec.ts
@@ -50,6 +50,7 @@ const mockedDeleteSnapshot = jest.fn();
 const mockedGetSnapshot = jest.fn();
 const mockedExportSnapshot = jest.fn();
 const mockedApplySnapshot = jest.fn();
+const mockedAbortPendingGetRequests = jest.fn();
 const mockedDryRunSnapshot = jest.fn();
 const mockedGetClient = jest.fn();
 const mockedEnsureSnapshotAccess = jest.mocked(ensureSnapshotAccess);
@@ -83,6 +84,7 @@ describe('Snapshot', () => {
   const doMockAuthenticatedClient = () => {
     mockedGetClient.mockImplementation(() =>
       Promise.resolve({
+        abortPendingGetRequests: mockedAbortPendingGetRequests,
         resourceSnapshot: {
           createFromBuffer: mockedCreateSnapshotFromBuffer,
           push: mockedPushSnapshot,

--- a/packages/cli/core/src/lib/snapshot/snapshot.ts
+++ b/packages/cli/core/src/lib/snapshot/snapshot.ts
@@ -236,6 +236,7 @@ export class Snapshot {
     operationToWaitFor?: ResourceSnapshotsReportType
   ): () => Promise<void> {
     return (async () => {
+      await this.client.abortPendingGetRequests();
       await this.refreshSnapshotData();
 
       const isUnsettled = this.isUnsettled();


### PR DESCRIPTION
https://coveord.atlassian.net/browse/CDX-1232

<!-- For Coveo Employees only. Fill this section.

CDX-XXX

-->

## Proposed changes

Abort pending requests to avoid exceeding the maximum amount of event listeners allowed by the process.
Otherwise,  the following error will occur:
```
(node:54396) MaxListenersExceededWarning: Possible EventTarget memory leak detected. 11 abort listeners added to [AbortSignal]. Use events.setMaxListeners() to increase limit
```

### TL;DR;
Too many requests with the same PlatformClient instance can cause memory leaks.

### Long explanation
Every new instance of PlatformClient will instantiate a new AbortController object. This controller is used by the Fetch API on every HTTPS requests to handle abort events from the DOM.

However, on every request, fetch adds a new abort listener to the same AbortSignal (signal associated to the AbortController). At a certain point, the limit of listener exceed the maximum authorized by the process and return MaxListenersExceededWarning warning.
To avoid this issue, we can ask for a new Abort Controller when we retry the same request. This is what the abortPendingGetRequests is doing. It aborts the existing requests and associates a new AbortController instance to the same PlatformClient instance


<!--
    Remove this section if the PR does not include any breaking change

    If your changes includes some breaking changes in the code, thoroughly explains:
        - What are the breaking changes programmatically speaking.
        - What is the impact on the end-user (e.g. user cannot do X anymore).
        - What motivates those changes.
-->

## Testing

- [ ] Unit Tests:
<!-- Did you write unit tests for your feature? If not, explains why?  -->
- [ ] Functionnal Tests:
<!-- Did you write functionnal tests for your feature? If not, explains why?  -->
- [ ] Manual Tests:
<!-- How did you test your changeset?  -->
