### PR TITLE
chore(cd): map linux to deb, darwin to macos

### DIFF
--- a/scripts/get-commit-short-hash.mjs
+++ b/scripts/get-commit-short-hash.mjs
@@ -3,8 +3,14 @@ import {readdirSync} from 'node:fs';
 import {join} from 'node:path';
 import {binariesMatcher} from './oclifArtifactMatchers.mjs';
 
+const platformToDirMap = {
+  'darwin':'macos',
+  'linux': 'deb',
+  'win32': 'win32'
+}
+
 // Should be executed at the root of the CLI workspace.
-const pathToArtifacts = join('dist', process.platform);
+const pathToArtifacts = join('dist', platformToDirMap[process.platform]);
 const artifacts = readdirSync(pathToArtifacts, {withFileTypes: true});
 const someExe = artifacts.find(
   (candidate) => candidate.isFile() && candidate.name.endsWith('.exe')

--- a/scripts/get-commit-short-hash.mjs
+++ b/scripts/get-commit-short-hash.mjs
@@ -4,10 +4,10 @@ import {join} from 'node:path';
 import {binariesMatcher} from './oclifArtifactMatchers.mjs';
 
 const platformToDirMap = {
-  'darwin':'macos',
-  'linux': 'deb',
-  'win32': 'win32'
-}
+  darwin: 'macos',
+  linux: 'deb',
+  win32: 'win32',
+};
 
 // Should be executed at the root of the CLI workspace.
 const pathToArtifacts = join('dist', platformToDirMap[process.platform]);


### PR DESCRIPTION
<!-- For Coveo Employees only. Fill this section.

CDX-764

-->

## Proposed changes

I assumed that oclif was always using `process.plaform`, well they don't :finnadie: 
