### PR TITLE
chore(cd): fix condition to match properly on linux and mac

### DIFF
--- a/scripts/get-commit-short-hash.mjs
+++ b/scripts/get-commit-short-hash.mjs
@@ -13,7 +13,7 @@ const platformToDirMap = {
 const pathToArtifacts = join('dist', platformToDirMap[process.platform]);
 const artifacts = readdirSync(pathToArtifacts, {withFileTypes: true});
 const someExe = artifacts.find(
-  (candidate) => candidate.isFile() && candidate.name.endsWith('.exe')
+  (candidate) => candidate.isFile() && /\.(exe|deb|pkg)$/.test(candidate.name)
 );
 
 if (!binariesMatcher.exec(someExe.name)?.groups?.commitSHA) {


### PR DESCRIPTION
<!-- For Coveo Employees only. Fill this section.

[CDX-764](https://coveord.atlassian.net/browse/CDX-764)

-->

## Proposed changes

There are no `.exe` generated on linux and macos, thus the script was failing. This fix that. 
## Testing

- [x] Manual Tests:
Run the workflow by hand locally.
