### PR TITLE
chore: make arborist run at the right cwd

### DIFF
--- a/patches/oclif+3.4.2.patch
+++ b/patches/oclif+3.4.2.patch
@@ -1,5 +1,5 @@
 diff --git a/node_modules/oclif/lib/tarballs/build.js b/node_modules/oclif/lib/tarballs/build.js
-index 6dc6c06..14dc008 100644
+index 6dc6c06..c17846e 100644
 --- a/node_modules/oclif/lib/tarballs/build.js
 +++ b/node_modules/oclif/lib/tarballs/build.js
 @@ -11,6 +11,7 @@ const upload_util_1 = require("../upload-util");
@@ -30,7 +30,7 @@ index 6dc6c06..14dc008 100644
 +                path.join(workspaceRoot, 'package-lock.json') :
 +                path.join(workspaceRoot, 'npm-shrinkwrap.json');
              await fs.copy(lockpath, path.join(c.workspace(), path.basename(lockpath)));
-+            const arb = new Arborist();
++            const arb = new Arborist({path: c.workspace()});
 +            await arb.loadVirtual();
 +            await arb.buildIdealTree({
 +              update: {


### PR DESCRIPTION
<!-- For Coveo Employees only. Fill this section.

CDX-764

-->

## Proposed changes

https://github.com/coveo/cli/commit/f218b3f2d8070890da1501622f34b757cd2ad3d9

Before, oclif was changing the cwd of the process, making arborist work without setting path. Now that it doesn't, we need to specify the path option, like they did for other stuff.
