### PR TITLE
refactor(fetch): use fetch-undici-polyfill

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12869,6 +12869,14 @@
         "pend": "~1.2.0"
       }
     },
+    "node_modules/fetch-undici-polyfill": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/fetch-undici-polyfill/-/fetch-undici-polyfill-1.1.1.tgz",
+      "integrity": "sha512-GU37KtVxsai0cFZXxpIXgWTKR1AZSk1FaKpoQSkAO7CPJzJ9GEm9oyS9CYqU2XYB0oNya7ydhgZ/m+fjEXsSuQ==",
+      "dependencies": {
+        "undici": "latest"
+      }
+    },
     "node_modules/figures": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
@@ -26521,10 +26529,10 @@
         "abortcontroller-polyfill": "^1.7.1",
         "archiver": "^5.3.0",
         "async-retry": "^1.3.1",
-        "axios": "^1.0.0",
         "chalk": "4.1.2",
         "cli-progress": "^3.9.1",
         "extract-zip": "^2.0.1",
+        "fetch-undici-polyfill": "1.1.1",
         "fs-extra": "^10.0.0",
         "get-port": "5.1.1",
         "https-proxy-agent": "^5.0.0",
@@ -26537,8 +26545,7 @@
         "semver": "^7.3.4",
         "tmp": "^0.2.1",
         "ts-dedent": "2.2.0",
-        "tslib": "2.4.1",
-        "undici": "5.15.0"
+        "tslib": "2.4.1"
       },
       "bin": {
         "coveo": "bin/run"
@@ -27094,7 +27101,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@coveo/platform-client": "37.13.0",
-        "undici": "5.15.0"
+        "fetch-undici-polyfill": "1.1.1"
       },
       "devDependencies": {
         "@babel/core": "7.20.12",
@@ -27332,11 +27339,11 @@
         "@vue/tsconfig": "^0.1.3",
         "eslint": "^8.22.0",
         "eslint-plugin-vue": "^9.3.0",
+        "fetch-undici-polyfill": "1.1.1",
         "npm-run-all": "^4.1.5",
         "prettier": "^2.7.1",
         "sass": "^1.55.0",
         "typescript": "~4.9.0",
-        "undici": "^5.11.0",
         "vite": "4.0.4",
         "vite-plugin-vuetify": "^1.0.1",
         "vue-tsc": "^1.0.8"

--- a/packages/cli-e2e/__tests__/__snapshots__/atomic.specs.ts.snap
+++ b/packages/cli-e2e/__tests__/__snapshots__/atomic.specs.ts.snap
@@ -14,7 +14,7 @@ HashedFolder {
                   "name": "areEnvironmentVariablesSet.ts",
                 },
                 HashedFile {
-                  "hash": "qJrXPWX6cL4N+TMvhr6+n05vNwk=",
+                  "hash": "3/G6brNR4QRqiJlaY/m/fsyTzzc=",
                   "name": "generateToken.ts",
                 },
                 HashedFile {
@@ -26,11 +26,11 @@ HashedFolder {
                   "name": "token.ts",
                 },
               ],
-              "hash": "qIYVWdq8oh9lCcu0H1X5XfQchcU=",
+              "hash": "pmEnQcGTj9o9+LzhyIv1naaY/ak=",
               "name": "token",
             },
           ],
-          "hash": "sBgXQK+6u5b7XzuUi8zQquqUtaU=",
+          "hash": "AYAizlKrvz2mLJQE53WMgok4NBY=",
           "name": "functions",
         },
         HashedFile {
@@ -54,7 +54,7 @@ HashedFolder {
           "name": "tsconfig.json",
         },
       ],
-      "hash": "MVuHWG3A8rTxFYXfcqRQA/UkK7s=",
+      "hash": "H4lv26/ky0DGVWpNK4hd7vom80g=",
       "name": "lambda",
     },
     HashedFile {
@@ -160,7 +160,7 @@ HashedFolder {
       "name": "tsconfig.json",
     },
   ],
-  "hash": "IYPZbhHV11MiatYxNfpMNg0GDQ4=",
+  "hash": "qiJ6tOeVT+G3Ixxup+ax7h1yJpo=",
   "name": "normalizedDir",
 }
 `;

--- a/packages/cli/core/package.json
+++ b/packages/cli/core/package.json
@@ -21,7 +21,6 @@
     "abortcontroller-polyfill": "^1.7.1",
     "archiver": "^5.3.0",
     "async-retry": "^1.3.1",
-    "axios": "^1.0.0",
     "chalk": "4.1.2",
     "cli-progress": "^3.9.1",
     "extract-zip": "^2.0.1",
@@ -38,7 +37,7 @@
     "tmp": "^0.2.1",
     "ts-dedent": "2.2.0",
     "tslib": "2.4.1",
-    "undici": "5.15.0"
+    "fetch-undici-polyfill": "1.1.1"
   },
   "devDependencies": {
     "@amplitude/types": "1.10.2",

--- a/packages/cli/core/src/lib/oauth/oauthClientServer.spec.ts
+++ b/packages/cli/core/src/lib/oauth/oauthClientServer.spec.ts
@@ -111,7 +111,7 @@ describe('OAuthClientServer', () => {
             method: 'POST',
             body: new URLSearchParams(expectedParams),
             headers: {
-              Authentication: 'Basic Y2xpOmNsaQ==',
+              Authorization: 'Basic Y2xpOmNsaQ==',
               'Content-Type': 'application/x-www-form-urlencoded',
             },
           })

--- a/packages/cli/core/src/lib/oauth/oauthClientServer.ts
+++ b/packages/cli/core/src/lib/oauth/oauthClientServer.ts
@@ -60,9 +60,9 @@ export class OAuthClientServer {
 
     return {
       'Content-Type': 'application/x-www-form-urlencoded',
-      Authentication: `Basic ${Buffer.from(
-        `${client_id}:${client_id}`
-      ).toString('base64')}`,
+      Authorization: `Basic ${Buffer.from(`${client_id}:${client_id}`).toString(
+        'base64'
+      )}`,
     };
   }
 

--- a/packages/cli/core/src/lib/oauth/oauthClientServer.ts
+++ b/packages/cli/core/src/lib/oauth/oauthClientServer.ts
@@ -29,10 +29,10 @@ export class OAuthClientServer {
             if (state !== expectedState) {
               throw new InvalidStateError(state, expectedState);
             }
-            const data = this.getTokenQueryString(code);
+            const body = this.getTokenQueryString(code);
             const authRequest = await fetch(tokenEndpoint, {
               method: 'POST',
-              body: JSON.stringify(data),
+              body,
               headers: this.requestHeaders,
             });
             const {access_token: accessToken} =

--- a/packages/cli/core/src/lib/oauth/oauthClientServer.ts
+++ b/packages/cli/core/src/lib/oauth/oauthClientServer.ts
@@ -1,9 +1,8 @@
-import axios, {AxiosRequestConfig} from 'axios';
+import 'fetch-undici-polyfill';
 import {createServer, IncomingMessage, Server, ServerResponse} from 'http';
 import {URL, URLSearchParams} from 'url';
 import {AuthorizationError, InvalidStateError} from './authorizationError';
 import {AuthorizationServiceConfiguration, ClientConfig} from './oauthConfig';
-
 interface AccessTokenResponse {
   access_token: string;
 }
@@ -30,14 +29,14 @@ export class OAuthClientServer {
             if (state !== expectedState) {
               throw new InvalidStateError(state, expectedState);
             }
-
             const data = this.getTokenQueryString(code);
-            const authRequest = await axios.post<AccessTokenResponse>(
-              tokenEndpoint,
-              data,
-              this.requestConfig
-            );
-            const accessToken = authRequest.data.access_token;
+            const authRequest = await fetch(tokenEndpoint, {
+              method: 'POST',
+              body: JSON.stringify(data),
+              headers: this.requestHeaders,
+            });
+            const {access_token: accessToken} =
+              (await authRequest.json()) as AccessTokenResponse;
 
             res.end('Close your browser to continue');
             resolve({accessToken});
@@ -56,17 +55,15 @@ export class OAuthClientServer {
     return serverPromise;
   }
 
-  private get requestConfig(): AxiosRequestConfig {
+  private get requestHeaders(): Record<string, string> {
     const {client_id} = this.clientConfig;
-    const config: AxiosRequestConfig = {
-      headers: {'Content-Type': 'application/x-www-form-urlencoded'},
-      auth: {
-        username: client_id,
-        password: client_id,
-      },
-    };
 
-    return config;
+    return {
+      'Content-Type': 'application/x-www-form-urlencoded',
+      Authentication: `Basic ${Buffer.from(
+        `${client_id}:${client_id}`
+      ).toString('base64')}`,
+    };
   }
 
   private parseUrl(req: IncomingMessage) {

--- a/packages/ui/search-token-lambda/functions/token/generateToken.ts
+++ b/packages/ui/search-token-lambda/functions/token/generateToken.ts
@@ -1,8 +1,4 @@
-import {fetch} from 'undici';
-
-if (!Object.keys(global).includes('fetch')) {
-  Object.defineProperty(global, 'fetch', {value: fetch});
-}
+import 'fetch-undici-polyfill';
 
 import {PlatformClient, RestUserIdType} from '@coveo/platform-client';
 

--- a/packages/ui/search-token-lambda/package.json
+++ b/packages/ui/search-token-lambda/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@coveo/platform-client": "37.13.0",
-    "undici": "5.15.0"
+    "fetch-undici-polyfill": "1.1.1"
   },
   "devDependencies": {
     "@babel/core": "7.20.12",

--- a/packages/ui/vue/create-headless-vue/template/package.json
+++ b/packages/ui/vue/create-headless-vue/template/package.json
@@ -35,7 +35,7 @@
     "prettier": "^2.7.1",
     "sass": "^1.55.0",
     "typescript": "~4.9.0",
-    "undici": "^5.11.0",
+    "fetch-undici-polyfill": "1.1.1",
     "vite": "4.0.4",
     "vite-plugin-vuetify": "^1.0.1",
     "vue-tsc": "^1.0.8"

--- a/packages/ui/vue/create-headless-vue/template/src/server/index.ts
+++ b/packages/ui/vue/create-headless-vue/template/src/server/index.ts
@@ -1,12 +1,8 @@
-import { generateToken } from "./searchTokenGenerator.js";
+import "fetch-undici-polyfill";
 
-import { fetch } from "undici";
+import { generateToken } from "./searchTokenGenerator.js";
 import type { ViteDevServer } from "vite";
 import isEnvValid from "../commons/isEnvValid.js";
-
-if (!Object.keys(global).includes("fetch")) {
-  Object.defineProperty(global, "fetch", { value: fetch });
-}
 
 export default (config: Record<string, string>) => {
   if (!isEnvValid(config)) {


### PR DESCRIPTION
<!-- For Coveo Employees only. Fill this section.

CDX-1295

-->

## Proposed changes

In #1090 axios is a pain because they break types, so I decide to remove axios (at least where it doesn't work) and use fetch.
It was the 5th time that I was about to copy-paste this, so I 🧹.

I didn't find a package that allows to polyfill 'fetch' using nodejs/undici implementation, so I created a dumb & small one based on the code we had in the CLI: https://github.com/coveooss/fetch-undici-polyfill

It will probably be used by push-api-client.js too, so I put it aside. Maybe one day we should create a monorepo for things like bueno and this 🤔 
## Testing

Existing tests, the new package is also covered with UT.