### PR TITLE
fix(atomic): support non-us regions

### DIFF
--- a/packages/cli/core/src/commands/ui/create/atomic.spec.ts
+++ b/packages/cli/core/src/commands/ui/create/atomic.spec.ts
@@ -77,6 +77,18 @@ describe('ui:create:atomic', () => {
       configurationMock({
         accessToken: 'foo',
         environment: 'dev',
+        region: 'us',
+        organization: 'my-org',
+      } as Configuration)
+    );
+  };
+
+  const doMockConfigurationInEurope = () => {
+    mockedConfig.mockImplementation(
+      configurationMock({
+        accessToken: 'foo',
+        environment: 'prod',
+        region: 'eu',
         organization: 'my-org',
       } as Configuration)
     );
@@ -246,4 +258,35 @@ describe('ui:create:atomic', () => {
         ]
       );
     });
+
+  describe('when connected in another region than US', () => {
+    beforeEach(() => {
+      doMockConfigurationInEurope();
+    });
+
+    test
+      .stdout()
+      .stderr()
+      .command(['ui:create:atomic', 'myapp'])
+      .it('should start 1 spawn processes with the good template', () => {
+        expect(mockedSpawnProcess).toHaveBeenCalledTimes(1);
+        expect(mockedSpawnProcess).nthCalledWith(
+          1,
+          expect.stringContaining('npx'),
+          [
+            `${createAtomicPackage}@1.0.0`,
+            '--project',
+            'myapp',
+            '--org-id',
+            'my-org',
+            '--api-key',
+            'foo',
+            '--platform-url',
+            'https://platform-eu.cloud.coveo.com',
+            '--user',
+            'bob@coveo.com',
+          ]
+        );
+      });
+  });
 });

--- a/packages/cli/core/src/commands/ui/create/atomic.ts
+++ b/packages/cli/core/src/commands/ui/create/atomic.ts
@@ -86,7 +86,7 @@ export default class Atomic extends CLICommand {
       '--api-key',
       cfg.accessToken,
       '--platform-url',
-      platformUrl({environment: cfg.environment}),
+      platformUrl({environment: cfg.environment, region: cfg.region}),
       '--user',
       username,
     ];


### PR DESCRIPTION
<!-- For Coveo Employees only. Fill this section.

https://coveord.atlassian.net/browse/CDX-1316

-->

## Proposed changes

- give the good url to @coveo/create-atomic package, it manages afterward

## Testing

- [x] Unit Tests: ye
- [ ] Functionnal Tests: nah, not worth testing on each region IMO
- [x] Manual Tests: created an org in EU, logged to it, ran the command from bin/dev. It works. Extra miles, npm started the project, it works too.
