### PR TITLE
fix(atomic): do not track lambda symlink

### DIFF
--- a/packages/cli-e2e/__tests__/__snapshots__/atomic.specs.ts.snap
+++ b/packages/cli-e2e/__tests__/__snapshots__/atomic.specs.ts.snap
@@ -14,27 +14,27 @@ HashedFolder {
                   "name": "areEnvironmentVariablesSet.ts",
                 },
                 HashedFile {
-                  "hash": "3/G6brNR4QRqiJlaY/m/fsyTzzc=",
+                  "hash": "awXFfDQB4u/SWLWIu/s7d5lDypg=",
                   "name": "generateToken.ts",
                 },
                 HashedFile {
-                  "hash": "AG8M1wAglfYRRL/+Y987D25+YcA=",
+                  "hash": "RE8gVn5L6IPgrgjSaHQgprTpOE4=",
                   "name": "token.spec.ts",
                 },
                 HashedFile {
-                  "hash": "LxpAYAmM+yDe4mLtd3Rj6R9S30k=",
+                  "hash": "8CnT2j+TqLXbaxi+gAL9d/Alk3E=",
                   "name": "token.ts",
                 },
               ],
-              "hash": "pmEnQcGTj9o9+LzhyIv1naaY/ak=",
+              "hash": "WtXb6ZQYgvzwFIFJlF+w/4gpVUQ=",
               "name": "token",
             },
           ],
-          "hash": "AYAizlKrvz2mLJQE53WMgok4NBY=",
+          "hash": "Jw1m1dA3f+wg0+kzN1w/f96o8K0=",
           "name": "functions",
         },
         HashedFile {
-          "hash": "qBh2kK6C/tcpIA4kKT8j7bm10Kw=",
+          "hash": "OVq4G+VOzVg6+LO7SDGMuYwA3gQ=",
           "name": "jest.config.js",
         },
         HashedFile {
@@ -54,7 +54,7 @@ HashedFolder {
           "name": "tsconfig.json",
         },
       ],
-      "hash": "H4lv26/ky0DGVWpNK4hd7vom80g=",
+      "hash": "SAqi9P1uzEYQKpk6WgZnft2+BRM=",
       "name": "lambda",
     },
     HashedFile {
@@ -66,8 +66,13 @@ HashedFolder {
       "name": "README.md",
     },
     HashedFolder {
-      "children": [],
-      "hash": "2jmj7l5rSw0yVb/vlWAYkK/YBwk=",
+      "children": [
+        HashedFile {
+          "hash": "Q005R5GLW6xqpD5rr3mDMF2rLo0=",
+          "name": "setup-lambda.mjs",
+        },
+      ],
+      "hash": "fuD+lsTS+ed8pIvaiB13YbKVwrg=",
       "name": "scripts",
     },
     HashedFolder {
@@ -160,7 +165,7 @@ HashedFolder {
       "name": "tsconfig.json",
     },
   ],
-  "hash": "qiJ6tOeVT+G3Ixxup+ax7h1yJpo=",
+  "hash": "UxIfu4fnp2tHiAlJELJWWBZA03U=",
   "name": "normalizedDir",
 }
 `;
@@ -179,7 +184,7 @@ HashedFolder {
     HashedFolder {
       "children": [
         HashedFile {
-          "hash": "Jy9yA5W89BgTcZN4pVbSygA3w9U=",
+          "hash": "dZCPeiAxqOaVVtRsZz+MidfshDs=",
           "name": "clean-up.js",
         },
         HashedFile {
@@ -191,7 +196,7 @@ HashedFolder {
           "name": "utils.js",
         },
       ],
-      "hash": "0DHKkhnIXmyyA6198J3HAA9T0C0=",
+      "hash": "RGm4yIYhtjB8PaZW7ipinrbth+A=",
       "name": "scripts",
     },
     HashedFolder {
@@ -284,7 +289,7 @@ HashedFolder {
       "name": "tsconfig.json",
     },
   ],
-  "hash": "2lWgSOnEGSStntBBD3K0O+ILOu0=",
+  "hash": "O0tuaMFIZRiaGYGPVnuBFT55kJI=",
   "name": "normalizedDir",
 }
 `;
@@ -303,7 +308,7 @@ HashedFolder {
     HashedFolder {
       "children": [
         HashedFile {
-          "hash": "Jy9yA5W89BgTcZN4pVbSygA3w9U=",
+          "hash": "dZCPeiAxqOaVVtRsZz+MidfshDs=",
           "name": "clean-up.js",
         },
         HashedFile {
@@ -315,7 +320,7 @@ HashedFolder {
           "name": "utils.js",
         },
       ],
-      "hash": "0DHKkhnIXmyyA6198J3HAA9T0C0=",
+      "hash": "RGm4yIYhtjB8PaZW7ipinrbth+A=",
       "name": "scripts",
     },
     HashedFolder {
@@ -408,7 +413,7 @@ HashedFolder {
       "name": "tsconfig.json",
     },
   ],
-  "hash": "0dKsmCapsdkr5IYsS8f74DLVZWs=",
+  "hash": "MNJhwXQYJ1sBFRQW5tXDl7V/54U=",
   "name": "normalizedDir",
 }
 `;

--- a/packages/ui/atomic/create-atomic/scripts/packageTemplate.json
+++ b/packages/ui/atomic/create-atomic/scripts/packageTemplate.json
@@ -17,6 +17,7 @@
     "site:variables": "netlify env:import .env",
     "site:init": "netlify init && npm run site:variables",
     "site:deploy": "npm run site:link && npm run build && npm run site:variables && netlify deploy --prod --open",
-    "postinstall": "npm run setup-lambda && npm run setup-cleanup && prettier --write . --loglevel warn"
+    "postinstall": "npm run setup-cleanup && prettier --write . --loglevel warn",
+    "prepare": "npm run setup-lambda"
   }
 }

--- a/packages/ui/atomic/template/.gitignore.hbs
+++ b/packages/ui/atomic/template/.gitignore.hbs
@@ -16,3 +16,6 @@ www
 
 # Local Netlify folder
 .netlify
+
+# Symlink of lambda
+lambda

--- a/packages/ui/atomic/template/scripts/clean-up.js
+++ b/packages/ui/atomic/template/scripts/clean-up.js
@@ -3,7 +3,7 @@ const {join} = require('path');
 const {getPackageManager} = require('./utils');
 const pkgJson = JSON.parse(readFileSync('package.json'));
 
-['postinstall', 'setup-lambda', 'setup-cleanup'].forEach(
+['postinstall', 'setup-cleanup'].forEach(
   (script) => delete pkgJson['scripts'][script]
 );
 
@@ -14,6 +14,6 @@ const pkgString = JSON.stringify(pkgJson, null, 2).replace(
 
 writeFileSync('package.json', pkgString);
 
-['setup-lambda.mjs', 'clean-up.js', 'utils.js'].forEach((file) =>
+['clean-up.js', 'utils.js'].forEach((file) =>
   unlinkSync(join(__dirname, file))
 );


### PR DESCRIPTION
<!-- For Coveo Employees only. Fill this section.

CDX-1319

-->

## The issue

When initializing an atomic project, we create a junction symlink that point 'lambda' as node_modules/path_to_coveo_lambda. 
However, the paths used are absolute.
This causes issue when users track the project thru git and then try to clone it (absolute path of usr A on usr B machine won't fly)

## Proposed changes

Because we cannot use relative path (junction requires absolute path, and dir symlink require more privileges), let's create the symlink after the user npm install occurs. (prepare lifecycle script), and stop tracking the symlink.


## Breaking changes

<!--
    Remove this section if the PR does not include any breaking change

    If your changes includes some breaking changes in the code, thoroughly explains:
        - What are the breaking changes programmatically speaking.
        - What is the impact on the end-user (e.g. user cannot do X anymore).
        - What motivates those changes.
-->

## Testing

- [x] Functionnal Tests: yea, existing + updated fs snap