### PR TITLE
chore: update jest snap when renovate fails 

### DIFF
--- a/.github/workflows/renovate-jest-snap-updater.yml
+++ b/.github/workflows/renovate-jest-snap-updater.yml
@@ -1,0 +1,59 @@
+on:
+  workflow_run:
+    workflows: ['CI']
+    types: ['completed']
+    branches: ['renovate/**']
+jobs:
+  update-snap:
+    name: 'Update Jest Snap of #${{ github.event.number }}'
+    if: ${{ github.event.workflow_run.conclusion == 'failure' }}
+    runs-on: ubuntu-20.04
+    # If we're already doing the process, cancel the old attempt.
+    concurrency:
+      group: update-snap-${{ github.event.number }}
+      cancel-in-progress: true
+    env:
+      BRANCH_NAME: 'renovate-snap/${{github.event.number}}'
+    steps:
+      - name: Setup runner
+        if: ${{matrix.os == 'ubuntu-20.04'}}
+        # Ensure we can use as many file watcher as we want. see https://github.com/facebook/create-react-app/blob/master/docusaurus/docs/troubleshooting.md#npm-start-fail-due-to-watch-error
+        run: echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p
+      - name: Setup runner
+        if: ${{matrix.os == 'windows-latest'}}
+        run: |
+          git config --global core.autocrlf false
+          git config --global core.eol lf
+      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3
+        with:
+          ref: ${{ github.event.workflow_run.head_branch }}
+      - uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3
+        with:
+          cache: 'npm'
+          node-version-file: '.nvmrc'
+      - name: Start update branch
+        run: git checkout -b $BRANCH_NAME
+      - name: Install dependencies
+        run: npm ci
+      - name: Update snapshots
+        run: npm test -- -u
+      - name: Commit-Push
+        run: |
+          git commit -am 'chore:refresh jest snap j:cdx-227'
+          git push -f
+      - name: Open PR
+        uses: actions/github-script
+        env:
+          DISPLAY_TITLE: ${{ github.event.workflow_run.display_title }}
+        with:
+          script: |
+            const jira = 'j:cdx-227';
+            const title = `${process.env.DISPLAY_TITLE.split(jira)[0]} and jest snaps ${jira}`;
+            github.rest.pulls.create({
+              title: title,
+              base: 'master',
+              head: process.env.BRANCH_NAME,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              maintainer_can_modify: true,
+            });

--- a/.github/workflows/renovate-jest-snap-updater.yml
+++ b/.github/workflows/renovate-jest-snap-updater.yml
@@ -3,13 +3,16 @@ on:
     workflows: ['CI']
     types: ['completed']
     branches: ['renovate/**']
+env:
+  BRANCH_NAME: 'renovate-snap/${{github.event.number}}'
 jobs:
-  close-snap-pr:
+  close-snap:
     name: 'Close Jest Snap PR'
-    if:
-    runs-on:
+    runs-on: ubuntu-20.04
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
-      # Delete the branch if it exists, PR will prolly be deleted by GH automagically.
+      - name: Delete the branch
+        run: git push --delete $BRANCH_NAME
   update-snap:
     name: 'Update Jest Snap of #${{ github.event.number }}'
     if: ${{ github.event.workflow_run.conclusion == 'failure' }}
@@ -18,8 +21,6 @@ jobs:
     concurrency:
       group: update-snap-${{ github.event.number }}
       cancel-in-progress: true
-    env:
-      BRANCH_NAME: 'renovate-snap/${{github.event.number}}'
     steps:
       - name: Setup runner
         if: ${{matrix.os == 'ubuntu-20.04'}}
@@ -38,19 +39,20 @@ jobs:
           cache: 'npm'
           node-version-file: '.nvmrc'
       - name: Start update branch
-        run: git checkout -b $BRANCH_NAME
+        run: |
+          git push --delete $BRANCH_NAME
+          git checkout -b $BRANCH_NAME
       - name: Install dependencies
         run: npm ci
       - name: Update snapshots
         run: npm test -- -u
-      - name: Check if branch already exists
-        run: # Check if the branch exists. Store the value. If the branch does exists do not create a PR
       - name: Commit-Push
         run: |
           git commit -am 'chore:refresh jest snap j:cdx-227'
           git push -f
       - name: Open PR
         uses: actions/github-script
+        continue-on-error: true
         env:
           DISPLAY_TITLE: ${{ github.event.workflow_run.display_title }}
         with:

--- a/.github/workflows/renovate-jest-snap-updater.yml
+++ b/.github/workflows/renovate-jest-snap-updater.yml
@@ -55,12 +55,14 @@ jobs:
         continue-on-error: true
         env:
           DISPLAY_TITLE: ${{ github.event.workflow_run.display_title }}
+          PR_BODY: '#${{ github.event.number }}'
         with:
           script: |
             const jira = 'j:cdx-227';
             const title = `${process.env.DISPLAY_TITLE.split(jira)[0]} and jest snaps ${jira}`;
             github.rest.pulls.create({
               title: title,
+              body: process.env.PR_BODY,
               base: 'master',
               head: process.env.BRANCH_NAME,
               owner: context.repo.owner,

--- a/.github/workflows/renovate-jest-snap-updater.yml
+++ b/.github/workflows/renovate-jest-snap-updater.yml
@@ -4,6 +4,12 @@ on:
     types: ['completed']
     branches: ['renovate/**']
 jobs:
+  close-snap-pr:
+    name: 'Close Jest Snap PR'
+    if:
+    runs-on:
+    steps:
+      # Delete the branch if it exists, PR will prolly be deleted by GH automagically.
   update-snap:
     name: 'Update Jest Snap of #${{ github.event.number }}'
     if: ${{ github.event.workflow_run.conclusion == 'failure' }}
@@ -37,6 +43,8 @@ jobs:
         run: npm ci
       - name: Update snapshots
         run: npm test -- -u
+      - name: Check if branch already exists
+        run: # Check if the branch exists. Store the value. If the branch does exists do not create a PR
       - name: Commit-Push
         run: |
           git commit -am 'chore:refresh jest snap j:cdx-227'


### PR DESCRIPTION
<!-- For Coveo Employees only. Fill this section.

CDX-1328

-->

## Proposed changes

The goal here is to avoid having to manually update the snap files used in the test for mundane dependency updates.

This workflow will create another PR from the renovate branch, targeting master, but with the snap files being updated.
It will refresh and delete the branch as needed.