### PR TITLE
docs: added example to manual for org:search:dump

### DIFF
--- a/packages/cli/core/src/commands/org/search/dump.ts
+++ b/packages/cli/core/src/commands/org/search/dump.ts
@@ -69,7 +69,7 @@ export default class Dump extends CLICommand {
       command:
         'coveo org:search:dump --source Products --pipeline Search --additionalFilter "@cat_categories==Shorts AND @color==Black"',
       description:
-        'Get all the products coming from the "Search" pipeline that are in the "Shorts" category and has the color field "Black".',
+        'Get all the products coming from the "Search" pipeline that are in the "Shorts" category and have the color "Black".',
     },
     {
       command:

--- a/packages/cli/core/src/commands/org/search/dump.ts
+++ b/packages/cli/core/src/commands/org/search/dump.ts
@@ -67,6 +67,12 @@ export default class Dump extends CLICommand {
     },
     {
       command:
+        'coveo org:search:dump --source Products --pipeline Search --additionalFilter "@cat_categories==Shorts AND @color==Black"',
+      description:
+        'Get all the products coming from the "Search" pipeline that are in the "Shorts" category and has the color field "Black".',
+    },
+    {
+      command:
         'coveo org:search:dump --fieldsToExclude ec_description ec_summary',
       description:
         'Get all the documents without the fields "ec_description" and "ec_summary" in them.',


### PR DESCRIPTION

DOC-10877
https://coveord.atlassian.net/browse/DOC-10877

## Proposed changes

Added an example for org:search:dump about how to combine fields in the additionalFilter flag

## Testing
coveo org:search:dump --help (To see manual for the command)