### PR TITLE
chore: specify remote when `--delete`

### DIFF
--- a/.github/workflows/renovate-jest-snap-updater.yml
+++ b/.github/workflows/renovate-jest-snap-updater.yml
@@ -14,7 +14,7 @@ jobs:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
       - name: Delete the branch
-        run: git push --delete $BRANCH_NAME
+        run: git push origin --delete $BRANCH_NAME
   update-snap:
     name: 'Update Jest Snap of #${{ github.event.number }}'
     if: ${{ github.event.workflow_run.conclusion == 'failure' }}
@@ -42,7 +42,7 @@ jobs:
           node-version-file: '.nvmrc'
       - name: Start update branch
         run: |
-          git push --delete $BRANCH_NAME
+          git push origin --delete $BRANCH_NAME
           git checkout -b $BRANCH_NAME
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
<!-- For Coveo Employees only. Fill this section.
[[CDX-1328](https://coveord.atlassian.net/browse/CDX-1328)](https://coveord.atlassian.net/browse/CDX-1328)
-->

## Proposed changes

`git push --delete` doesn't work without the remote being explicitly specified

## Testing

Try to run `git push --delete testfoo` in a clone of this repo.
Then try to run `git push origin --delete testfoo`

(If someone did it already, just push out a new random ref)

[CDX-1328]: https://coveord.atlassian.net/browse/CDX-1328?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ