### PR TITLE
chore: polish snap updater

### DIFF
--- a/.github/workflows/renovate-jest-snap-updater.yml
+++ b/.github/workflows/renovate-jest-snap-updater.yml
@@ -1,9 +1,14 @@
 name: Update Jest Snaps after Renovate
+run-name: 'Update Jest Snap of #${{ github.event.workflow_run.pull_requests[0].number }}'
 on:
   workflow_run:
     workflows: ['CI']
     types: ['completed']
     branches: ['renovate/**']
+# If we're already doing the process, cancel the old attempt.
+concurrency:
+  group: update-snap-${{ github.event.workflow_run.pull_requests[0].number }}
+  cancel-in-progress: true
 env:
   PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
   BRANCH_NAME: 'renovate-snap/${{github.event.workflow_run.pull_requests[0].number}}'
@@ -19,10 +24,6 @@ jobs:
     name: 'Update Jest Snap of #${{ github.event.workflow_run.pull_requests[0].number }}'
     if: ${{ github.event.workflow_run.conclusion == 'failure' }}
     runs-on: ubuntu-20.04
-    # If we're already doing the process, cancel the old attempt.
-    concurrency:
-      group: update-snap-$PR_NUMBER
-      cancel-in-progress: true
     steps:
       - name: Setup runner
         if: ${{matrix.os == 'ubuntu-20.04'}}


### PR DESCRIPTION
<!-- For Coveo Employees only. Fill this section.

CDX-1328

-->

## Proposed changes

- Fixed concurrency key: env is not available, we need to use the long key.
- Moved the concurrency at the workflow level: if the OG PR actually succeeds, then we can cancel the update and close ASAP
- Tweaked the run-name so it renders better in GitHub UI.
