### PR TITLE
chore: lock stencil, freeze netlify

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -26,6 +26,18 @@
       "rangeStrategy": "replace"
     },
     {
+      "matchPackagePatterns": ["^@stencil/*"],
+      "groupSlug": "stencil",
+      "description": "KIT-2312 Migrate Stencil projects to V3",
+      "allowedVersions": "2.x"
+    },
+    {
+      "matchPackagePatterns": ["netlify-cli"],
+      "groupSlug": "stencil",
+      "description": "🧊",
+      "allowedVersions": "12.x"
+    },
+    {
       "matchPackageNames": ["strip-ansi"],
       "allowedVersions": "6.x"
     },


### PR DESCRIPTION
CDX-227

We will remove Netlify soon. So let's not bother updating its major.