### PR TITLE
chore: sort prerelease using semver

### DIFF
--- a/utils/release/npm-publish-package.mjs
+++ b/utils/release/npm-publish-package.mjs
@@ -18,7 +18,7 @@ import angularChangelogConvention from 'conventional-changelog-angular';
 import {dirname, resolve, join} from 'node:path';
 import {fileURLToPath} from 'node:url';
 import retry from 'async-retry';
-import {inc} from 'semver';
+import {inc, compareBuild} from 'semver';
 import {json as fetchNpm} from 'npm-registry-fetch';
 
 const hasPackageJsonChanged = (directoryPath) => {
@@ -177,7 +177,7 @@ async function getNextBetaVersion(packageName, nextGoldVersion) {
   const nextGoldMatcher = new RegExp(`${nextGoldVersion}-\\d+`);
   const matchingPreReleasedVersions = versions
     .filter((version) => nextGoldMatcher.test(version))
-    .sort();
+    .sort(compareBuild);
   if (matchingPreReleasedVersions.length === 0) {
     return `${nextGoldVersion}-0`;
   }


### PR DESCRIPTION
<!-- For Coveo Employees only. Fill this section.

CDX-764

-->

## Proposed changes

`1.2.3-10<1.2.3-9` with default sort (which is alphabetical). This caused the prerelease process to try to release -10 over and over, which ofc fails because you cannot publish over an existing version with NPM.


### Test:
Call `getNextBetaVersion('@coveo/headless','1.1.0')`.
Before it returns `1.1.0-10` which already exists
After it returns `1.1.0-11`.
