### PR TITLE
chore: jest snap updater, trigger ci manually

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - master
   pull_request:
+  workflow_dispatch:
 env:
   # Platform environment to log into for the e2e tests.
   PLATFORM_ENV: 'stg'

--- a/.github/workflows/renovate-jest-snap-updater.yml
+++ b/.github/workflows/renovate-jest-snap-updater.yml
@@ -78,3 +78,9 @@ jobs:
               repo: context.repo.repo,
               maintainer_can_modify: true,
             });
+            github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'CI',
+              ref: process.env.BRANCH_NAME,
+            });


### PR DESCRIPTION
<!-- For Coveo Employees only. Fill this section.

[CDX-1328](https://coveord.atlassian.net/browse/CDX-1328)

-->

## Proposed changes

GitHub won't trigger workflow on stuff created by GitHub Actions (releases, PRs, commits, etc).
This triggers the workflow after creating the PR with the snap.

[CDX-1328]: https://coveord.atlassian.net/browse/CDX-1328?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ