### PR TITLE
chore: fix worfklow trigger for jest updater

### DIFF
--- a/.github/workflows/renovate-jest-snap-updater.yml
+++ b/.github/workflows/renovate-jest-snap-updater.yml
@@ -81,6 +81,6 @@ jobs:
             github.rest.actions.createWorkflowDispatch({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              workflow_id: 'CI',
+              workflow_id: 'build.yml',
               ref: process.env.BRANCH_NAME,
             });


### PR DESCRIPTION
by name, they meant filename.
[CDX-1328](https://coveord.atlassian.net/browse/CDX-1328)


[CDX-1328]: https://coveord.atlassian.net/browse/CDX-1328?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ