### PR TITLE
fix(cli-commons): color orgId magenta only when on unix or WT

### DIFF
--- a/packages/cli/commons/src/utils/__snapshots__/ux.spec.ts.snap
+++ b/packages/cli/commons/src/utils/__snapshots__/ux.spec.ts.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ux formatOrgId() colors the color magenta 1`] = `"[35mmyOrgId[39m"`;
+exports[`ux formatOrgId() when shouldUseColor returns true colors the color magenta 1`] = `"[35mmyOrgId[39m"`;

--- a/packages/cli/commons/src/utils/ux.ts
+++ b/packages/cli/commons/src/utils/ux.ts
@@ -1,8 +1,17 @@
 import {CliUx} from '@oclif/core';
 import {red, green, magenta} from 'chalk';
 
+
+functions isWindows() {
+  return process.platform === 'win32'
+}
+
+function isWindowsTerminal() {
+  return Boolean(process.env['WT_PROFILE_ID']);
+}
+
 export function shouldUseColor() {
-  return process.platform !== 'win32' || Boolean(process.env['WT_PROFILE_ID']);
+  return !isWindows() || isWindowsTerminal();
 }
 
 export function startSpinner(task: string, status?: string) {

--- a/packages/cli/commons/src/utils/ux.ts
+++ b/packages/cli/commons/src/utils/ux.ts
@@ -2,7 +2,7 @@ import {CliUx} from '@oclif/core';
 import {red, green, magenta} from 'chalk';
 
 
-functions isWindows() {
+function isWindows() {
   return process.platform === 'win32'
 }
 

--- a/packages/cli/commons/src/utils/ux.ts
+++ b/packages/cli/commons/src/utils/ux.ts
@@ -1,6 +1,10 @@
 import {CliUx} from '@oclif/core';
 import {red, green, magenta} from 'chalk';
 
+export function shouldUseColor() {
+  return process.platform !== 'win32' || Boolean(process.env['WT_PROFILE_ID']);
+}
+
 export function startSpinner(task: string, status?: string) {
   if (CliUx.ux.action.running) {
     CliUx.ux.action.stop(green('✔'));
@@ -19,4 +23,4 @@ export function stopSpinner(options?: {success?: boolean}) {
 }
 
 export const formatOrgId = (orgId: TemplateStringsArray | string) =>
-  magenta(orgId);
+  shouldUseColor() ? magenta(orgId) : orgId;


### PR DESCRIPTION
https://coveord.atlassian.net/browse/CDX-1365

## Proposed changes

Some color doesn't work nicely on PS, so let's just skip'em'.
Windows users should use WT if they want niceties.

## Testing

- [x] Unit Tests
- [x] Manual Tests: `packages\cli\core\bin\dev auth:login` with powershell