### PR TITLE
feat: generate component docs on build

### DIFF
--- a/packages/ui/atomic/create-atomic-component/template/src/components/sample-component/package.json
+++ b/packages/ui/atomic/create-atomic-component/template/src/components/sample-component/package.json
@@ -15,10 +15,9 @@
     "loader/"
   ],
   "scripts": {
-    "prepublishOnly": "npm run build && npm version patch",
+    "prepublishOnly": "npm run build && atomic-meta-check && npm version patch",
     "prebuild": "rimraf dist",
     "build": "stencil build --docs",
-    "prepublish": "atomic-meta-check",
     "test": "stencil test --spec --e2e",
     "test.watch": "stencil test --spec --e2e --watchAll",
     "generate": "stencil generate"

--- a/packages/ui/atomic/create-atomic-component/template/src/components/sample-component/stencil.config.ts
+++ b/packages/ui/atomic/create-atomic-component/template/src/components/sample-component/stencil.config.ts
@@ -13,6 +13,10 @@ export const config: Config = {
     {
       type: 'docs-readme',
     },
+    {
+      type: 'docs-json',
+      file: 'docs/atomic-docs.json',
+    },
   ],
   rollupPlugins: {
     before: [

--- a/packages/ui/atomic/create-atomic-component/tests/__snapshots__/test.spec.ts.snap
+++ b/packages/ui/atomic/create-atomic-component/tests/__snapshots__/test.spec.ts.snap
@@ -20,6 +20,20 @@ HashedFolder {
                 HashedFolder {
                   "children": [
                     HashedFile {
+                      "hash": "ewQGf3/bnIIj+Rv249cv7K7YGsg=",
+                      "name": "atomic-docs.d.ts",
+                    },
+                    HashedFile {
+                      "hash": "w2xFBsevWFkJd1Sgn40UEfVAiFA=",
+                      "name": "atomic-docs.json",
+                    },
+                  ],
+                  "hash": "OIK/Vrv6m5llhzdauzHHuzUdUhE=",
+                  "name": "docs",
+                },
+                HashedFolder {
+                  "children": [
+                    HashedFile {
                       "hash": "/5yLi44o1uyQViLBqN4GTX4Wifo=",
                       "name": "cdn.js",
                     },
@@ -48,7 +62,7 @@ HashedFolder {
                   "name": "loader",
                 },
                 HashedFile {
-                  "hash": "Od34IIu/kM4od5aRZTT3BTjhYFM=",
+                  "hash": "kXAHDQ1O9ekXzA/BXFhyae6Af6Y=",
                   "name": "package.json",
                 },
                 HashedFolder {
@@ -74,7 +88,7 @@ HashedFolder {
                   "name": "src",
                 },
                 HashedFile {
-                  "hash": "o/wjp7ceO6Frr8oWEWwMMbpgj60=",
+                  "hash": "/I6cpMBEai4jB1K8BG/AfmtSUqs=",
                   "name": "stencil.config.ts",
                 },
                 HashedFile {
@@ -82,11 +96,11 @@ HashedFolder {
                   "name": "tsconfig.json",
                 },
               ],
-              "hash": "TsDzWiJg1KIQhH3CaIEVyddcYzg=",
+              "hash": "ItV6WKyL5bttYLWMnNmqkjYBzPs=",
               "name": "oh-wow-another-component-can-you-believe-it",
             },
           ],
-          "hash": "Cv5oF+Z8vxF9viGxNLk4dwcteUQ=",
+          "hash": "HmYgWOFOSAXQ5OAo+BroYaJs64c=",
           "name": "components",
         },
         HashedFile {
@@ -112,7 +126,7 @@ HashedFolder {
           "name": "pages",
         },
       ],
-      "hash": "nuAHzYim2iF+AyTRAG2zrXsAT0U=",
+      "hash": "gWS+LuDxXrqQNffTZNMTxeUM6KY=",
       "name": "src",
     },
     HashedFile {
@@ -124,7 +138,7 @@ HashedFolder {
       "name": "tsconfig.json",
     },
   ],
-  "hash": "augdx1vM63L3w++Xa8A7jAMnB9c=",
+  "hash": "PwaHFazp0jNVV64aqr8P0izGvjo=",
   "name": "no-args",
 }
 `;
@@ -147,7 +161,7 @@ HashedFolder {
             HashedFolder {
               "children": [
                 HashedFile {
-                  "hash": "8jqQ8jMKUmsMHXqPJ+Va2FWnJI4=",
+                  "hash": "b6IE637UMamVYBKTsToO/IJ+E1U=",
                   "name": "package.json",
                 },
                 HashedFolder {
@@ -165,7 +179,7 @@ HashedFolder {
                   "name": "src",
                 },
                 HashedFile {
-                  "hash": "o/wjp7ceO6Frr8oWEWwMMbpgj60=",
+                  "hash": "/I6cpMBEai4jB1K8BG/AfmtSUqs=",
                   "name": "stencil.config.ts",
                 },
                 HashedFile {
@@ -173,11 +187,11 @@ HashedFolder {
                   "name": "tsconfig.json",
                 },
               ],
-              "hash": "3oooSGhdbEz9bFIW+jxQx8c9MmY=",
+              "hash": "NMxjOZrOTRVb9SR+O4WiP2BE0do=",
               "name": "atomic-nohypen",
             },
           ],
-          "hash": "boOLM5KP1kIa8zd4AIHWVxgdIeA=",
+          "hash": "7sqRXUv6tiR870+xIqM4eai9asw=",
           "name": "components",
         },
         HashedFile {
@@ -203,7 +217,7 @@ HashedFolder {
           "name": "pages",
         },
       ],
-      "hash": "hEnufsNhu8FP0hL5j7xyANoGZiI=",
+      "hash": "HA48reXrNftmWgfyhCK3/eHktQg=",
       "name": "src",
     },
     HashedFile {
@@ -215,7 +229,7 @@ HashedFolder {
       "name": "tsconfig.json",
     },
   ],
-  "hash": "J5jveeUIjHPmoTJqhia/U/rjzI4=",
+  "hash": "MR0XyW35ApLBM9iBnU2L/FoFi/8=",
   "name": "invalid-arg",
 }
 `;
@@ -238,7 +252,7 @@ HashedFolder {
             HashedFolder {
               "children": [
                 HashedFile {
-                  "hash": "4i09LDgki1knJ++sEJ25B7OatIQ=",
+                  "hash": "ivMYowyXrV/mAYnSe8vDk1/hDE8=",
                   "name": "package.json",
                 },
                 HashedFolder {
@@ -256,7 +270,7 @@ HashedFolder {
                   "name": "src",
                 },
                 HashedFile {
-                  "hash": "o/wjp7ceO6Frr8oWEWwMMbpgj60=",
+                  "hash": "/I6cpMBEai4jB1K8BG/AfmtSUqs=",
                   "name": "stencil.config.ts",
                 },
                 HashedFile {
@@ -264,11 +278,11 @@ HashedFolder {
                   "name": "tsconfig.json",
                 },
               ],
-              "hash": "MLwPXFxYzvMMusp514t4K8gYwoA=",
+              "hash": "3KMMygPxtGWXAPmgfs4GduWnY1g=",
               "name": "valid-component-name",
             },
           ],
-          "hash": "oDqOaFla4zXrVE3QlqWTjupRKvM=",
+          "hash": "yFp9bm0FxRn/W2ueQGWUsFss4dA=",
           "name": "components",
         },
         HashedFile {
@@ -294,7 +308,7 @@ HashedFolder {
           "name": "pages",
         },
       ],
-      "hash": "vPN008UEclaaaMIBJOKoziQvveE=",
+      "hash": "O5JUKHm1Fh9pzlPP+w/WWBy3vCw=",
       "name": "src",
     },
     HashedFile {
@@ -306,7 +320,7 @@ HashedFolder {
       "name": "tsconfig.json",
     },
   ],
-  "hash": "6KFgRP/0ZbRZ7sNGlNLnoN/yGUM=",
+  "hash": "bzElATq0MFokavc6VSsV14nxK/I=",
   "name": "valid-arg",
 }
 `;
@@ -329,7 +343,7 @@ HashedFolder {
             HashedFolder {
               "children": [
                 HashedFile {
-                  "hash": "NfYhjfT2zx1gJGPJQcG3GGx4+9U=",
+                  "hash": "6xt1KezZg2qEkMmLcB7eTwx/yJI=",
                   "name": "package.json",
                 },
                 HashedFolder {
@@ -347,7 +361,7 @@ HashedFolder {
                   "name": "src",
                 },
                 HashedFile {
-                  "hash": "o/wjp7ceO6Frr8oWEWwMMbpgj60=",
+                  "hash": "/I6cpMBEai4jB1K8BG/AfmtSUqs=",
                   "name": "stencil.config.ts",
                 },
                 HashedFile {
@@ -355,11 +369,11 @@ HashedFolder {
                   "name": "tsconfig.json",
                 },
               ],
-              "hash": "C1lUixYy5PqFPChCSEf4u1O+KiE=",
+              "hash": "HLQtcB0KuFpImUsdWzvti6JSCow=",
               "name": "sample-component",
             },
           ],
-          "hash": "EJ+DqRDmJ6t1nDn1YxXsmLUODH8=",
+          "hash": "f156CiEfZU9ZiG6WQEy8dqw2ZV4=",
           "name": "components",
         },
         HashedFile {
@@ -385,7 +399,7 @@ HashedFolder {
           "name": "pages",
         },
       ],
-      "hash": "CuWH1YBEISTAmF0ImcUK5ol3MlU=",
+      "hash": "xWrsoKJR7YyQkRb/uocmliq0qMo=",
       "name": "src",
     },
     HashedFile {
@@ -397,7 +411,7 @@ HashedFolder {
       "name": "tsconfig.json",
     },
   ],
-  "hash": "5yaiVtNTMwWU4WMWafaWcUtv0ho=",
+  "hash": "C87tKpoeJAKQL6kJwQ5cmZrO8m4=",
   "name": "no-args",
 }
 `;

--- a/packages/ui/atomic/create-atomic-result-component/template/src/components/sample-result-component/package.json
+++ b/packages/ui/atomic/create-atomic-result-component/template/src/components/sample-result-component/package.json
@@ -14,10 +14,9 @@
     "loader/"
   ],
   "scripts": {
-    "prepublishOnly": "npm run build",
+    "prepublishOnly": "npm run build && atomic-meta-check && npm version patch",
     "prebuild": "rimraf dist",
     "build": "stencil build --docs",
-    "prepublish": "atomic-meta-check",
     "start": "stencil build --dev --watch --serve",
     "test": "stencil test --spec --e2e",
     "test.watch": "stencil test --spec --e2e --watchAll",

--- a/packages/ui/atomic/create-atomic-result-component/template/src/components/sample-result-component/stencil.config.ts
+++ b/packages/ui/atomic/create-atomic-result-component/template/src/components/sample-result-component/stencil.config.ts
@@ -13,6 +13,10 @@ export const config: Config = {
     {
       type: 'docs-readme',
     },
+    {
+      type: 'docs-json',
+      file: 'docs/atomic-docs.json',
+    },
   ],
   rollupPlugins: {
     before: [

--- a/packages/ui/atomic/create-atomic-result-component/tests/__snapshots__/test.spec.ts.snap
+++ b/packages/ui/atomic/create-atomic-result-component/tests/__snapshots__/test.spec.ts.snap
@@ -20,6 +20,20 @@ HashedFolder {
                 HashedFolder {
                   "children": [
                     HashedFile {
+                      "hash": "ewQGf3/bnIIj+Rv249cv7K7YGsg=",
+                      "name": "atomic-docs.d.ts",
+                    },
+                    HashedFile {
+                      "hash": "uJJT7qiNu6Np6W/N49ZI1KxMksQ=",
+                      "name": "atomic-docs.json",
+                    },
+                  ],
+                  "hash": "kGQ/BAVN20NCKnFD2sHQRPxm+AI=",
+                  "name": "docs",
+                },
+                HashedFolder {
+                  "children": [
+                    HashedFile {
                       "hash": "/5yLi44o1uyQViLBqN4GTX4Wifo=",
                       "name": "cdn.js",
                     },
@@ -48,7 +62,7 @@ HashedFolder {
                   "name": "loader",
                 },
                 HashedFile {
-                  "hash": "WTygoJu28gB8AipVkRk9tM7AZdM=",
+                  "hash": "CX0g5ILYXXOkL+zo6VJlPDXWPWU=",
                   "name": "package.json",
                 },
                 HashedFolder {
@@ -74,7 +88,7 @@ HashedFolder {
                   "name": "src",
                 },
                 HashedFile {
-                  "hash": "o/wjp7ceO6Frr8oWEWwMMbpgj60=",
+                  "hash": "/I6cpMBEai4jB1K8BG/AfmtSUqs=",
                   "name": "stencil.config.ts",
                 },
                 HashedFile {
@@ -82,11 +96,11 @@ HashedFolder {
                   "name": "tsconfig.json",
                 },
               ],
-              "hash": "C064tkBzrl34NFXWpycWeiBjxkw=",
+              "hash": "3rBAFb0aW4O5P7PauDxUa6Q3Lkk=",
               "name": "oh-wow-another-component-can-you-believe-it",
             },
           ],
-          "hash": "zhHfasNANEOeHZ2kzmxmVew/gCQ=",
+          "hash": "auZ6R0XSRO3NVemi2KEpnxhdG3A=",
           "name": "components",
         },
         HashedFile {
@@ -112,7 +126,7 @@ HashedFolder {
           "name": "pages",
         },
       ],
-      "hash": "aDqIqPHmOUMNdUBOGKv51BG0BeU=",
+      "hash": "4fyv5PF6bNDUvgV94owchi7mv7Y=",
       "name": "src",
     },
     HashedFile {
@@ -124,7 +138,7 @@ HashedFolder {
       "name": "tsconfig.json",
     },
   ],
-  "hash": "vqlH/wn4AHcEEQzfS5NnCfyUzik=",
+  "hash": "4E2qaDAsJOVlbqHMbT1PV1JDwog=",
   "name": "no-args",
 }
 `;
@@ -147,7 +161,7 @@ HashedFolder {
             HashedFolder {
               "children": [
                 HashedFile {
-                  "hash": "LyfVcHttd/GRxWyrbFuPp9WYyqw=",
+                  "hash": "FSfgS3SgNbSwj3u966JuRCwMZoc=",
                   "name": "package.json",
                 },
                 HashedFolder {
@@ -165,7 +179,7 @@ HashedFolder {
                   "name": "src",
                 },
                 HashedFile {
-                  "hash": "o/wjp7ceO6Frr8oWEWwMMbpgj60=",
+                  "hash": "/I6cpMBEai4jB1K8BG/AfmtSUqs=",
                   "name": "stencil.config.ts",
                 },
                 HashedFile {
@@ -173,11 +187,11 @@ HashedFolder {
                   "name": "tsconfig.json",
                 },
               ],
-              "hash": "drOwFOoCP+txKnqE/Fe4MZQ0fX8=",
+              "hash": "w5faFgW3l2m+CZ9lfcv08B3FlhE=",
               "name": "atomic-nohypen",
             },
           ],
-          "hash": "Psa1vwdRY4EQZL9a/wLYgkRXEd8=",
+          "hash": "KkSkJoo0rlG+ngNhGUb3l0xSpjU=",
           "name": "components",
         },
         HashedFile {
@@ -203,7 +217,7 @@ HashedFolder {
           "name": "pages",
         },
       ],
-      "hash": "ydhh23XFIcdnMoaG0P267ZrwwHQ=",
+      "hash": "CojDD7v8r4n3Z013kUL3FgRsIZs=",
       "name": "src",
     },
     HashedFile {
@@ -215,7 +229,7 @@ HashedFolder {
       "name": "tsconfig.json",
     },
   ],
-  "hash": "MUFB1seww85a1FX9SKiiSyOpOW4=",
+  "hash": "p5BINGewiPT7cGRE9sv6XK9GF8k=",
   "name": "invalid-arg",
 }
 `;
@@ -238,7 +252,7 @@ HashedFolder {
             HashedFolder {
               "children": [
                 HashedFile {
-                  "hash": "XqcG/QmCnAQO044AbgJJcGrhswE=",
+                  "hash": "B2+TpcCRrf3siFvON05C0fgQHRg=",
                   "name": "package.json",
                 },
                 HashedFolder {
@@ -256,7 +270,7 @@ HashedFolder {
                   "name": "src",
                 },
                 HashedFile {
-                  "hash": "o/wjp7ceO6Frr8oWEWwMMbpgj60=",
+                  "hash": "/I6cpMBEai4jB1K8BG/AfmtSUqs=",
                   "name": "stencil.config.ts",
                 },
                 HashedFile {
@@ -264,11 +278,11 @@ HashedFolder {
                   "name": "tsconfig.json",
                 },
               ],
-              "hash": "OF9MWF4qQrd6ppWaLFnSvx5dHfQ=",
+              "hash": "77Pb9PNBnkSyhT1YA+WblFAfDVE=",
               "name": "valid-component-name",
             },
           ],
-          "hash": "PnN2FufBNziNaHdsOtPgN7UnPLc=",
+          "hash": "sNTixgo4ZpANbpQZ2seovEXo2SA=",
           "name": "components",
         },
         HashedFile {
@@ -294,7 +308,7 @@ HashedFolder {
           "name": "pages",
         },
       ],
-      "hash": "rYazOqgSlzgHKpkTFOBUf6Yzjf8=",
+      "hash": "UdhjXbVhUZwKAtIngAhFDObYdR0=",
       "name": "src",
     },
     HashedFile {
@@ -306,7 +320,7 @@ HashedFolder {
       "name": "tsconfig.json",
     },
   ],
-  "hash": "9jADuV+16bSriTgOb8C1P0ojFhM=",
+  "hash": "bBjDKUbNVVMCxdRdOREkP4OI990=",
   "name": "valid-arg",
 }
 `;
@@ -329,7 +343,7 @@ HashedFolder {
             HashedFolder {
               "children": [
                 HashedFile {
-                  "hash": "Z+EMy90VzNJZA9QIeUlsNjb5h4o=",
+                  "hash": "5g3ilwGzuHMX4G2xx1GRCuHL4Ls=",
                   "name": "package.json",
                 },
                 HashedFolder {
@@ -347,7 +361,7 @@ HashedFolder {
                   "name": "src",
                 },
                 HashedFile {
-                  "hash": "o/wjp7ceO6Frr8oWEWwMMbpgj60=",
+                  "hash": "/I6cpMBEai4jB1K8BG/AfmtSUqs=",
                   "name": "stencil.config.ts",
                 },
                 HashedFile {
@@ -355,11 +369,11 @@ HashedFolder {
                   "name": "tsconfig.json",
                 },
               ],
-              "hash": "ykyqze2Tr35iw3b0Sxv04GXZDfo=",
+              "hash": "HJaLNtWL1emw+TUDCogmj7Ab6R0=",
               "name": "sample-result-component",
             },
           ],
-          "hash": "cGhT4a6U0AOShn4z4IMLHxn1pks=",
+          "hash": "9Ul3egqZhkLwdU/kKKWs5OkpnyY=",
           "name": "components",
         },
         HashedFile {
@@ -385,7 +399,7 @@ HashedFolder {
           "name": "pages",
         },
       ],
-      "hash": "63zxIqQVzynjhJ7k4dmfUGu475w=",
+      "hash": "ugCs27Kka2I204iJkcpnA9siQDM=",
       "name": "src",
     },
     HashedFile {
@@ -397,7 +411,7 @@ HashedFolder {
       "name": "tsconfig.json",
     },
   ],
-  "hash": "ibb+ZFZ01tV6JggI0MUSo3299I4=",
+  "hash": "Gttx+sMTT7aFiJQnnctep+bCKzI=",
   "name": "no-args",
 }
 `;

--- a/packages/ui/atomic/health-check/readme.md
+++ b/packages/ui/atomic/health-check/readme.md
@@ -14,13 +14,13 @@ npm install health-check --save-dev
 ## Usage
 
 Once installed, you can use Health Check by running the bin file (`atomic-meta-check`) available in the node modules:
-It is meant to be used as a `prepublish` script.
+It is meant to be used as a `prepublishOnly` script.
 You can add it to your package.json:
 
 ```json
 ...
 "scripts": {
-    "prepublish": "atomic-meta-check",
+    "prepublishOnly": "npm run build && atomic-meta-check",
 },
 ...
 "devDependencies": {


### PR DESCRIPTION
<!-- For Coveo Employees only. Fill this section.

CDX-XXX

-->

## Proposed changes
Generate a json file with the component

The `npm run build` command will now generate a `atomic-docs.json` file with the following format:
```json
{
  "timestamp": "2023-03-23T14:53:34",
  "compiler": {
    "name": "@stencil/core",
    "version": "2.22.2",
    "typescriptVersion": "4.9.4"
  },
  "components": [
    {
      "filePath": "./src/my-custom-component.tsx",
      "encapsulation": "shadow",
      "tag": "my-custom-component",
      "readme": "...",
      "docs": "Sample custom Atomic component...",
      // ...
    }
  ]
}
```

This file can later be used for component name validation.
<!--
    Remove this section if the PR does not include any breaking change

    If your changes includes some breaking changes in the code, thoroughly explains:
        - What are the breaking changes programmatically speaking.
        - What is the impact on the end-user (e.g. user cannot do X anymore).
        - What motivates those changes.
-->

## Testing

- [ ] Unit Tests:
<!-- Did you write unit tests for your feature? If not, explains why?  -->
- [ ] Functionnal Tests:
<!-- Did you write functionnal tests for your feature? If not, explains why?  -->
- [ ] Manual Tests:
<!-- How did you test your changeset?  -->
