### PR TITLE
fix(atomic): simplify spinner+OK message

### DIFF
--- a/packages/cli-e2e/__tests__/deploy.specs.ts
+++ b/packages/cli-e2e/__tests__/deploy.specs.ts
@@ -90,8 +90,7 @@ describe('ui:deploy', () => {
       async () => {
         addPageNameToConfig('create');
         await deploy({debugName: 'ui-deploy-new'});
-
-        const regex = /Hosted Page creation successful with id "(.+)"/g;
+        const regex = /To update your page, run "coveo ui:deploy -p=(.+)/g;
         expect(stdout).toMatch(regex);
         const matches = regex.exec(stdout)!;
         const hostedPageId = matches[1];
@@ -113,12 +112,7 @@ describe('ui:deploy', () => {
 
         await deploy({id, debugName: 'ui-deploy-update'});
 
-        const regex = /Hosted Page update successful with id "(.+)"/g;
-        expect(stdout).toMatch(regex);
-        const matches = regex.exec(stdout)!;
-        const hostedPageId = matches[1];
-
-        const hostedPage = await platformClient.hostedPages.get(hostedPageId);
+        const hostedPage = await platformClient.hostedPages.get(id);
         expect(hostedPage.name).toEqual(pageName);
       },
       defaultTimeout

--- a/packages/cli-e2e/__tests__/deploy.specs.ts
+++ b/packages/cli-e2e/__tests__/deploy.specs.ts
@@ -90,7 +90,7 @@ describe('ui:deploy', () => {
       async () => {
         addPageNameToConfig('create');
         await deploy({debugName: 'ui-deploy-new'});
-        const regex = /To update your page, run "coveo ui:deploy -p=(.+)/g;
+        const regex = /To update your page, run "coveo ui:deploy -p=(.+)"./g;
         expect(stdout).toMatch(regex);
         const matches = regex.exec(stdout)!;
         const hostedPageId = matches[1];

--- a/packages/cli/core/src/commands/ui/__snapshots__/deploy.spec.ts.snap
+++ b/packages/cli/core/src/commands/ui/__snapshots__/deploy.spec.ts.snap
@@ -6,8 +6,7 @@ exports[`ui:deploy interacting with Platform client should call hostedPages.list
 `;
 
 exports[`ui:deploy interacting with Platform client should call hostedPages.list and hostedPages.create when no page id argument is passed 2`] = `
-"Creating new Hosted Page named "my page"....
-Creating new Hosted Page named "my page".... ✔
+"Creating new Hosted Page named "my page".... ✔
 "
 `;
 
@@ -22,8 +21,7 @@ Request ID: [31mb33pb00p[39m]
 exports[`ui:deploy interacting with Platform client when a page id argument is passed, it should call hostedPages.update 1`] = `""`;
 
 exports[`ui:deploy interacting with Platform client when a page id argument is passed, it should call hostedPages.update 2`] = `
-"Updating existing Hosted Page with the id "thisistheid"....
-Updating existing Hosted Page with the id "thisistheid".... ✔
+"Updating existing Hosted Page with the id "thisistheid".... ✔
 "
 `;
 

--- a/packages/cli/core/src/commands/ui/__snapshots__/deploy.spec.ts.snap
+++ b/packages/cli/core/src/commands/ui/__snapshots__/deploy.spec.ts.snap
@@ -1,11 +1,30 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`ui:deploy interacting with Platform client should call hostedPages.list and hostedPages.create when no page id argument is passed 1`] = `
+"To update your page, run "coveo ui:deploy -p=somePageId".
+"
+`;
+
+exports[`ui:deploy interacting with Platform client should call hostedPages.list and hostedPages.create when no page id argument is passed 2`] = `
+"Creating new Hosted Page named "my page"....
+Creating new Hosted Page named "my page".... ✔
+"
+`;
+
 exports[`ui:deploy interacting with Platform client should print an API Error if the update fails 1`] = `
 [APIError: 
 Status code: 418
 Error code: [31mSO_BAD[39m
 Message: [31mthis is bad[39m
 Request ID: [31mb33pb00p[39m]
+`;
+
+exports[`ui:deploy interacting with Platform client when a page id argument is passed, it should call hostedPages.update 1`] = `""`;
+
+exports[`ui:deploy interacting with Platform client when a page id argument is passed, it should call hostedPages.update 2`] = `
+"Updating existing Hosted Page with the id "thisistheid"....
+Updating existing Hosted Page with the id "thisistheid".... ✔
+"
 `;
 
 exports[`ui:deploy interacting with Platform client when no page id argument is passed, a page with the same name already exists, the user declines the overwrite, it should not call hostedPages.update 1`] = `[CLI Error: Page name must be unique, try changing the "name" field in "coveo.deploy.json".]`;

--- a/packages/cli/core/src/commands/ui/deploy.spec.ts
+++ b/packages/cli/core/src/commands/ui/deploy.spec.ts
@@ -163,7 +163,7 @@ describe('ui:deploy', () => {
         ({
           initialize: () => Promise.resolve(),
           hostedPages: {
-            create: mockHostedPageCreate.mockResolvedValue({}),
+            create: mockHostedPageCreate.mockResolvedValue({id: 'somePageId'}),
             update: mockHostedPageUpdate.mockResolvedValue({}),
             list: mockHostedPageList.mockResolvedValue({
               items: [],
@@ -469,12 +469,14 @@ describe('ui:deploy', () => {
       .command(['ui:deploy'])
       .it(
         'should call hostedPages.list and hostedPages.create when no page id argument is passed',
-        () => {
+        ({stdout, stderr}) => {
           expect(mockHostedPageList).toHaveBeenCalledWith(
             expect.objectContaining({
               filter: expectedHostedPage.name,
             })
           );
+          expect(stdout).toMatchSnapshot();
+          expect(stderr).toMatchSnapshot();
           expect(mockHostedPageCreate).toHaveBeenCalledWith(expectedHostedPage);
         }
       );
@@ -543,7 +545,9 @@ describe('ui:deploy', () => {
       .command(['ui:deploy', `-p=${pageTestId}`])
       .it(
         'when a page id argument is passed, it should call hostedPages.update',
-        () => {
+        ({stdout, stderr}) => {
+          expect(stdout).toMatchSnapshot();
+          expect(stderr).toMatchSnapshot();
           expect(mockHostedPageUpdate).toHaveBeenCalledWith({
             ...expectedHostedPage,
             id: pageTestId,

--- a/packages/cli/core/src/commands/ui/deploy.ts
+++ b/packages/cli/core/src/commands/ui/deploy.ts
@@ -227,7 +227,7 @@ export default class Deploy extends CLICommand {
   private async confirmOverwrite(): Promise<void | never> {
     if (
       !(await CliUx.ux.confirm(dedent`
-      Overwrite page with ID: "${this.pageId}" in organization ${this.organization}?`))
+      Overwrite page with ID: "${this.pageId}" in organization ${this.organization}? (y/n)`))
     ) {
       this.error(
         'Page name must be unique, try changing the "name" field in "coveo.deploy.json".'

--- a/packages/cli/core/src/commands/ui/deploy.ts
+++ b/packages/cli/core/src/commands/ui/deploy.ts
@@ -284,15 +284,16 @@ export default class Deploy extends CLICommand {
     startSpinner(`Creating new Hosted Page named "${page.name}".`);
 
     const response = await this.platformClient.hostedPages.create(page);
-    this.log(`Hosted Page creation successful with id "${response.id}".`);
     stopSpinner();
+    this.log(
+      `To update your page, run "coveo ${this.identifier} -p=${response.id}".`
+    );
   }
 
   private async updatePage(page: HostedPage) {
     startSpinner(`Updating existing Hosted Page with the id "${page.id}".`);
 
-    const response = await this.platformClient.hostedPages.update(page);
-    this.log(`Hosted Page update successful with id "${response.id}".`);
+    await this.platformClient.hostedPages.update(page);
     stopSpinner();
   }
 


### PR DESCRIPTION
<!-- For Coveo Employees only. Fill this section.

KIT-2339

-->

## Proposed changes

- For 'positive' confirmation (i.e. OK we're done), rely on the ✔️ from the spinner
- Give the user the command to update its page after they created it.


## Testing

- [x] Unit Tests
- [x] E2E