### PR TITLE
fix: missing secrets mapping

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,3 +86,8 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           VERSION: ${{ inputs.version }}
           DEBUG: ${{ inputs.debug && '*' || '' }}
+          RELEASER_APP_ID: ${{ secrets.RELEASER_APP_ID }}
+          RELEASER_PRIVATE_KEY: ${{ secrets.RELEASER_PRIVATE_KEY }}
+          RELEASER_CLIENT_ID: ${{ secrets.RELEASER_CLIENT_ID }}
+          RELEASER_CLIENT_SECRET: ${{ secrets.RELEASER_CLIENT_SECRET }}
+          RELEASER_INSTALLATION_ID: ${{ secrets.RELEASER_INSTALLATION_ID }}

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "commit-msg": "node ./hooks/commit-msg.js",
     "pre-commit": "lint-staged",
     "postinstall": "patch-package && nx run-many --target=postinstall --all",
-    "release": "npm run nx:graph && npm run release:phase1 && npm run release:phase2",
+    "release": "npm run nx:graph && npm run release:phase0 && npm run release:phase1 && npm run release:phase2",
     "nx:graph": "nx graph --file=topology.json",
     "release:phase0": "npx -p=@coveord/release git-lock",
     "release:phase1": "nx run-many --target=release:phase1 --all --parallel=false --output-style=stream",


### PR DESCRIPTION
<!-- For Coveo Employees only. Fill this section.

CDX-764

-->

## Proposed changes

- fix: NodeJS can't find the process.env.SOMETHING if the env is not set in the GH workflow.
- fix: actually execute the phase 0 🤦 

⚠️ because this caused a release to fail, E2E will fails, so I'll skip them ⚠️ 
