### PR TITLE
ci: remove teams and lock admin out

### DIFF
--- a/utils/release/lock-master.mjs
+++ b/utils/release/lock-master.mjs
@@ -1,9 +1,18 @@
+/**
+ * Because our release process creates release commits on our main branch,
+ * it needs to reserve the branch when running, so that no 'new commits' come up.
+ */
+
 import {Octokit} from 'octokit';
 
 const REPO_OWNER = 'coveo';
 const REPO_NAME = 'cli';
 const MAIN_BRANCH_NAME = 'master';
-
+const COVEO_CLI_MASTER = {
+  owner: REPO_OWNER,
+  repo: REPO_NAME,
+  branch: MAIN_BRANCH_NAME,
+};
 export const limitWriteAccessToBot = () => changeBranchRestrictions(true);
 
 export const removeWriteAccessRestrictions = () =>
@@ -13,27 +22,16 @@ async function changeBranchRestrictions(onlyBot) {
   const octokit = new Octokit({auth: process.env.GITHUB_CREDENTIALS});
   if (onlyBot) {
     await octokit.rest.repos.setTeamAccessRestrictions({
-      branch: MAIN_BRANCH_NAME,
-      owner: REPO_OWNER,
-      repo: REPO_NAME,
+      ...COVEO_CLI_MASTER,
       teams: [],
     });
-    await octokit.rest.repos.setAdminBranchProtection({
-      branch: MAIN_BRANCH_NAME,
-      owner: REPO_OWNER,
-      repo: {},
-    });
+
+    await octokit.rest.repos.setAdminBranchProtection(COVEO_CLI_MASTER);
   } else {
     await octokit.rest.repos.setTeamAccessRestrictions({
-      branch: MAIN_BRANCH_NAME,
-      owner: REPO_OWNER,
-      repo: REPO_NAME,
+      ...COVEO_CLI_MASTER,
       teams: ['dx'],
     });
-    await octokit.rest.repos.setAdminBranchProtection({
-      branch: MAIN_BRANCH_NAME,
-      owner: REPO_OWNER,
-      repo: REPO_NAME,
-    });
+    await octokit.rest.repos.deleteAdminBranchProtection(COVEO_CLI_MASTER);
   }
 }


### PR DESCRIPTION
<!-- For Coveo Employees only. Fill this section.

CDX-724

-->

## Proposed changes

The data ` getBranchProtection` requires a lot of processing to be usable for the update call.
Instead, let's do 2x APIs call (per lock or unlock action):
 - Include/remove admin in the write protection (just to be safe)
 - Remove/Add the team in the authorized folks.
 
 The app will always have access