### PR TITLE
ci: fix missing imports, bad func usage, add fail check when release in progress

### DIFF
--- a/.github/workflows/git-lock-fail.yml
+++ b/.github/workflows/git-lock-fail.yml
@@ -1,0 +1,13 @@
+name: 'master lock validator'
+
+on:
+  pull_request:
+    branches: [master]
+    paths:
+      - '.git-lock'
+
+jobs:
+  git-locked:
+    runs-on: ubuntu-20.04
+    steps:
+      - run: exit 1

--- a/.github/workflows/git-lock-success.yml
+++ b/.github/workflows/git-lock-success.yml
@@ -1,0 +1,13 @@
+name: 'master lock validator'
+
+on:
+  pull_request:
+    branches: [master]
+    paths-ignore:
+      - '.git-lock'
+
+jobs:
+  git-locked:
+    runs-on: ubuntu-20.04
+    steps:
+      - run: exit 0

--- a/package-lock.json
+++ b/package-lock.json
@@ -13269,6 +13269,7 @@
       "version": "1.0.16",
       "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz",
       "integrity": "sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==",
+      "dev": true,
       "engines": {
         "node": ">= 4.9.1"
       }
@@ -27079,7 +27080,8 @@
     "node_modules/text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-      "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw=="
+      "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
+      "dev": true
     },
     "node_modules/textextensions": {
       "version": "5.15.0",
@@ -31469,6 +31471,9 @@
         "git-lock": "git-lock.mjs",
         "git-publish-all": "git-publish-all.mjs",
         "npm-publish": "npm-publish-package.mjs"
+      },
+      "devDependencies": {
+        "typescript": "4.9.5"
       }
     },
     "utils/verdaccio-starter": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -7318,6 +7318,25 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/conventional-changelog-writer": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/conventional-changelog-writer/-/conventional-changelog-writer-4.0.2.tgz",
+      "integrity": "sha512-3WZjXOh1k2FYDZlmR/lFCaTJlOGTfqOW0PWd4A1hwIVVSk5fWP8fRR9228DiEbcq9ZrQl07ACbPpxGCCEJ6cQQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/conventional-commits-parser": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/conventional-commits-parser": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/conventional-commits-parser/-/conventional-commits-parser-3.0.3.tgz",
+      "integrity": "sha512-aoUKfRQYvGMH+spFpOTX9jO4nZoz9/BKp4hlHPxL3Cj2r2Xj+jEcwlXtFIyZr5uL8bh1nbWynDEYaAota+XqPg==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/cookie-session": {
       "version": "2.0.44",
       "resolved": "https://registry.npmjs.org/@types/cookie-session/-/cookie-session-2.0.44.tgz",
@@ -31473,6 +31492,7 @@
         "npm-publish": "npm-publish-package.mjs"
       },
       "devDependencies": {
+        "@types/conventional-changelog-writer": "^4.0.2",
         "typescript": "4.9.5"
       }
     },

--- a/utils/release/git-lock.mjs
+++ b/utils/release/git-lock.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import {gitPull, getSHA1fromRef} from '@coveo/semantic-monorepo-tools';
-import dedent from 'ts-dedent';
+import {dedent} from 'ts-dedent';
 
 import {
   limitWriteAccessToBot,

--- a/utils/release/git-lock.mjs
+++ b/utils/release/git-lock.mjs
@@ -1,15 +1,24 @@
 #!/usr/bin/env node
 
-import {gitPull, getSHA1fromRef} from '@coveo/semantic-monorepo-tools';
+import {
+  gitPull,
+  getSHA1fromRef,
+  gitCommit,
+  gitPush,
+  gitAdd,
+} from '@coveo/semantic-monorepo-tools';
 import {dedent} from 'ts-dedent';
 
 import {
   limitWriteAccessToBot,
   removeWriteAccessRestrictions,
 } from './lock-master.mjs';
+import {writeFileSync} from 'node:fs';
+import {spawnSync} from 'node:child_process';
 
 const isPrerelease = process.env.IS_PRERELEASE === 'true';
 const noLockRequired = Boolean(process.env.NO_LOCK);
+const PATH = '.';
 
 const ensureUpToDateBranch = async () => {
   // Lock-out master
@@ -29,6 +38,18 @@ const ensureUpToDateBranch = async () => {
   }
 };
 
+/**
+ * This will make .github\workflows\git-lock-fail.yml run and thus fail the associated check.
+ */
+const lockBranch = async () => {
+  writeFileSync('.git-lock', '');
+  await gitAdd('.git-lock');
+  await gitCommit('lock master', PATH);
+  await gitPush();
+  spawnSync('git', ['reset', '--hard', 'HEAD~1']);
+};
+
 if (!(isPrerelease || noLockRequired)) {
   await ensureUpToDateBranch();
+  await lockBranch();
 }

--- a/utils/release/git-publish-all.mjs
+++ b/utils/release/git-publish-all.mjs
@@ -204,6 +204,7 @@ async function commitChanges(releaseNumber, commitMessage, octokit) {
     repo: REPO_NAME,
     ref: `refs/heads/${mainBranchName}`,
     sha: commit.data.sha,
+    force: true,
   });
 
   // Delete the temp branch

--- a/utils/release/git-publish-all.mjs
+++ b/utils/release/git-publish-all.mjs
@@ -155,7 +155,7 @@ const getCliChangelog = () => {
 })();
 
 /**
- *
+ * "Craft" the signed release commit.
  * @param {string|number} releaseNumber
  * @param {string} commitMessage
  * @param {Octokit} octokit

--- a/utils/release/git-publish-all.mjs
+++ b/utils/release/git-publish-all.mjs
@@ -14,9 +14,17 @@ import {
   npmBumpVersion,
   getSHA1fromRef,
   gitSetupUser,
+  gitCreateBranch,
+  gitCheckoutBranch,
+  gitAdd,
+  gitWriteTree,
+  gitCommitTree,
+  gitUpdateRef,
+  gitPublishBranch,
 } from '@coveo/semantic-monorepo-tools';
 import {Octokit} from 'octokit';
 import {createAppAuth} from '@octokit/auth-app';
+// @ts-ignore no dts is ok.
 import angularChangelogConvention from 'conventional-changelog-angular';
 import {dedent} from 'ts-dedent';
 import {readFileSync, writeFileSync} from 'fs';
@@ -66,9 +74,9 @@ const getCliChangelog = () => {
   currentVersionTag.inc('prerelease');
   const npmNewVersion = currentVersionTag.format();
   // Write release version in the root package.json
-  await npmBumpVersion(npmNewVersion);
+  await npmBumpVersion(npmNewVersion, PATH);
 
-  const releaseNumber = currentVersionTag.prerelease;
+  const releaseNumber = currentVersionTag.prerelease[0];
   const gitNewTag = `release-${releaseNumber}`;
 
   // Find all changes since last release and generate the changelog.
@@ -136,7 +144,7 @@ const getCliChangelog = () => {
   }
   const releaseBody = getCliChangelog();
   const cliLatestTag = cliReleaseInfoMatch[0];
-  const cliVersion = cliReleaseInfoMatch.groups.version;
+  const cliVersion = cliReleaseInfoMatch?.groups?.version;
   await octokit.rest.repos.createRelease({
     owner: REPO_OWNER,
     repo: REPO_NAME,
@@ -146,6 +154,13 @@ const getCliChangelog = () => {
   });
 })();
 
+/**
+ *
+ * @param {string|number} releaseNumber
+ * @param {string} commitMessage
+ * @param {Octokit} octokit
+ * @returns {Promise<string>}
+ */
 async function commitChanges(releaseNumber, commitMessage, octokit) {
   // Get latest commit and name of the main branch.
   const mainBranchName = await getCurrentBranchName();
@@ -200,7 +215,10 @@ function updateRootReadme() {
   const usageRegExp = /^<!-- usage -->(.|\n)*<!-- usagestop -->$/m;
   const cliReadme = readFileSync('packages/cli/core/README.md', 'utf-8');
   let rootReadme = readFileSync('README.md', 'utf-8');
-  const cliUsage = usageRegExp.exec(cliReadme);
-  rootReadme.replace(usageRegExp, cliUsage[0]);
+  const cliUsage = usageRegExp.exec(cliReadme)?.[0];
+  if (!cliUsage) {
+    return;
+  }
+  rootReadme.replace(usageRegExp, cliUsage);
   writeFileSync('README.md', rootReadme);
 }

--- a/utils/release/lock-master.mjs
+++ b/utils/release/lock-master.mjs
@@ -18,6 +18,10 @@ export const limitWriteAccessToBot = () => changeBranchRestrictions(true);
 export const removeWriteAccessRestrictions = () =>
   changeBranchRestrictions(false);
 
+/**
+ * Lock/Unlock the main branch to only allow the 🤖 to write on it.
+ * @param {boolean} onlyBot
+ */
 async function changeBranchRestrictions(onlyBot) {
   const octokit = new Octokit({auth: process.env.GITHUB_CREDENTIALS});
   if (onlyBot) {

--- a/utils/release/lock-master.mjs
+++ b/utils/release/lock-master.mjs
@@ -25,17 +25,30 @@ export const removeWriteAccessRestrictions = () =>
 async function changeBranchRestrictions(onlyBot) {
   const octokit = new Octokit({auth: process.env.GITHUB_CREDENTIALS});
   if (onlyBot) {
+    // Disallow direct write access to the team
     await octokit.rest.repos.setTeamAccessRestrictions({
       ...COVEO_CLI_MASTER,
       teams: [],
     });
-
+    // Requires branches to be up to date before merging
+    await octokit.rest.repos.updateStatusCheckProtection({
+      ...COVEO_CLI_MASTER,
+      strict: true,
+    });
+    // Requires admins to pass the status checks
     await octokit.rest.repos.setAdminBranchProtection(COVEO_CLI_MASTER);
   } else {
+    // Allow direct write access to the team
     await octokit.rest.repos.setTeamAccessRestrictions({
       ...COVEO_CLI_MASTER,
       teams: ['dx'],
     });
+    // Allow admins to bypass the status checks
     await octokit.rest.repos.deleteAdminBranchProtection(COVEO_CLI_MASTER);
+    // Do not requires branches to be up to date before merging
+    await octokit.rest.repos.updateStatusCheckProtection({
+      ...COVEO_CLI_MASTER,
+      strict: false,
+    });
   }
 }

--- a/utils/release/npm-publish-package.mjs
+++ b/utils/release/npm-publish-package.mjs
@@ -172,10 +172,10 @@ async function updateWorkspaceDependent(version) {
 }
 
 /**
- *
- * @param {any} packageJson
- * @param {string} dependency
- * @param {string} version
+ * Update all instancies of the `dependency` in the `packageJson` to the given `version`.
+ * @param {any} packageJson the packageJson object to update
+ * @param {string} dependency the dependency to look for and update
+ * @param {string} version the version to update to.
  */
 function updateDependency(packageJson, dependency, version) {
   for (const dependencyType of [
@@ -190,7 +190,7 @@ function updateDependency(packageJson, dependency, version) {
 }
 
 /**
- *
+ * Append `.cmd` to the input if the runtime OS is Windows.
  * @param {string} cmd
  * @returns
  */

--- a/utils/release/npm-publish-package.mjs
+++ b/utils/release/npm-publish-package.mjs
@@ -126,7 +126,7 @@ const isPrerelease = process.env.IS_PRERELEASE === 'true';
 })();
 
 /**
- *
+ * Update the version of the package in the other packages of the workspace
  * @param {string} version
  */
 async function updateWorkspaceDependent(version) {
@@ -205,6 +205,9 @@ function isPrivatePackage() {
 }
 
 /**
+ * Compute the next beta version of the package,
+ * based on what the next gold version would be,
+ * and the latest beta version published.
  *
  * @param {string} packageName
  * @param {string} nextGoldVersion
@@ -212,12 +215,13 @@ function isPrivatePackage() {
  */
 async function getNextBetaVersion(packageName, nextGoldVersion) {
   let nextBetaVersion = `${nextGoldVersion}-0`;
+
   const registryMeta = await fetchNpm(packageName);
 
   /**
    * @type {string[]}
    */
-  // @ts-ignore force-cast.
+  // @ts-ignore force-cast: `fetchNpm` do not returns a `Record<string,unknown>, which is hard to work with.
   const versions = Object.keys(registryMeta.versions);
   const nextGoldMatcher = new RegExp(`${nextGoldVersion}-\\d+`);
   const matchingPreReleasedVersions = versions

--- a/utils/release/package.json
+++ b/utils/release/package.json
@@ -15,6 +15,7 @@
     "ts-dedent": "2.2.0"
   },
   "devDependencies": {
+    "@types/conventional-changelog-writer": "^4.0.2",
     "typescript": "4.9.5"
   },
   "bin": {

--- a/utils/release/package.json
+++ b/utils/release/package.json
@@ -14,9 +14,15 @@
     "semver": "7.3.8",
     "ts-dedent": "2.2.0"
   },
+  "devDependencies": {
+    "typescript": "4.9.5"
+  },
   "bin": {
     "git-lock": "./git-lock.mjs",
     "npm-publish": "./npm-publish-package.mjs",
     "git-publish-all": "./git-publish-all.mjs"
+  },
+  "scripts": {
+    "test": "tsc"
   }
 }

--- a/utils/release/tsconfig.json
+++ b/utils/release/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "ESNext",
+    "moduleResolution": "nodenext",
+    "allowJs": true,
+    "checkJs": true,
+    "skipLibCheck": true,
+    "noEmit": true
+  },
+  "exclude": ["node_modules"],
+  "include": ["*.mjs"]
+}


### PR DESCRIPTION
<!-- For Coveo Employees only. Fill this section.

CDX-724

-->

## Proposed changes

- Fixes missing imports that caused https://github.com/coveo/cli/actions/runs/4597808599/jobs/8121171408 :x:
- Fix-it-twice: Typescript checks on the JS files. (I elected a JS check instead of using compilation or ts-node to KISS)
- Add further protection against merging while a release is in progress

## New protections

Currently (assuming it was working), if a PR has all its checks ✅, we as admin could still merge it.
The only solution to prevent an admin to merge is to make a check of the PR to fail
To do that, I used the logic we had for the 'rogue' package-lock protection: a check that exit 1 or 0 depending on the presence of a file or not.
To enforce it, I need to "Requires branches to be up to date before merging", otherwise no further checks would be made.

So now to lock the branch:
 - We verify the main branch hasn't changed
 - We write and commit-push a 'lockfile' into the repo: this is the actual 'lock': from here, until this file get removed from master, nothing can go in or out.
 - We reset the local to the commit before (indeed we don't want to keep this file or commit)
 - We continue the process as usual
 - When we set where `master` should ref, we use 'force' because it is not a fast-forward operation. (i.e. we want to remove 'gitlock'
