### PR TITLE
ci: relax restrictions enough so the bot can pass

### DIFF
--- a/utils/release/lock-master.mjs
+++ b/utils/release/lock-master.mjs
@@ -20,35 +20,14 @@ export const removeWriteAccessRestrictions = () =>
 
 /**
  * Lock/Unlock the main branch to only allow the 🤖 to write on it.
+ * Note: admins can always bypass.
  * @param {boolean} onlyBot
  */
 async function changeBranchRestrictions(onlyBot) {
   const octokit = new Octokit({auth: process.env.GITHUB_CREDENTIALS});
-  if (onlyBot) {
-    // Disallow direct write access to the team
-    await octokit.rest.repos.setTeamAccessRestrictions({
-      ...COVEO_CLI_MASTER,
-      teams: [],
-    });
-    // Requires branches to be up to date before merging
-    await octokit.rest.repos.updateStatusCheckProtection({
-      ...COVEO_CLI_MASTER,
-      strict: true,
-    });
-    // Requires admins to pass the status checks
-    await octokit.rest.repos.setAdminBranchProtection(COVEO_CLI_MASTER);
-  } else {
-    // Allow direct write access to the team
-    await octokit.rest.repos.setTeamAccessRestrictions({
-      ...COVEO_CLI_MASTER,
-      teams: ['dx'],
-    });
-    // Allow admins to bypass the status checks
-    await octokit.rest.repos.deleteAdminBranchProtection(COVEO_CLI_MASTER);
-    // Do not requires branches to be up to date before merging
-    await octokit.rest.repos.updateStatusCheckProtection({
-      ...COVEO_CLI_MASTER,
-      strict: false,
-    });
-  }
+  // Requires branches to be up to date before merging
+  await octokit.rest.repos.updateStatusCheckProtection({
+    ...COVEO_CLI_MASTER,
+    strict: onlyBot,
+  });
 }


### PR DESCRIPTION
<!-- For Coveo Employees only. Fill this section.

CDX-764

-->

## Proposed changes

> Deploy keys with write access can perform the same actions as an organization member with admin access

https://docs.github.com/en/authentication/connecting-to-github-with-ssh/managing-deploy-keys#deploy-keys

So, when using `setAdminBranchProtection`, I prevent the bot to deploy with the deploy key :(
So I need to remove this restrictions, and from there the `setTeamAccessRestrictions` become useless because the restrictions won't be a hard enforcement, but as admin, you will have to ignore several warnings to go ahead and merge :finnadie: :
![image](https://user-images.githubusercontent.com/12366410/229919893-8cbee9c2-9000-4592-8c0b-1e8daae8a339.png)

Collaborators and other with write access won't be able to merge at all.