### PR TITLE
fix(cli): do not reassign fetch after polyfill

### DIFF
--- a/packages/cli/commons/src/platform/authenticatedClient.ts
+++ b/packages/cli/commons/src/platform/authenticatedClient.ts
@@ -3,7 +3,7 @@ import PlatformClient from '@coveo/platform-client';
 import {Config, Configuration} from '../config/config';
 import {castEnvironmentToPlatformClient} from './environment';
 import globalConfig from '../config/globalConfig';
-import {lt} from 'semver';
+import 'fetch-undici-polyfill';
 
 export class AuthenticatedClient {
   public cfg: Config;
@@ -35,8 +35,9 @@ export class AuthenticatedClient {
     if (proxyServer) {
       setGlobalDispatcher(new ProxyAgent(proxyServer));
     }
-    if (lt(process.version, '18.0.0')) {
-      Object.assign(global, {FormData, fetch});
+    // TODO: CDX-1407, remove this https://developer.mozilla.org/en-US/docs/Web/API/FormData#browser_compatibility
+    if (!Object.keys(global).includes('FormData')) {
+      Object.assign(global, {FormData});
     }
     return new PlatformClient({
       globalRequestSettings,


### PR DESCRIPTION
<!-- For Coveo Employees only. Fill this section.

CDX-1405

-->

## Proposed changes

- Relegate all fetch polyfill to fetch-undici-polyfill
- Change the polyfill condition for FormData

## Testing

- Corner-case that'll disappear in less than a semester, so I decided to not create automated tests for it.
- [x] Manual Tests:
  - While on branch `master`, run `nvm use 16; /path-to-cli-repo/packages/cli/core/bin/dev auth:login` and see the bug
  - While on branch `CDX-1405`, run `nvm use 16; /path-to-cli-repo/packages/cli/core/bin/dev auth:login` and see no bug
<!-- How did you test your changeset?  -->
