### PR TITLE
chore(workflows): don't use always() in workflows

### DIFF
--- a/.github/actions/e2e-clean/action.yml
+++ b/.github/actions/e2e-clean/action.yml
@@ -20,16 +20,16 @@ runs:
       shell: bash
       env:
         DISPLAY: ':1'
-      if: always()
+      if: cancelled() || failure() || success()
       run: |
         Xvfb :1 -screen 0 1024x768x16 & sleep 1
         xdg-settings set default-web-browser google-chrome.desktop
         node -r ts-node/register/transpile-only packages/cli-e2e/cleaning.ts
     - name: Delete test orgs
       shell: bash
-      if: always()
+      if: cancelled() || failure() || success()
       run: node ./scripts/cleaning/delete-orgs.js
     - name: Delete test API key
       shell: bash
-      if: always()
+      if: cancelled() || failure() || success()
       run: node ./scripts/cleaning/delete-api-keys.js

--- a/.github/actions/e2e-login/action.yml
+++ b/.github/actions/e2e-login/action.yml
@@ -44,7 +44,7 @@ runs:
         echo "${{ env.E2E_TOKEN_PASSPHRASE }}" | gpg -a --batch --passphrase-fd 0 --symmetric --cipher-algo AES256 --output encodedConfig $CLI_CONFIG_PATH
         echo "cliConfigJson=$(base64 -w 0 encodedConfig)" >> $GITHUB_OUTPUT
     - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3
-      if: always()
+      if: cancelled() || failure() || success()
       with:
         name: login-test-artifacts
         path: ./packages/cli-e2e/artifacts

--- a/.github/actions/e2e-run/action.yml
+++ b/.github/actions/e2e-run/action.yml
@@ -73,7 +73,7 @@ runs:
       working-directory: packages/cli-e2e
       run: npm run jest:ci -- ${{inputs.spec}}
     - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3
-      if: always()
+      if: cancelled() || failure() || success()
       with:
         name: ${{inputs.os}}-${{inputs.spec}}-test-artifacts
         path: ./packages/cli-e2e/artifacts

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -122,7 +122,7 @@ jobs:
       - name: Setup E2E tests
         run: node -r ts-node/register/transpile-only packages/cli-e2e/setup/ci-verdaccio.ts
       - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3
-        if: always()
+        if: cancelled() || failure() || success()
         with:
           name: ${{matrix.os}}-verdaccio-publish-artifacts
           path: ./packages/cli-e2e/artifacts

--- a/.github/workflows/delete-resources.yml
+++ b/.github/workflows/delete-resources.yml
@@ -25,15 +25,15 @@ jobs:
       - run: npm ci
       - name: Resume org
         timeout-minutes: 30
-        if: always()
+        if: cancelled() || failure() || success()
         run: node ./scripts/cleaning/wake-org.mjs || true
       - name: Delete test API keys
         timeout-minutes: 30
-        if: always()
+        if: cancelled() || failure() || success()
         run: node ./scripts/cleaning/delete-api-keys.js --olderThan 1d
       - name: Delete test orgs
         timeout-minutes: 30
-        if: always()
+        if: cancelled() || failure() || success()
         run: |
           Xvfb :1 -screen 0 1024x768x16 & sleep 1
           xdg-settings set default-web-browser google-chrome.desktop
@@ -42,7 +42,7 @@ jobs:
         env:
           DISPLAY: ':1'
       - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3
-        if: always()
+        if: cancelled() || failure() || success()
         with:
           name: cleaning-artifacts
           path: ./packages/cli-e2e/artifacts


### PR DESCRIPTION
Related Issue
DT-5692

## Hi, what's this?
👋 We have come across a problem with using `if: always()` in workflows. The basic gist is that these steps become un-cancellable, possibly creating all sorts of unexpected problems. This is less frequent with GitHub hosted runners, but it can happen.

This PR introduces and workaround this problem by explicitly defining the different states the step can face.
Namely:
* `success()`
* `cancelled()`
* `failure()`

This way, you get the `always()` behaviour without it's possible caveats.

## I don't want this change
In a way, this is more of a "we really recommend this" kind of PR. That is because you may never face the problem I'm talking about, but when you do, you'll want this workaround.

If you decide against merging this, please make sure you mention this if you need support in the future to help us identify this issue faster.

## Final notes
Please review and merge this PR. Since this is a CI change, you don't need to release this change.

This PR is created as part of a large batch. I would appreciate it if you could merge this yourself to ease the amount of followup on my end.

## References
* https://coveo.slack.com/archives/CBP3GTFTQ/p1679495407426389 (Coveo internal)
* https://github.com/orgs/community/discussions/26303