### PR TITLE
test(verdaccio): ensure package publish order

### DIFF
--- a/packages/ui/atomic/create-atomic-component/package.json
+++ b/packages/ui/atomic/create-atomic-component/package.json
@@ -38,5 +38,13 @@
     "ts-jest": "^29.0.5",
     "ts-node": "^10.9.1",
     "typescript": "^4.9.5"
+  },
+  "peerDependencies": {
+    "@coveo/atomic-component-health-check": "1.0.4"
+  },
+  "peerDependenciesMeta": {
+    "@coveo/atomic-component-health-check": {
+      "optional": true
+    }
   }
 }

--- a/packages/ui/atomic/create-atomic-result-component/package.json
+++ b/packages/ui/atomic/create-atomic-result-component/package.json
@@ -38,5 +38,13 @@
     "ts-node": "^10.9.1",
     "typescript": "^4.9.5",
     "tree-kill-promise": "3.0.1"
+  },
+  "peerDependencies": {
+    "@coveo/atomic-component-health-check": "1.0.4"
+  },
+  "peerDependenciesMeta": {
+    "@coveo/atomic-component-health-check": {
+      "optional": true
+    }
   }
 }


### PR DESCRIPTION
<!-- For Coveo Employees only. Fill this section.

CDX-1393

-->

## Proposed changes

Previous logic doesn't ensure that the local dependencies of the package are published prior.
This does it (very inefficiently)

The algorithm is _very_ naive but should work
I'm honestly too lazy to create a proper tree struct. here.


## Testing

https://github.com/coveo/cli/pull/1278
https://github.com/coveo/cli/pull/1279

If those are green, all good 😎 