### PR TITLE
fix(cli): use proper package

### DIFF
--- a/packages/cli/core/src/lib/atomic/__snapshots__/createAtomicProject.spec.ts.snap
+++ b/packages/cli/core/src/lib/atomic/__snapshots__/createAtomicProject.spec.ts.snap
@@ -40,12 +40,12 @@ exports[`createAtomicProject createAtomicApp() without options.pageId calls \`np
 ]
 `;
 
-exports[`createAtomicProject createAtomicLib() calls \`npx @coveo/create-atomic-project\` properly 1`] = `
+exports[`createAtomicProject createAtomicLib() calls \`npx @coveo/create-atomic-component-project\` properly 1`] = `
 [
   "npm",
   [
     "init",
-    "@coveo/atomic-project",
+    "@coveo/create-atomic-component-project",
   ],
   {
     "cwd": "kewlProject",

--- a/packages/cli/core/src/lib/atomic/createAtomicProject.spec.ts
+++ b/packages/cli/core/src/lib/atomic/createAtomicProject.spec.ts
@@ -82,7 +82,7 @@ describe('createAtomicProject', () => {
       expect(mockedMkdirSync).toBeCalledWith('kewlProject');
     });
 
-    it('calls `npx @coveo/create-atomic-project` properly', async () => {
+    it('calls `npx @coveo/create-atomic-component-project` properly', async () => {
       await createAtomicLib({projectName: 'kewlProject'});
 
       expect(mockedSpawnProcess).toBeCalledTimes(1);

--- a/packages/cli/core/src/lib/atomic/createAtomicProject.ts
+++ b/packages/cli/core/src/lib/atomic/createAtomicProject.ts
@@ -27,7 +27,8 @@ interface CreateAppOptions {
   cfg: Configuration;
 }
 export const atomicAppInitializerPackage = '@coveo/create-atomic';
-export const atomicLibInitializerPackage = '@coveo/atomic-project';
+export const atomicLibInitializerPackage =
+  '@coveo/create-atomic-component-project';
 
 const supportedNodeVersions = '16.x || 18.x';
 


### PR DESCRIPTION
https://coveord.atlassian.net/browse/CDX-1420


## Proposed changes

Use the proper packageName. Derp.

## Testing

I pondered about moving the E2E scope to englobe the CLI, but I think the cost/gain ratio ain't good so I chose to go by with UT.

- [x] Unit Tests
- [x] Manual tests:
  - try to run `coveo atomic:init --type=lib potato` -> wont work, 
![image](https://user-images.githubusercontent.com/12366410/233164056-9a98aef7-8ad8-4b7f-9d0b-2666d4977eaa.png)
  - try to run `bin/dev atomic:init --type=lib potato` ✔️ 