### PR TITLE
feat(atomic): meta update + major bump

### DIFF
--- a/packages/ui/atomic/create-atomic-component-project/package.json
+++ b/packages/ui/atomic/create-atomic-component-project/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@coveo/create-atomic-component-project",
   "version": "0.2.1",
-  "description": "",
+  "description": "Initialize a Coveo Atomic Library Project",
   "type": "module",
   "main": "index.js",
   "bin": "index.js",
@@ -15,8 +15,12 @@
     "release:phase1": "npx -p=@coveord/release npm-publish",
     "test": "node --experimental-vm-modules --no-warnings ../../../../node_modules/jest/bin/jest.js"
   },
-  "keywords": [],
-  "author": "",
+  "keywords": [
+    "coveo",
+    "cli",
+    "atomic"
+  ],
+  "author": "Coveo",
   "license": "Apache-2.0",
   "publishConfig": {
     "access": "public"

--- a/packages/ui/atomic/create-atomic-component/package.json
+++ b/packages/ui/atomic/create-atomic-component/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@coveo/create-atomic-component",
   "version": "0.2.4",
-  "description": "",
+  "description": "Initialize a Coveo Atomic Component",
   "type": "module",
   "main": "index.js",
   "bin": "index.js",
@@ -15,8 +15,12 @@
     "release:phase1": "npx -p=@coveord/release npm-publish",
     "test": "node --experimental-vm-modules --no-warnings ../../../../node_modules/jest/bin/jest.js"
   },
-  "keywords": [],
-  "author": "",
+  "keywords": [
+    "coveo",
+    "cli",
+    "atomic"
+  ],
+  "author": "Coveo",
   "license": "Apache-2.0",
   "publishConfig": {
     "access": "public"

--- a/packages/ui/atomic/create-atomic-result-component/package.json
+++ b/packages/ui/atomic/create-atomic-result-component/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@coveo/create-atomic-result-component",
   "version": "0.2.4",
-  "description": "",
+  "description": "Initialize a Coveo Atomic Result Component",
   "type": "module",
   "main": "index.js",
   "bin": "index.js",
@@ -15,8 +15,12 @@
     "release:phase1": "npx -p=@coveord/release npm-publish",
     "test": "node --experimental-vm-modules --no-warnings ../../../../node_modules/jest/bin/jest.js"
   },
-  "keywords": [],
-  "author": "",
+  "keywords": [
+    "coveo",
+    "cli",
+    "atomic"
+  ],
+  "author": "Coveo",
   "license": "Apache-2.0",
   "publishConfig": {
     "access": "public"

--- a/packages/ui/atomic/health-check/package.json
+++ b/packages/ui/atomic/health-check/package.json
@@ -32,7 +32,10 @@
   "files": [
     "dist"
   ],
-  "keywords": [],
+  "keywords": [
+    "coveo",
+    "atomic"
+  ],
   "dependencies": {
     "chalk": "4.1.2",
     "zod": "^3.21.4"


### PR DESCRIPTION
Same as #1282, but this time will be merged with:

```
feat(atomic): release of ACCD

BREAKING CHANGE: ACCD is now stable.
```

The latest merge failed because I wrongly thought that the angular convention would tolerate `type(scope)!:` for a breaking change, but the `!` is a no go.