### PR TITLE
fix(atomic): remove create- prefix when using npm init

### DIFF
--- a/packages/cli/core/src/lib/atomic/__snapshots__/createAtomicProject.spec.ts.snap
+++ b/packages/cli/core/src/lib/atomic/__snapshots__/createAtomicProject.spec.ts.snap
@@ -45,7 +45,7 @@ exports[`createAtomicProject createAtomicLib() calls \`npx @coveo/create-atomic-
   "npm",
   [
     "init",
-    "@coveo/create-atomic-component-project",
+    "@coveo/atomic-component-project",
   ],
   {
     "cwd": "kewlProject",

--- a/packages/cli/core/src/lib/atomic/createAtomicProject.ts
+++ b/packages/cli/core/src/lib/atomic/createAtomicProject.ts
@@ -32,6 +32,9 @@ export const atomicLibInitializerPackage =
 
 const supportedNodeVersions = '16.x || 18.x';
 
+const transformPackageNameToNpmInitializer = (packageName: string) =>
+  packageName.replace('/create-', '/');
+
 export const atomicLibPreconditions = [
   IsNodeVersionInRange(supportedNodeVersions),
 ];
@@ -82,7 +85,10 @@ interface CreateLibOptions {
 export function createAtomicLib(options: CreateLibOptions) {
   const projectDirectory = resolve(options.projectName);
   mkdirSync(projectDirectory);
-  const cliArgs = ['init', atomicLibInitializerPackage];
+  const cliArgs = [
+    'init',
+    transformPackageNameToNpmInitializer(atomicLibInitializerPackage),
+  ];
   return spawnProcess(appendCmdIfWindows`npm`, cliArgs, {
     cwd: projectDirectory,
   });


### PR DESCRIPTION
https://coveord.atlassian.net/browse/CDX-1430

<!-- For Coveo Employees only. Fill this section.

CDX-1430

-->

## Proposed changes

> The init command is transformed to a corresponding npm exec operation as follows:

> npm init foo -> npm exec create-foo
> npm init @usr/foo -> npm exec @usr/create-foo
> npm init @usr -> npm exec @usr/create
> npm init @usr@2.0.0 -> npm exec @usr/create@2.0.0
> npm init @usr/foo@2.0.0 -> npm exec @usr/create-foo@2.0.0

https://docs.npmjs.com/cli/v8/commands/npm-init

![image](https://user-images.githubusercontent.com/12366410/233662770-a50793b7-ce0e-4335-a805-9aa73cfa5a21.png)

TL;DR: npm add `create-` regardless of its there or not before.

## Testing

- [x] Unit Tests: via snap
- [x] Manual Tests: tested using /bin/dev
