### PR TITLE
fix(atomic): remove spinner in `atomic:cmp`

### DIFF
--- a/packages/cli/core/src/commands/atomic/component.ts
+++ b/packages/cli/core/src/commands/atomic/component.ts
@@ -4,7 +4,6 @@ import {Flags} from '@oclif/core';
 import inquirer from 'inquirer';
 import {appendCmdIfWindows} from '../../lib/utils/os';
 import {spawnProcess} from '../../lib/utils/process';
-import {startSpinner} from '@coveo/cli-commons/utils/ux';
 import {Trackable} from '@coveo/cli-commons/preconditions/trackable';
 
 export default class AtomicInit extends CLICommand {

--- a/packages/cli/core/src/commands/atomic/component.ts
+++ b/packages/cli/core/src/commands/atomic/component.ts
@@ -33,7 +33,6 @@ export default class AtomicInit extends CLICommand {
     const {initializer, name} = await this.getSpawnOptions();
 
     const cliArgs = ['init', initializer, name];
-    startSpinner('Scaffolding project');
     await spawnProcess(appendCmdIfWindows`npm`, cliArgs);
   }
 


### PR DESCRIPTION
<!-- For Coveo Employees only. Fill this section.

CDX-1432

-->

## Proposed changes

Before:
![image](https://user-images.githubusercontent.com/12366410/233663760-5406e4ed-a6c3-42c3-a4ba-c58683fd1bf5.png)

On first usage, users may need to confirm that yes they are OK installing the init package. However the spinner mangle the stdio, making it hard for the user to proceed.

## Testing
corner case really.
- [x] Manual Tests: `/bin/dev`  tested, see 
![image](https://user-images.githubusercontent.com/12366410/233664285-bdd9b816-9fe9-400b-9778-6dfb0377645f.png)
