### PR TITLE
fix(atomic): use the initializer version from CLI

### DIFF
--- a/packages/cli/core/src/commands/atomic/__snapshots__/component.spec.ts.snap
+++ b/packages/cli/core/src/commands/atomic/__snapshots__/component.spec.ts.snap
@@ -5,7 +5,7 @@ exports[`atomic:component calls \`npm init @coveo/atomic-component\` properly 1`
   "npm",
   [
     "init",
-    "@coveo/atomic-component",
+    "@coveo/atomic-component@1.2.3",
     "foo",
   ],
 ]
@@ -16,7 +16,7 @@ exports[`atomic:component calls \`npm init @coveo/atomic-component\` when the us
   "npm",
   [
     "init",
-    "@coveo/atomic-component",
+    "@coveo/atomic-component@1.2.3",
     "foo",
   ],
 ]
@@ -27,7 +27,7 @@ exports[`atomic:component calls \`npm init @coveo/atomic-result-component\` prop
   "npm",
   [
     "init",
-    "@coveo/atomic-result-component",
+    "@coveo/atomic-result-component@1.2.3",
     "foo",
   ],
 ]
@@ -38,7 +38,7 @@ exports[`atomic:component calls \`npm init @coveo/atomic-result-component\` when
   "npm",
   [
     "init",
-    "@coveo/atomic-result-component",
+    "@coveo/atomic-result-component@1.2.3",
     "foo",
   ],
 ]

--- a/packages/cli/core/src/commands/atomic/__snapshots__/init.spec.ts.snap
+++ b/packages/cli/core/src/commands/atomic/__snapshots__/init.spec.ts.snap
@@ -8,7 +8,6 @@ exports[`atomic:init calls \`createAtomicApp\` properly 1`] = `
       "organization": "default-org",
       "region": "us",
     },
-    "initializerVersion": "latest",
     "projectName": "foo",
   },
 ]
@@ -22,7 +21,6 @@ exports[`atomic:init calls \`createAtomicApp\` properly 2`] = `
       "organization": "default-org",
       "region": "us",
     },
-    "initializerVersion": "latest",
     "projectName": "foo",
   },
 ]
@@ -36,7 +34,6 @@ exports[`atomic:init calls \`createAtomicApp\` when the user select application 
       "organization": "default-org",
       "region": "us",
     },
-    "initializerVersion": "latest",
     "projectName": "foo",
   },
 ]

--- a/packages/cli/core/src/commands/atomic/component.spec.ts
+++ b/packages/cli/core/src/commands/atomic/component.spec.ts
@@ -6,18 +6,21 @@ jest.mock('../../lib/utils/os');
 import {appendCmdIfWindows} from '../../lib/utils/os';
 jest.mock('../../lib/utils/process');
 import {spawnProcess} from '../../lib/utils/process';
-jest.mock('../../lib/utils/os');
+jest.mock('../../lib/utils/misc');
+import {getPackageVersion} from '../../lib/utils/misc';
 
 describe('atomic:component', () => {
   const mockedSpawnProcess = jest.mocked(spawnProcess);
   const mockedInquirer = jest.mocked(inquirer);
   const mockAppendCmdIfWindows = jest.mocked(appendCmdIfWindows);
+  const mockedGetPackageVersion = jest.mocked(getPackageVersion);
 
   beforeEach(() => {
     jest.resetAllMocks();
     mockAppendCmdIfWindows.mockImplementation(
       (input: TemplateStringsArray) => `${input}`
     );
+    mockedGetPackageVersion.mockReturnValue('1.2.3');
   });
 
   test

--- a/packages/cli/core/src/commands/atomic/component.ts
+++ b/packages/cli/core/src/commands/atomic/component.ts
@@ -6,6 +6,7 @@ import {appendCmdIfWindows} from '../../lib/utils/os';
 import {spawnProcess} from '../../lib/utils/process';
 import {startSpinner} from '@coveo/cli-commons/utils/ux';
 import {Trackable} from '@coveo/cli-commons/preconditions/trackable';
+import {getPackageVersion} from '../../lib/utils/misc';
 
 export default class AtomicInit extends CLICommand {
   public static description =
@@ -41,8 +42,14 @@ export default class AtomicInit extends CLICommand {
     const {args, flags} = await this.parse(AtomicInit);
     const type = flags.type || (await this.askType());
 
-    const initializer = this.getInitializerPackage(type);
-    return {initializer, name: args.name};
+    const initializerPackage = this.getInitializerPackage(type);
+
+    return {
+      initializer: `${initializerPackage}@${getPackageVersion(
+        initializerPackage
+      )}`,
+      name: args.name,
+    };
   }
 
   private async askType(): Promise<string> {

--- a/packages/cli/core/src/commands/atomic/component.ts
+++ b/packages/cli/core/src/commands/atomic/component.ts
@@ -44,10 +44,12 @@ export default class AtomicInit extends CLICommand {
 
     const initializerPackage = this.getInitializerPackage(type);
 
+    // TODO CDX-1340: Refactor the replace into a well named utils.
     return {
-      initializer: `${initializerPackage}@${getPackageVersion(
-        initializerPackage
-      )}`,
+      initializer: `${initializerPackage.replace(
+        '/create-',
+        '/'
+      )}@${getPackageVersion(initializerPackage)}`,
       name: args.name,
     };
   }
@@ -67,9 +69,9 @@ export default class AtomicInit extends CLICommand {
   private getInitializerPackage(type: string): string {
     switch (type) {
       case 'page':
-        return '@coveo/atomic-component';
+        return '@coveo/create-atomic-component';
       case 'result':
-        return '@coveo/atomic-result-component';
+        return '@coveo/create-atomic-result-component';
       default:
         throw new UnknownError();
     }

--- a/packages/cli/core/src/commands/atomic/init.ts
+++ b/packages/cli/core/src/commands/atomic/init.ts
@@ -70,7 +70,6 @@ export default class AtomicInit extends CLICommand {
   private createAtomicApp(projectName: string) {
     const cfg = this.configuration.get();
     return createAtomicApp({
-      initializerVersion: 'latest',
       projectName,
       cfg,
     });

--- a/packages/cli/core/src/lib/atomic/__snapshots__/createAtomicProject.spec.ts.snap
+++ b/packages/cli/core/src/lib/atomic/__snapshots__/createAtomicProject.spec.ts.snap
@@ -1,29 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`createAtomicProject createAtomicApp() without options.pageId calls \`npx @coveo/create-atomic\` properly 1`] = `
+exports[`createAtomicProject createAtomicApp() with options.initializerVersion set calls \`npx @coveo/create-atomic\` properly 1`] = `
 [
   "npx",
   [
-    "@coveo/create-atomic@latest",
-    "--project",
-    "potato",
-    "--org-id",
-    "bobbyOrg",
-    "--api-key",
-    "someToken",
-    "--platform-url",
-    "https://platformdev-au.cloud.coveo.com",
-    "--user",
-    "bob@coveo.com",
-  ],
-]
-`;
-
-exports[`createAtomicProject createAtomicApp() without options.pageId calls \`npx @coveo/create-atomic\` properly 2`] = `
-[
-  "npx",
-  [
-    "@coveo/create-atomic@latest",
+    "@coveo/create-atomic@test",
     "--project",
     "potato",
     "--org-id",
@@ -36,6 +17,67 @@ exports[`createAtomicProject createAtomicApp() without options.pageId calls \`np
     "bob@coveo.com",
     "--page-id",
     "pageId",
+  ],
+]
+`;
+
+exports[`createAtomicProject createAtomicApp() with options.pageId calls \`npx @coveo/create-atomic\` properly 1`] = `
+[
+  "npx",
+  [
+    "@coveo/create-atomic@1.2.3",
+    "--project",
+    "potato",
+    "--org-id",
+    "bobbyOrg",
+    "--api-key",
+    "someToken",
+    "--platform-url",
+    "https://platformdev-au.cloud.coveo.com",
+    "--user",
+    "bob@coveo.com",
+    "--page-id",
+    "pageId",
+  ],
+]
+`;
+
+exports[`createAtomicProject createAtomicApp() without options.initializerVersion calls \`npx @coveo/create-atomic\` properly and calls getPackageVersion 1`] = `
+[
+  "npx",
+  [
+    "@coveo/create-atomic@1.2.3",
+    "--project",
+    "potato",
+    "--org-id",
+    "bobbyOrg",
+    "--api-key",
+    "someToken",
+    "--platform-url",
+    "https://platformdev-au.cloud.coveo.com",
+    "--user",
+    "bob@coveo.com",
+    "--page-id",
+    "pageId",
+  ],
+]
+`;
+
+exports[`createAtomicProject createAtomicApp() without options.pageId calls \`npx @coveo/create-atomic\` properly 1`] = `
+[
+  "npx",
+  [
+    "@coveo/create-atomic@1.2.3",
+    "--project",
+    "potato",
+    "--org-id",
+    "bobbyOrg",
+    "--api-key",
+    "someToken",
+    "--platform-url",
+    "https://platformdev-au.cloud.coveo.com",
+    "--user",
+    "bob@coveo.com",
   ],
 ]
 `;

--- a/packages/cli/core/src/lib/atomic/createAtomicProject.spec.ts
+++ b/packages/cli/core/src/lib/atomic/createAtomicProject.spec.ts
@@ -11,14 +11,19 @@ jest.mock('../utils/process');
 import {spawnProcess} from '../utils/process';
 jest.mock('../utils/os');
 import {appendCmdIfWindows} from '../utils/os';
+jest.mock('../utils/misc');
+import {getPackageVersion} from '../utils/misc';
+
 import {createAtomicApp, createAtomicLib} from './createAtomicProject';
 
 describe('createAtomicProject', () => {
   const mockedSpawnProcess = jest.mocked(spawnProcess);
   const mockedAppendCmdIfWindows = jest.mocked(appendCmdIfWindows);
+  const mockedGetPackageVersion = jest.mocked(getPackageVersion);
   beforeEach(() => {
     jest.resetAllMocks();
     mockedAppendCmdIfWindows.mockImplementation((input) => `${input}`);
+    mockedGetPackageVersion.mockReturnValue('1.2.3');
   });
 
   describe('createAtomicApp()', () => {
@@ -41,7 +46,6 @@ describe('createAtomicProject', () => {
         region: Region.AU,
         version: '1.0.0',
       },
-      initializerVersion: 'latest',
       projectName: 'potato',
     };
 
@@ -57,9 +61,34 @@ describe('createAtomicProject', () => {
       });
     });
 
-    describe('without options.pageId', () => {
+    describe('with options.pageId', () => {
       it('calls `npx @coveo/create-atomic` properly', async () => {
         await createAtomicApp({...callOptions, pageId: 'pageId'});
+        expect(mockedSpawnProcess).toBeCalledTimes(1);
+        expect(mockedSpawnProcess.mock.lastCall).toMatchSnapshot();
+      });
+    });
+
+    describe('with options.initializerVersion set', () => {
+      it('calls `npx @coveo/create-atomic` properly', async () => {
+        await createAtomicApp({
+          ...callOptions,
+          initializerVersion: 'test',
+          pageId: 'pageId',
+        });
+        expect(mockedSpawnProcess).toBeCalledTimes(1);
+        expect(mockedSpawnProcess.mock.lastCall).toMatchSnapshot();
+      });
+    });
+
+    describe('without options.initializerVersion', () => {
+      it('calls `npx @coveo/create-atomic` properly and calls getPackageVersion', async () => {
+        await createAtomicApp({
+          ...callOptions,
+          initializerVersion: undefined,
+          pageId: 'pageId',
+        });
+        expect(mockedGetPackageVersion).toBeCalledTimes(1);
         expect(mockedSpawnProcess).toBeCalledTimes(1);
         expect(mockedSpawnProcess.mock.lastCall).toMatchSnapshot();
       });

--- a/packages/cli/core/src/lib/atomic/createAtomicProject.ts
+++ b/packages/cli/core/src/lib/atomic/createAtomicProject.ts
@@ -19,9 +19,10 @@ import {
   IsNpxInstalled,
   IsNodeVersionInRange,
 } from '../decorators/preconditions';
+import {getPackageVersion} from '../utils/misc';
 
 interface CreateAppOptions {
-  initializerVersion: string;
+  initializerVersion?: string;
   pageId?: string;
   projectName: string;
   cfg: Configuration;
@@ -52,7 +53,10 @@ export async function createAtomicApp(options: CreateAppOptions) {
 
   const username = await authenticatedClient.getUsername();
   const cliArgs: string[] = [
-    `${atomicAppInitializerPackage}@${options.initializerVersion}`,
+    `${atomicAppInitializerPackage}@${
+      options.initializerVersion ??
+      getPackageVersion(atomicAppInitializerPackage)
+    }`,
     '--project',
     options.projectName,
     '--org-id',


### PR DESCRIPTION
<!-- For Coveo Employees only. Fill this section.

CDX-1431

-->

## Proposed changes

We were trying to always resolves on latest, which would can causes breaking changes in the CLI if we're doing breaking change in one of the initializer. This ensure we use the version from the CLI.

## Testing

- [x] Unit Tests:
- [x] Manual Tests:
