### PR TITLE
fix: remove unnecessary `cd` instruction from success message

### DIFF
--- a/packages/ui/atomic/create-atomic-component/index.js
+++ b/packages/ui/atomic/create-atomic-component/index.js
@@ -12,13 +12,12 @@ import {cwd} from 'node:process';
 import {fileURLToPath} from 'node:url';
 
 /***************** TODO: CDX-1428: Move to @coveo/create-atomic-commons package ******************/
-const successMessage = (componentName) => {
+const successMessage = () => {
   console.log(`
   Project successfully configured
 
   We suggest that you begin by typing:
 
-  $ cd ${componentName}
   $ npm install
   $ npm start
 
@@ -134,4 +133,4 @@ if (componentName) {
   transform(transformers);
 }
 
-successMessage(componentName || 'sample-component');
+successMessage();

--- a/packages/ui/atomic/create-atomic-component/tests/__snapshots__/test.spec.ts.snap
+++ b/packages/ui/atomic/create-atomic-component/tests/__snapshots__/test.spec.ts.snap
@@ -6,7 +6,6 @@ exports[`@coveo/create-atomic-component when called in an existing project when 
 
   We suggest that you begin by typing:
 
-  $ cd oh-wow-another-component-can-you-believe-it
   $ npm install
   $ npm start
 
@@ -169,7 +168,6 @@ exports[`@coveo/create-atomic-component when called with a valid component name 
 
   We suggest that you begin by typing:
 
-  $ cd valid-component-name
   $ npm install
   $ npm start
 
@@ -284,7 +282,6 @@ exports[`@coveo/create-atomic-component when called without any args when initia
 
   We suggest that you begin by typing:
 
-  $ cd sample-component
   $ npm install
   $ npm start
 

--- a/packages/ui/atomic/create-atomic-result-component/index.js
+++ b/packages/ui/atomic/create-atomic-result-component/index.js
@@ -12,13 +12,12 @@ import {cwd} from 'node:process';
 import {fileURLToPath} from 'node:url';
 
 /***************** TODO: CDX-1428: Move to @coveo/create-atomic-commons package ******************/
-const successMessage = (componentName) => {
+const successMessage = () => {
   console.log(`
   Project successfully configured
 
   We suggest that you begin by typing:
 
-  $ cd ${componentName}
   $ npm install
   $ npm start
 
@@ -134,4 +133,4 @@ if (componentName) {
   transform(transformers);
 }
 
-successMessage(componentName || 'sample-result-component');
+successMessage();

--- a/packages/ui/atomic/create-atomic-result-component/tests/__snapshots__/test.spec.ts.snap
+++ b/packages/ui/atomic/create-atomic-result-component/tests/__snapshots__/test.spec.ts.snap
@@ -6,7 +6,6 @@ exports[`@coveo/create-atomic-result-component when called in an existing projec
 
   We suggest that you begin by typing:
 
-  $ cd oh-wow-another-component-can-you-believe-it
   $ npm install
   $ npm start
 
@@ -169,7 +168,6 @@ exports[`@coveo/create-atomic-result-component when called with a valid componen
 
   We suggest that you begin by typing:
 
-  $ cd valid-component-name
   $ npm install
   $ npm start
 
@@ -284,7 +282,6 @@ exports[`@coveo/create-atomic-result-component when called without any args when
 
   We suggest that you begin by typing:
 
-  $ cd sample-result-component
   $ npm install
   $ npm start
 


### PR DESCRIPTION
<!-- For Coveo Employees only. Fill this section.

CDX-XXX

-->

## Proposed changes

No need to `cd` as the user is already in the right cwd to start the project

<!--
    Remove this section if the PR does not include any breaking change

    If your changes includes some breaking changes in the code, thoroughly explains:
        - What are the breaking changes programmatically speaking.
        - What is the impact on the end-user (e.g. user cannot do X anymore).
        - What motivates those changes.
-->

## Testing

- [ ] Unit Tests:
<!-- Did you write unit tests for your feature? If not, explains why?  -->
- [ ] Functionnal Tests:
<!-- Did you write functionnal tests for your feature? If not, explains why?  -->
- [ ] Manual Tests:
<!-- How did you test your changeset?  -->
