### PR TITLE
feat(oauth): swap default and fallback port

### DIFF
--- a/packages/cli/core/src/lib/oauth/oauth.spec.ts
+++ b/packages/cli/core/src/lib/oauth/oauth.spec.ts
@@ -25,7 +25,7 @@ describe('OAuth', () => {
       mockedStartServer
     );
     mockedOpen.mockResolvedValue({unref: () => {}} as ChildProcess);
-    mockedGetPort.mockResolvedValue(32111);
+    mockedGetPort.mockResolvedValue(52296);
   });
 
   afterAll(() => {
@@ -42,13 +42,13 @@ describe('OAuth', () => {
 
   it('should call `get-port` to acquire a port', async () => {
     await new OAuth().getToken();
-    expect(mockedGetPort).toHaveBeenCalledWith({port: [32111, 52296]});
+    expect(mockedGetPort).toHaveBeenCalledWith({port: [52296, 32111]});
   });
 
   it('should use proper port for client server', async () => {
     await new OAuth().getToken();
     expect(mockedStartServer).toHaveBeenCalledWith(
-      32111,
+      52296,
       expect.anything(),
       expect.anything()
     );
@@ -71,7 +71,7 @@ describe('OAuth', () => {
 
     const defaultClientConfig = {
       client_id: 'cli',
-      redirect_uri: 'http://127.0.0.1:32111',
+      redirect_uri: 'http://127.0.0.1:52296',
       scope: 'full',
     };
 

--- a/packages/cli/core/src/lib/oauth/oauth.ts
+++ b/packages/cli/core/src/lib/oauth/oauth.ts
@@ -19,7 +19,7 @@ interface OAuthOptions {
 }
 
 export class OAuth {
-  private static readonly AllowedPorts = [32111, 52296];
+  private static readonly AllowedPorts = [52296, 32111];
 
   private opts: OAuthOptions;
   private _port: number | undefined = undefined;


### PR DESCRIPTION
<!-- For Coveo Employees only. Fill this section.

CDX-1417

-->

## Proposed changes

We will eventually remove the OAuth port 32111 to avoid the collision, so let's swap the default with VMWare (https://kb.vmware.com/s/article/1027217)

## Testing

- [x] Unit Tests:
- [x] Manual Tests:
  - code analysis of `get-port` and san check with a simple comparaison between `getPort({ports:[n,n+1]})` and `getPort({ports:[n+1,n]}` shows that the lib try to return the first port provided in the array (no sort)
  - `bin/run/dev auth:login`, assert the final redirect lands on http://127.0.0.1:52296/
