### PR TITLE
ci: ensure `atomic-health-check` `bin` is available when running npm command targeting it

### DIFF
--- a/packages/ui/atomic/health-check/package.json
+++ b/packages/ui/atomic/health-check/package.json
@@ -16,7 +16,7 @@
   "scripts": {
     "release:phase1": "npx -p=@coveord/release npm-publish",
     "build": "rimraf dist && tsc -b tsconfig.build.json",
-    "prepublishOnly": "npm run build",
+    "preversion": "npm run build",
     "pretest": "rimraf dist && tsc -b tsconfig.json",
     "test:unit": "jest --testPathIgnorePatterns=e2e",
     "test:e2e": "node --experimental-vm-modules --no-warnings ../../../../node_modules/jest/bin/jest.js --testPathPattern=e2e",


### PR DESCRIPTION
<!-- For Coveo Employees only. Fill this section.

CDX-1445

-->

## Proposed changes

Band-aid, but it works nicely: `npm version` was failing because the bin was unavailable and npm panicked because of that
So I moved the script from `preRelease` to `preversion`.

## Testing

https://github.com/coveo/cli/actions/runs/4895257210/jobs/8740598103/
