### PR TITLE
chore(codeql): ignore e2e artifact

### DIFF
--- a/.github/codeql/config.yml
+++ b/.github/codeql/config.yml
@@ -1,0 +1,2 @@
+paths-ignore:
+  - ./cli/packages/cli-e2e/deploy-project/dist-folder/index.js

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -34,6 +34,7 @@ jobs:
         uses: github/codeql-action/init@f3feb00acb00f31a6f60280e6ace9ca31d91c76a # v2
         with:
           languages: ${{ matrix.language }}
+          config-file: .github/codeql/config.yml
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@f3feb00acb00f31a6f60280e6ace9ca31d91c76a # v2


### PR DESCRIPTION
<!-- For Coveo Employees only. Fill this section.

CDX-764

-->

## Proposed changes

CodeQL cannot digest this file, but we should not care because it's a generated artifact kept for testing purposes