### PR TITLE
ci: added skip ci to master lock commit

### DIFF
--- a/utils/release/git-lock.mjs
+++ b/utils/release/git-lock.mjs
@@ -49,7 +49,7 @@ const ensureUpToDateBranch = async () => {
 const lockBranch = async () => {
   writeFileSync('.git-lock', '');
   await gitAdd('.git-lock');
-  await gitCommit('lock master', PATH);
+  await gitCommit('[skip ci]: lock master', PATH);
   await gitPush({remote: GIT_SSH_REMOTE});
   spawnSync('git', ['reset', '--hard', 'HEAD~1']);
 };


### PR DESCRIPTION
https://coveord.atlassian.net/browse/CDX-1452

We don't need to run any CI on master lock commits. They only exist to prevent us from merging stuff to `master`.
