### PR TITLE
fix(cli): use ci-friendly confirm

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7126,6 +7126,15 @@
         "rxjs": "^7.2.0"
       }
     },
+    "node_modules/@types/is-ci": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/is-ci/-/is-ci-3.0.0.tgz",
+      "integrity": "sha512-Q0Op0hdWbYd1iahB+IFNQcWXFq4O0Q5MwQP7uN0souuQ4rPg1vEYcnIOfr1gY+M+6rc8FGoRaBO1mOOvL29sEQ==",
+      "dev": true,
+      "dependencies": {
+        "ci-info": "^3.1.0"
+      }
+    },
     "node_modules/@types/is-running": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@types/is-running/-/is-running-2.1.0.tgz",
@@ -30564,141 +30573,16 @@
         "node": ">=18"
       }
     },
-    "packages/cli-e2e/node_modules/@coveo/cli-commons": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/@coveo/cli-commons/-/cli-commons-2.4.3.tgz",
-      "integrity": "sha512-yPfnXl43Og0nJe2PYFI1HtEwiDeef8lnrv6nUFyKZ9Zw8txtTmn2yaPIao68F6+n82pSpLZuw4WOgtoIC3fdtg==",
-      "dependencies": {
-        "@amplitude/node": "1.10.2",
-        "@coveo/platform-client": "42.5.0",
-        "@oclif/core": "1.24.0",
-        "abortcontroller-polyfill": "1.7.5",
-        "chalk": "4.1.2",
-        "fs-extra": "11.1.0",
-        "https-proxy-agent": "5.0.1",
-        "isomorphic-fetch": "3.0.0",
-        "semver": "7.3.8",
-        "ts-dedent": "2.2.0"
-      }
-    },
-    "packages/cli-e2e/node_modules/@coveo/cli-commons/node_modules/@coveo/platform-client": {
-      "version": "42.5.0",
-      "resolved": "https://registry.npmjs.org/@coveo/platform-client/-/platform-client-42.5.0.tgz",
-      "integrity": "sha512-zCp2QTDD+UMpjDJSAWOPn33TydjPkH7/vWTWFKty5AZFEomYM9APAYkOu2mJA2l+YozA7M+Eljh841/qJCQ7kg==",
-      "dependencies": {
-        "exponential-backoff": "^3.1.0",
-        "query-string-cjs": "npm:query-string@^7.0.0",
-        "query-string-esm": "npm:query-string@^8.0.0"
-      }
-    },
-    "packages/cli-e2e/node_modules/@coveo/cli-commons/node_modules/fs-extra": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.0.tgz",
-      "integrity": "sha512-0rcTq621PD5jM/e0a3EJoGC/1TC5ZBCERW82LQuwfGnCa1V8w7dpYH1yNu+SLb6E5dkeCBzKEyLGlFrnr+dUyw==",
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=14.14"
-      }
-    },
-    "packages/cli-e2e/node_modules/@coveo/cli-plugin-source": {
-      "version": "2.0.10",
-      "resolved": "https://registry.npmjs.org/@coveo/cli-plugin-source/-/cli-plugin-source-2.0.10.tgz",
-      "integrity": "sha512-LYLb0RHY3AhQAWNIGtfuv/oT8q3j0jGtREjzHmICRrlpdVXKCEebGSkvNPDmrxNKmFXM2RYmGI9PGeqJrM6ioQ==",
-      "dependencies": {
-        "@coveo/cli-commons": "2.4.3",
-        "@coveo/platform-client": "42.5.0",
-        "@coveo/push-api-client": "3.1.6",
-        "@oclif/core": "1.24.0",
-        "@oclif/plugin-help": "5.1.23",
-        "@oclif/plugin-plugins": "2.1.12",
-        "chalk": "4.1.2",
-        "jsonschema": "1.4.1",
-        "ts-dedent": "2.2.0"
-      },
-      "engines": {
-        "node": "^16.13.0 || ^18.12.0"
-      }
-    },
-    "packages/cli-e2e/node_modules/@coveo/cli-plugin-source/node_modules/@coveo/platform-client": {
-      "version": "42.5.0",
-      "resolved": "https://registry.npmjs.org/@coveo/platform-client/-/platform-client-42.5.0.tgz",
-      "integrity": "sha512-zCp2QTDD+UMpjDJSAWOPn33TydjPkH7/vWTWFKty5AZFEomYM9APAYkOu2mJA2l+YozA7M+Eljh841/qJCQ7kg==",
-      "dependencies": {
-        "exponential-backoff": "^3.1.0",
-        "query-string-cjs": "npm:query-string@^7.0.0",
-        "query-string-esm": "npm:query-string@^8.0.0"
-      }
-    },
     "packages/cli-e2e/node_modules/@coveo/cli/node_modules/@coveo/platform-client": {
       "version": "42.5.0",
       "resolved": "https://registry.npmjs.org/@coveo/platform-client/-/platform-client-42.5.0.tgz",
       "integrity": "sha512-zCp2QTDD+UMpjDJSAWOPn33TydjPkH7/vWTWFKty5AZFEomYM9APAYkOu2mJA2l+YozA7M+Eljh841/qJCQ7kg==",
+      "extraneous": true,
       "dependencies": {
         "exponential-backoff": "^3.1.0",
         "query-string-cjs": "npm:query-string@^7.0.0",
         "query-string-esm": "npm:query-string@^8.0.0"
       }
-    },
-    "packages/cli-e2e/node_modules/@coveo/push-api-client": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/@coveo/push-api-client/-/push-api-client-3.1.6.tgz",
-      "integrity": "sha512-d9OvMnTxAlkGfkK612dJO5g12hPhf++A3RPECq7a5oj5I/Esl3BySoLrd+xxqG8Nh17fBUmr+OAj2ZeaeEC8wg==",
-      "dependencies": {
-        "@coveo/bueno": "^0.43.0",
-        "@coveo/platform-client": "42.4.0",
-        "dayjs": "^1.10.4",
-        "exponential-backoff": "^3.1.0",
-        "fetch-undici-polyfill": "1.2.1",
-        "ts-dedent": "2.2.0",
-        "zod": "^3.20.2"
-      },
-      "engines": {
-        "node": ">=16.x"
-      }
-    },
-    "packages/cli-e2e/node_modules/@coveo/push-api-client/node_modules/@coveo/platform-client": {
-      "version": "42.4.0",
-      "resolved": "https://registry.npmjs.org/@coveo/platform-client/-/platform-client-42.4.0.tgz",
-      "integrity": "sha512-dj2i/W56fE0HWJQfaSr4xJrQmQir9eaOHEiqbfIXx6hrguD5BATxCLtaBi/0YX2jTJX4FuHqrBn6bpYzyr5QJA==",
-      "dependencies": {
-        "exponential-backoff": "^3.1.0",
-        "query-string-cjs": "npm:query-string@^7.0.0",
-        "query-string-esm": "npm:query-string@^8.0.0"
-      }
-    },
-    "packages/cli-e2e/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "packages/cli-e2e/node_modules/semver": {
-      "version": "7.3.8",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "packages/cli-e2e/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "packages/cli/commons": {
       "name": "@coveo/cli-commons",
@@ -30712,6 +30596,7 @@
         "chalk": "4.1.2",
         "fs-extra": "11.1.1",
         "https-proxy-agent": "5.0.1",
+        "is-ci": "3.0.1",
         "isomorphic-fetch": "3.0.0",
         "npm-package-arg": "10.1.0",
         "semver": "7.5.0",
@@ -30719,6 +30604,7 @@
       },
       "devDependencies": {
         "@coveo/cli-commons-dev": "6.0.6",
+        "@types/is-ci": "3.0.0",
         "@types/jest": "29.5.1",
         "@types/npm-package-arg": "6.1.1",
         "jest": "29.5.0",
@@ -30738,6 +30624,17 @@
       "devDependencies": {
         "@types/jest": "29.5.1",
         "typescript": "4.9.5"
+      }
+    },
+    "packages/cli/commons/node_modules/is-ci": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-3.0.1.tgz",
+      "integrity": "sha512-ZYvCgrefwqoQ6yTyYUbQu64HsITZ3NfKX1lzaEYdkTDcfKzzCI/wthRRYKkdjHKFVgNiXKAKm65Zo1pk2as/QQ==",
+      "dependencies": {
+        "ci-info": "^3.2.0"
+      },
+      "bin": {
+        "is-ci": "bin.js"
       }
     },
     "packages/cli/core": {

--- a/packages/cli/commons/package.json
+++ b/packages/cli/commons/package.json
@@ -15,6 +15,7 @@
   },
   "devDependencies": {
     "@coveo/cli-commons-dev": "6.0.6",
+    "@types/is-ci": "3.0.0",
     "@types/jest": "29.5.1",
     "@types/npm-package-arg": "6.1.1",
     "jest": "29.5.0",
@@ -30,6 +31,7 @@
     "chalk": "4.1.2",
     "fs-extra": "11.1.1",
     "https-proxy-agent": "5.0.1",
+    "is-ci": "3.0.1",
     "isomorphic-fetch": "3.0.0",
     "npm-package-arg": "10.1.0",
     "semver": "7.5.0",

--- a/packages/cli/commons/src/utils/ux.ts
+++ b/packages/cli/commons/src/utils/ux.ts
@@ -1,4 +1,5 @@
 import {CliUx} from '@oclif/core';
+import isCi from 'is-ci';
 import {red, green, magenta} from 'chalk';
 
 function isWindows() {
@@ -32,3 +33,6 @@ export function stopSpinner(options?: {success?: boolean}) {
 
 export const formatOrgId = (orgId: TemplateStringsArray | string) =>
   shouldUseColor() ? magenta(orgId) : orgId;
+
+export const confirm = (message: string, ciDefault: boolean) =>
+  isCi ? Promise.resolve(ciDefault) : CliUx.ux.confirm(message);

--- a/packages/cli/core/src/commands/org/resources/push.spec.ts
+++ b/packages/cli/core/src/commands/org/resources/push.spec.ts
@@ -2,11 +2,18 @@ jest.mock('@coveo/cli-commons/config/config');
 jest.mock('@coveo/cli-commons/preconditions/trackable');
 
 jest.mock('@coveo/cli-commons/platform/authenticatedClient');
+jest.mock('@coveo/cli-commons/utils/ux');
+
 jest.mock('../../../lib/snapshot/snapshot');
 jest.mock('../../../lib/snapshot/snapshotFactory');
 jest.mock('../../../lib/project/project');
 
-import {CliUx} from '@oclif/core';
+import {
+  formatOrgId,
+  startSpinner,
+  stopSpinner,
+  confirm,
+} from '@coveo/cli-commons/utils/ux';
 import {test} from '@oclif/test';
 import {Project} from '../../../lib/project/project';
 import {Config} from '@coveo/cli-commons/config/config';
@@ -41,6 +48,10 @@ const mockedPreviewSnapshot = jest.fn();
 const mockedLastReport = jest.fn();
 const mockedAuthenticatedClient = jest.mocked(AuthenticatedClient);
 const mockEvaluate = jest.fn();
+const mockedConfirm = jest.mocked(confirm);
+jest.mocked(startSpinner);
+jest.mocked(stopSpinner);
+const mockedFormatOrgId = jest.mocked(formatOrgId);
 
 const fakeProject = {
   deleteTemporaryZipFile: mockedDeleteTemporaryZipFile,
@@ -174,6 +185,10 @@ describe('org:resources:push', () => {
 
   beforeEach(() => {
     mockUserHavingAllRequiredPlatformPrivileges();
+    mockedFormatOrgId.mockImplementation(
+      (input: TemplateStringsArray | string) => input?.toString()
+    );
+    mockedConfirm.mockResolvedValue(true);
   });
 
   afterEach(() => {
@@ -217,7 +232,9 @@ describe('org:resources:push', () => {
     test
       .stdout()
       .stderr()
-      .stub(CliUx.ux, 'confirm', () => () => Promise.resolve(true))
+      .do(() => {
+        mockedConfirm.mockResolvedValue(true);
+      })
       .command(['org:resources:push'])
       .it('should preview the snapshot', () => {
         expect(mockedPreviewSnapshot).toHaveBeenCalledTimes(1);
@@ -226,7 +243,9 @@ describe('org:resources:push', () => {
     test
       .stdout()
       .stderr()
-      .stub(CliUx.ux, 'confirm', () => () => Promise.resolve(true))
+      .do(() => {
+        mockedConfirm.mockResolvedValue(true);
+      })
       .command(['org:resources:push'])
       .it('should apply the snapshot after confirmation', () => {
         expect(mockedApplySnapshot).toHaveBeenCalledTimes(1);
@@ -235,7 +254,9 @@ describe('org:resources:push', () => {
     test
       .stdout()
       .stderr()
-      .stub(CliUx.ux, 'confirm', () => () => Promise.resolve(false))
+      .do(() => {
+        mockedConfirm.mockResolvedValue(false);
+      })
       .command(['org:resources:push'])
       .it('should not apply the snapshot if not confirmed', () => {
         expect(mockedApplySnapshot).toHaveBeenCalledTimes(0);
@@ -244,7 +265,9 @@ describe('org:resources:push', () => {
     test
       .stdout()
       .stderr()
-      .stub(CliUx.ux, 'confirm', () => () => Promise.resolve(true))
+      .do(() => {
+        mockedConfirm.mockResolvedValue(true);
+      })
       .command(['org:resources:push'])
       .it('should work with default connected org', () => {
         expect(
@@ -259,7 +282,9 @@ describe('org:resources:push', () => {
     test
       .stdout()
       .stderr()
-      .stub(CliUx.ux, 'confirm', () => () => Promise.resolve(true))
+      .do(() => {
+        mockedConfirm.mockResolvedValue(true);
+      })
       .command(['org:resources:push', '-o', 'myorg'])
       .it('should work with specified target org', () => {
         expect(mockedProject).toHaveBeenCalledWith(expect.anything(), 'myorg');
@@ -275,7 +300,9 @@ describe('org:resources:push', () => {
     test
       .stdout()
       .stderr()
-      .stub(CliUx.ux, 'confirm', () => () => Promise.resolve(true))
+      .do(() => {
+        mockedConfirm.mockResolvedValue(true);
+      })
       .command(['org:resources:push'])
       .it('should set a 60 seconds wait', () => {
         expect(
@@ -286,7 +313,9 @@ describe('org:resources:push', () => {
     test
       .stdout()
       .stderr()
-      .stub(CliUx.ux, 'confirm', () => () => Promise.resolve(true))
+      .do(() => {
+        mockedConfirm.mockResolvedValue(true);
+      })
       .command(['org:resources:push', '-w', '99'])
       .it('should set a 99 seconds wait', () => {
         expect(
@@ -297,7 +326,9 @@ describe('org:resources:push', () => {
     test
       .stdout()
       .stderr()
-      .stub(CliUx.ux, 'confirm', () => () => Promise.resolve(true))
+      .do(() => {
+        mockedConfirm.mockResolvedValue(true);
+      })
       .command(['org:resources:push'])
       .it('#should not apply missing resources', () => {
         expect(mockedApplySnapshot).toHaveBeenCalledWith(false, {wait: 60});
@@ -306,7 +337,9 @@ describe('org:resources:push', () => {
     test
       .stdout()
       .stderr()
-      .stub(CliUx.ux, 'confirm', () => () => Promise.resolve(true))
+      .do(() => {
+        mockedConfirm.mockResolvedValue(true);
+      })
       .command(['org:resources:push', '--deleteMissingResources'])
       .it('should apply missing resoucres', () => {
         expect(mockedApplySnapshot).toHaveBeenCalledWith(true, {wait: 60});
@@ -315,7 +348,9 @@ describe('org:resources:push', () => {
     test
       .stdout()
       .stderr()
-      .stub(CliUx.ux, 'confirm', () => () => Promise.resolve(true))
+      .do(() => {
+        mockedConfirm.mockResolvedValue(true);
+      })
       .command(['org:resources:push'])
       .it('should delete the compressed folder', () => {
         expect(mockedDeleteTemporaryZipFile).toHaveBeenCalledTimes(1);
@@ -324,7 +359,9 @@ describe('org:resources:push', () => {
     test
       .stdout()
       .stderr()
-      .stub(CliUx.ux, 'confirm', () => () => Promise.resolve(true))
+      .do(() => {
+        mockedConfirm.mockResolvedValue(true);
+      })
       .do(() => {
         mockedValidateSnapshot.mockImplementationOnce(() => {
           throw new Error('You shall not pass');
@@ -339,7 +376,9 @@ describe('org:resources:push', () => {
     test
       .stdout()
       .stderr()
-      .stub(CliUx.ux, 'confirm', () => () => Promise.resolve(true))
+      .do(() => {
+        mockedConfirm.mockResolvedValue(true);
+      })
       .command(['org:resources:push'])
       .it('should delete the snapshot', () => {
         expect(mockedDeleteSnapshot).toHaveBeenCalledTimes(1);
@@ -356,7 +395,9 @@ describe('org:resources:push', () => {
     test
       .stdout()
       .stderr()
-      .stub(CliUx.ux, 'confirm', () => () => Promise.resolve(true))
+      .do(() => {
+        mockedConfirm.mockResolvedValue(true);
+      })
       .command(['org:resources:push', '--previewLevel', 'light'])
       .it('should only display light preview', () => {
         expect(mockedPreviewSnapshot).toHaveBeenCalledWith(
@@ -369,7 +410,9 @@ describe('org:resources:push', () => {
     test
       .stdout()
       .stderr()
-      .stub(CliUx.ux, 'confirm', () => () => Promise.resolve(true))
+      .do(() => {
+        mockedConfirm.mockResolvedValue(true);
+      })
       .command(['org:resources:push', '--previewLevel', 'detailed'])
       .it('should display light and expanded preview', () => {
         expect(mockedPreviewSnapshot).toHaveBeenCalledWith(
@@ -416,10 +459,12 @@ describe('org:resources:push', () => {
     });
 
     describe('when the user refuses to migrate or type in the missing vault entries', () => {
+      beforeEach(() => {
+        mockedConfirm.mockResolvedValue(false);
+      });
       test
         .stdout()
         .stderr()
-        .stub(CliUx.ux, 'confirm', () => () => Promise.resolve(false))
         .command(['org:resources:push'])
         .catch(/Your destination organization is missing vault entries/)
         .it('should show the missingVaultEntries snapshot error');
@@ -427,7 +472,6 @@ describe('org:resources:push', () => {
       test
         .stdout()
         .stderr()
-        .stub(CliUx.ux, 'confirm', () => () => Promise.resolve(false))
         .command(['org:resources:push'])
         .catch(() => {
           expect(mockedPreviewSnapshot).toHaveBeenCalledTimes(1);

--- a/packages/cli/core/src/commands/ui/__snapshots__/deploy.spec.ts.snap
+++ b/packages/cli/core/src/commands/ui/__snapshots__/deploy.spec.ts.snap
@@ -5,10 +5,7 @@ exports[`ui:deploy interacting with Platform client should call hostedPages.list
 "
 `;
 
-exports[`ui:deploy interacting with Platform client should call hostedPages.list and hostedPages.create when no page id argument is passed 2`] = `
-"Creating new Hosted Page named "my page".... ✔
-"
-`;
+exports[`ui:deploy interacting with Platform client should call hostedPages.list and hostedPages.create when no page id argument is passed 2`] = `""`;
 
 exports[`ui:deploy interacting with Platform client should print an API Error if the update fails 1`] = `
 [APIError: 
@@ -20,9 +17,6 @@ Request ID: [31mb33pb00p[39m]
 
 exports[`ui:deploy interacting with Platform client when a page id argument is passed, it should call hostedPages.update 1`] = `""`;
 
-exports[`ui:deploy interacting with Platform client when a page id argument is passed, it should call hostedPages.update 2`] = `
-"Updating existing Hosted Page with the id "thisistheid".... ✔
-"
-`;
+exports[`ui:deploy interacting with Platform client when a page id argument is passed, it should call hostedPages.update 2`] = `""`;
 
 exports[`ui:deploy interacting with Platform client when no page id argument is passed, a page with the same name already exists, the user declines the overwrite, it should not call hostedPages.update 1`] = `[CLI Error: Page name must be unique, try changing the "name" field in "coveo.deploy.json".]`;

--- a/packages/cli/core/src/commands/ui/deploy.spec.ts
+++ b/packages/cli/core/src/commands/ui/deploy.spec.ts
@@ -2,6 +2,7 @@ jest.mock('child_process');
 jest.mock('fs-extra');
 jest.mock('jsonschema');
 
+jest.mock('@coveo/cli-commons/utils/ux');
 jest.mock('@coveo/cli-commons/config/config');
 jest.mock('@coveo/cli-commons/preconditions/trackable');
 jest.mock('@coveo/cli-commons/preconditions/authenticated');
@@ -33,7 +34,7 @@ import {readJSONSync, readFileSync} from 'fs-extra';
 import {DeployConfig} from './deploy';
 import {validate, ValidatorResult} from 'jsonschema';
 import {join} from 'path';
-import {CliUx} from '@oclif/core';
+import {confirm} from '@coveo/cli-commons/utils/ux';
 
 const actualValidate = jest.requireActual('jsonschema').validate;
 
@@ -89,10 +90,7 @@ describe('ui:deploy', () => {
   const mockHostedPageCreate = jest.fn();
   const mockHostedPageList = jest.fn();
   const mockHostedPageUpdate = jest.fn();
-  const mockedConfirm = jest.fn();
-  const doMockConfirm = () => {
-    Object.defineProperty(CliUx.ux, 'confirm', {value: mockedConfirm});
-  };
+  const mockedConfirm = jest.mocked(confirm);
 
   const preconditionStatus = {
     apiKey: true,
@@ -174,6 +172,10 @@ describe('ui:deploy', () => {
   };
 
   let modifiedConfig: DeepPartial<DeployConfig>;
+
+  beforeAll(() => {
+    mockedConfirm.mockResolvedValue(true);
+  });
 
   beforeEach(() => {
     doMockedGetPackageVersion();
@@ -485,7 +487,6 @@ describe('ui:deploy', () => {
       .stdout()
       .stderr()
       .do(() => {
-        doMockConfirm();
         mockedConfirm.mockResolvedValueOnce(true);
         mockHostedPageList.mockResolvedValueOnce({
           items: [{name: validJsonConfig.name, id: pageTestId}],
@@ -503,7 +504,6 @@ describe('ui:deploy', () => {
       .stdout()
       .stderr()
       .do(() => {
-        doMockConfirm();
         mockedConfirm.mockResolvedValueOnce(true);
         mockHostedPageList.mockResolvedValueOnce({
           items: [{name: validJsonConfig.name, id: pageTestId}],
@@ -524,7 +524,6 @@ describe('ui:deploy', () => {
       .stdout()
       .stderr()
       .do(() => {
-        doMockConfirm();
         mockedConfirm.mockResolvedValueOnce(false);
         mockHostedPageList.mockResolvedValueOnce({
           items: [{name: validJsonConfig.name, id: pageTestId}],

--- a/packages/cli/core/src/commands/ui/deploy.ts
+++ b/packages/cli/core/src/commands/ui/deploy.ts
@@ -11,12 +11,12 @@ import {
 import type {HostedPage, New} from '@coveo/platform-client';
 import type PlatformClient from '@coveo/platform-client';
 import {createSearchPagesPrivilege} from '@coveo/cli-commons/preconditions/platformPrivilege';
-import {CliUx, Flags} from '@oclif/core';
+import {Flags} from '@oclif/core';
 import {readJsonSync, ensureDirSync, readFileSync} from 'fs-extra';
 import {DeployConfigError} from '../../lib/errors/deployErrors';
 import {join} from 'path';
 import {Example} from '@oclif/core/lib/interfaces';
-import {startSpinner, stopSpinner} from '@coveo/cli-commons/utils/ux';
+import {confirm, startSpinner, stopSpinner} from '@coveo/cli-commons/utils/ux';
 import {getTargetOrg} from '../../lib/utils/platform';
 import {Config} from '@coveo/cli-commons/config/config';
 import {organization} from '../../lib/flags/platformCommonFlags';
@@ -226,8 +226,11 @@ export default class Deploy extends CLICommand {
 
   private async confirmOverwrite(): Promise<void | never> {
     if (
-      !(await CliUx.ux.confirm(dedent`
-      Overwrite page with ID: "${this.pageId}" in organization ${this.organization}? (y/n)`))
+      !(await confirm(
+        dedent`
+      Overwrite page with ID: "${this.pageId}" in organization ${this.organization}? (y/n)`,
+        false
+      ))
     ) {
       this.error(
         'Page name must be unique, try changing the "name" field in "coveo.deploy.json".'

--- a/packages/cli/core/src/lib/snapshot/vaultEntriesFunctions/transferFromOrganization.spec.ts
+++ b/packages/cli/core/src/lib/snapshot/vaultEntriesFunctions/transferFromOrganization.spec.ts
@@ -15,6 +15,7 @@ import {
   formatOrgId,
   startSpinner,
   stopSpinner,
+  confirm,
 } from '@coveo/cli-commons/utils/ux';
 import PlatformClient, {VaultFetchStrategy} from '@coveo/platform-client';
 import {CliUx} from '@oclif/core';
@@ -34,7 +35,7 @@ describe('#tryTransferFromOrganization', () => {
   const mockedSnapshotMissingVaultEntriesFromOriginError = jest.mocked(
     SnapshotMissingVaultEntriesFromOriginError
   );
-  const mockedCliConfirm = jest.mocked(CliUx.ux.confirm);
+  const mockedCliConfirm = jest.mocked(confirm);
   const mockedCliWarn = jest.mocked(CliUx.ux.warn);
   const mockedVaultList = jest.fn();
   const mockedVaultImport = jest.fn();

--- a/packages/cli/core/src/lib/snapshot/vaultEntriesFunctions/transferFromOrganization.ts
+++ b/packages/cli/core/src/lib/snapshot/vaultEntriesFunctions/transferFromOrganization.ts
@@ -1,10 +1,10 @@
 import {VaultFetchStrategy, VaultEntryModel} from '@coveo/platform-client';
 import {CliUx} from '@oclif/core';
-import {bold} from 'chalk';
 import {
   formatOrgId,
   startSpinner,
   stopSpinner,
+  confirm,
 } from '@coveo/cli-commons/utils/ux';
 import dedent from 'ts-dedent';
 import {SnapshotMissingVaultEntriesFromOriginError} from '../../errors/vaultErrors';
@@ -26,11 +26,13 @@ export async function tryTransferFromOrganization({
   if (!originOrgId) {
     return false;
   }
-
-  const shouldTransfer = await CliUx.ux.confirm(
+  const shouldTransfer = await confirm(
     `\nWould you like to try transferring the vault entries from ${formatOrgId(
       originOrgId
-    )} to the destination organization ${formatOrgId(snapshot.targetId)}? (y/n)`
+    )} to the destination organization ${formatOrgId(
+      snapshot.targetId
+    )}? (y/n)`,
+    false
   );
   if (!shouldTransfer) {
     return false;

--- a/packages/cli/core/src/lib/snapshot/vaultEntriesFunctions/tryCreateMissingVaultEntries.ts
+++ b/packages/cli/core/src/lib/snapshot/vaultEntriesFunctions/tryCreateMissingVaultEntries.ts
@@ -1,5 +1,4 @@
-import {formatOrgId} from '@coveo/cli-commons/utils/ux';
-import {CliUx} from '@oclif/core';
+import {formatOrgId, confirm} from '@coveo/cli-commons/utils/ux';
 import {bold} from 'chalk';
 import {VaultHandler} from '../vaultHandler';
 import {VaultTransferFunctionsParam} from './interfaces';
@@ -8,10 +7,11 @@ export async function tryCreateMissingVaultEntries({
   reporter,
   snapshot,
 }: VaultTransferFunctionsParam) {
-  const shouldCreate = await CliUx.ux.confirm(
+  const shouldCreate = await confirm(
     `\nWould you like to create the missing vault entries in the destination organization ${formatOrgId(
       snapshot.targetId
-    )}? (y/n)`
+    )}? (y/n)`,
+    false
   );
   if (!shouldCreate) {
     return false;

--- a/packages/cli/core/src/lib/utils/cli.spec.ts
+++ b/packages/cli/core/src/lib/utils/cli.spec.ts
@@ -1,19 +1,18 @@
 jest.mock('@coveo/cli-commons/preconditions/trackable');
 jest.mock('@coveo/cli-commons/config/globalConfig');
+jest.mock('@coveo/cli-commons/utils/ux');
 
-import {Interfaces, CliUx} from '@oclif/core';
+import {Interfaces} from '@oclif/core';
+import {confirm} from '@coveo/cli-commons/utils/ux';
 import {fancyIt} from '@coveo/cli-commons-dev/testUtils/it';
 import globalConfig from '@coveo/cli-commons/config/globalConfig';
 import {confirmWithAnalytics} from './cli';
 
 const mockedGlobalConfig = jest.mocked(globalConfig);
 const mockedAnalyticHook = jest.fn();
-const mockedConfirm = jest.fn();
-const doMockConfirm = () => {
-  Object.defineProperty(CliUx.ux, 'confirm', {value: mockedConfirm});
-};
 
 describe('cli', () => {
+  const mockedConfirm = jest.mocked(confirm);
   beforeAll(() => {
     mockedGlobalConfig.get.mockReturnValue({
       configDir: 'the_config_dir',
@@ -21,22 +20,18 @@ describe('cli', () => {
     } as unknown as Interfaces.Config);
   });
 
-  beforeEach(() => {
-    doMockConfirm();
-  });
-
   afterEach(() => {
-    mockedConfirm.mockClear();
+    mockedConfirm.mockReset();
   });
 
   fancyIt()('should call cli.confirm with the right question', async () => {
     await confirmWithAnalytics('this is a question', 'question name');
-    expect(mockedConfirm).toHaveBeenCalledWith('this is a question');
+    expect(mockedConfirm).toHaveBeenCalledWith('this is a question', false);
   });
 
   describe('when the user confirmed', () => {
     beforeEach(() => {
-      mockedConfirm.mockReturnValue(true);
+      mockedConfirm.mockResolvedValue(true);
     });
 
     fancyIt()('should log a `confirmed` event', async () => {
@@ -52,7 +47,7 @@ describe('cli', () => {
 
   describe('when the user did not confirm', () => {
     beforeEach(() => {
-      mockedConfirm.mockReturnValue(false);
+      mockedConfirm.mockResolvedValue(false);
     });
 
     fancyIt()('should log a `cancelled` event', async () => {

--- a/packages/cli/core/src/lib/utils/cli.ts
+++ b/packages/cli/core/src/lib/utils/cli.ts
@@ -1,4 +1,4 @@
-import {CliUx} from '@oclif/core';
+import {confirm} from '@coveo/cli-commons/utils/ux';
 
 import globalConfig from '@coveo/cli-commons/config/globalConfig';
 import {buildEvent} from '@coveo/cli-commons/analytics/eventUtils';
@@ -14,7 +14,7 @@ export async function confirmWithAnalytics(
   message: string,
   questionName: string
 ): Promise<boolean> {
-  const doAction = await CliUx.ux.confirm(message);
+  const doAction = await confirm(message, false);
   if (doAction) {
     trackEvent(`confirmed ${questionName}`);
     return true;

--- a/packages/ui/atomic/create-atomic-component/tests/__snapshots__/test.spec.ts.snap
+++ b/packages/ui/atomic/create-atomic-component/tests/__snapshots__/test.spec.ts.snap
@@ -81,7 +81,7 @@ HashedFolder {
                   "name": "loader",
                 },
                 HashedFile {
-                  "hash": "iP1Z2hcsWgEC61Xa0BkpIgU+qa4=",
+                  "hash": "n8lKw21LwG/QmEJCb8e30Ubv9FE=",
                   "name": "package.json",
                 },
                 HashedFile {
@@ -115,11 +115,11 @@ HashedFolder {
                   "name": "tsconfig.json",
                 },
               ],
-              "hash": "t+U0JC/GX1tTdZB2Vt9zbsj7gac=",
+              "hash": "UvXAs7n+IhX5YY+yKKYv3eE01NE=",
               "name": "oh-wow-another-component-can-you-believe-it",
             },
           ],
-          "hash": "EMF/UK0I+L2NhEsHvb4GY5G7RNM=",
+          "hash": "vXpuoDZlzWmwAcxKkLv4Ku9k7N4=",
           "name": "components",
         },
         HashedFile {
@@ -145,7 +145,7 @@ HashedFolder {
           "name": "pages",
         },
       ],
-      "hash": "9jUDFFygCZnuUN8LRb2d1Rysv0Q=",
+      "hash": "v6WK6mcKW4FuRYRyHmImKwfOtmU=",
       "name": "src",
     },
     HashedFile {
@@ -157,7 +157,7 @@ HashedFolder {
       "name": "tsconfig.json",
     },
   ],
-  "hash": "NX0r37d3dunlRCdHqIs3QKen7jQ=",
+  "hash": "6lJgpiIUtlDikxJGlMDXfGJbab4=",
   "name": "no-args",
 }
 `;
@@ -203,7 +203,7 @@ HashedFolder {
             HashedFolder {
               "children": [
                 HashedFile {
-                  "hash": "P1U+h7kWRdRWyfQhQQveQZa3hI4=",
+                  "hash": "35WQZxNG+v2Eq1+yiY8nfuthAvU=",
                   "name": "package.json",
                 },
                 HashedFolder {
@@ -229,11 +229,11 @@ HashedFolder {
                   "name": "tsconfig.json",
                 },
               ],
-              "hash": "uEz4uMQM0pev7VexNb7uvDHbZVU=",
+              "hash": "BzX+UvVK0zUXkLpsCntzfDazolI=",
               "name": "valid-component-name",
             },
           ],
-          "hash": "bsm7if1Hbegu2sIb0zHctci30vk=",
+          "hash": "sIF+huZEh1B0fntHmUWhbEYpKCg=",
           "name": "components",
         },
         HashedFile {
@@ -259,7 +259,7 @@ HashedFolder {
           "name": "pages",
         },
       ],
-      "hash": "VEf68N3iY/e2+EdbUkz9cU+9zeg=",
+      "hash": "zY9pQwGiDMQNU8rO5dIQi0PfqMM=",
       "name": "src",
     },
     HashedFile {
@@ -271,7 +271,7 @@ HashedFolder {
       "name": "tsconfig.json",
     },
   ],
-  "hash": "4HI/NtMDtJ5KecPhwVvbBlNvli4=",
+  "hash": "TnIk1rs0LHXQFSt46Q4Bob8zLdM=",
   "name": "valid-arg",
 }
 `;
@@ -317,7 +317,7 @@ HashedFolder {
             HashedFolder {
               "children": [
                 HashedFile {
-                  "hash": "fnpvTsa9LLUE7tD3iMTsOvCwFYs=",
+                  "hash": "iyMXrQ8HLVvWdSU9zBo8yewpUsM=",
                   "name": "package.json",
                 },
                 HashedFolder {
@@ -343,11 +343,11 @@ HashedFolder {
                   "name": "tsconfig.json",
                 },
               ],
-              "hash": "vTpXEYa27SsL57dj5xGUrZhXCRQ=",
+              "hash": "YiYL6woakEu6uzpQ74txEusXKmw=",
               "name": "sample-component",
             },
           ],
-          "hash": "80iYwCSm5y3G3q/oD/v2FquoWG0=",
+          "hash": "CljHyRkx3PbbiNzmG1+ajQDzEr8=",
           "name": "components",
         },
         HashedFile {
@@ -373,7 +373,7 @@ HashedFolder {
           "name": "pages",
         },
       ],
-      "hash": "MDQmY3gHJoNJVPAB8miGf+3c7J4=",
+      "hash": "v8iIrOCC+4HDfV0qu1AB0haZnxs=",
       "name": "src",
     },
     HashedFile {
@@ -385,7 +385,7 @@ HashedFolder {
       "name": "tsconfig.json",
     },
   ],
-  "hash": "OgejK17I8qdTGwr+Q5Jm6c+4cxU=",
+  "hash": "zN10WIbBHQRQzt2p7sBSVKZS57w=",
   "name": "no-args",
 }
 `;

--- a/packages/ui/atomic/create-atomic-result-component/tests/__snapshots__/test.spec.ts.snap
+++ b/packages/ui/atomic/create-atomic-result-component/tests/__snapshots__/test.spec.ts.snap
@@ -81,7 +81,7 @@ HashedFolder {
                   "name": "loader",
                 },
                 HashedFile {
-                  "hash": "JsimBUwRWsTTGSxqfHw4EGHH8h4=",
+                  "hash": "b/hxIXqfJSYBuwJaCp0vyzHeZPc=",
                   "name": "package.json",
                 },
                 HashedFile {
@@ -115,11 +115,11 @@ HashedFolder {
                   "name": "tsconfig.json",
                 },
               ],
-              "hash": "TjKsTV0hiEPHMTUdgLD27VqIYCw=",
+              "hash": "P8zaGwiRnnUfkX6g+6Y9vFisTJE=",
               "name": "oh-wow-another-component-can-you-believe-it",
             },
           ],
-          "hash": "ny/2WIakAA7lIKWG57U/LCIIjHI=",
+          "hash": "bdpNzPVY5LnX2QKHKommF4Q8klI=",
           "name": "components",
         },
         HashedFile {
@@ -145,7 +145,7 @@ HashedFolder {
           "name": "pages",
         },
       ],
-      "hash": "j5m2cCD5QCVfrIx4wZNWiFepetc=",
+      "hash": "KOAHe/sANz9MglgCCgeoEDMOqCs=",
       "name": "src",
     },
     HashedFile {
@@ -157,7 +157,7 @@ HashedFolder {
       "name": "tsconfig.json",
     },
   ],
-  "hash": "4HO4ZVWi/BxiwYY9BCTgtaek5Zc=",
+  "hash": "tcJJ1ipVxf/ph6FaFQCtJvUOqAA=",
   "name": "no-args",
 }
 `;
@@ -203,7 +203,7 @@ HashedFolder {
             HashedFolder {
               "children": [
                 HashedFile {
-                  "hash": "9wUm7J748WMHhj3HJWuVDXVB6SE=",
+                  "hash": "/ndnQkZFDpjscDW7FBHU2SbJ7MY=",
                   "name": "package.json",
                 },
                 HashedFolder {
@@ -229,11 +229,11 @@ HashedFolder {
                   "name": "tsconfig.json",
                 },
               ],
-              "hash": "wkILSkb35SNYL4UAK3MtV2gLqzo=",
+              "hash": "b+caCoj6Zi9gZLuEx6UbJE8iAnM=",
               "name": "valid-component-name",
             },
           ],
-          "hash": "RXkrkBrtle8mA9QaCptr84qhr0I=",
+          "hash": "M7BjKNRd2P/mpuut4lC42qLJoTo=",
           "name": "components",
         },
         HashedFile {
@@ -259,7 +259,7 @@ HashedFolder {
           "name": "pages",
         },
       ],
-      "hash": "Fz8rzmJ8worrkOvTZAMDDxoY9yE=",
+      "hash": "06vImAC+vG8IEHp+2QUG9ixhR28=",
       "name": "src",
     },
     HashedFile {
@@ -271,7 +271,7 @@ HashedFolder {
       "name": "tsconfig.json",
     },
   ],
-  "hash": "lFrsi7m8wV6FtOBjuOH2enqXDZo=",
+  "hash": "XKsAa9uYbJDPSyYPLyLiA5OKNXk=",
   "name": "valid-arg",
 }
 `;
@@ -317,7 +317,7 @@ HashedFolder {
             HashedFolder {
               "children": [
                 HashedFile {
-                  "hash": "wgsagcaazLCa0yYQLRGn2wQM73A=",
+                  "hash": "vASoGIdyHIDV9A5FLN1AC19BK00=",
                   "name": "package.json",
                 },
                 HashedFolder {
@@ -343,11 +343,11 @@ HashedFolder {
                   "name": "tsconfig.json",
                 },
               ],
-              "hash": "zEbenXIHBMVySoYTB5sTx2pXHJg=",
+              "hash": "VisqHQhGg2x8EVlcCuytyHSj3SI=",
               "name": "sample-result-component",
             },
           ],
-          "hash": "0gCTgHiJOity8E5/cyU1gPvu5uM=",
+          "hash": "11AanwRpi+Ob50w6Juzu+yfn2j4=",
           "name": "components",
         },
         HashedFile {
@@ -373,7 +373,7 @@ HashedFolder {
           "name": "pages",
         },
       ],
-      "hash": "0tl1Zo7GIpoG3YLopp6wZfH6QM8=",
+      "hash": "Q/WgUpCAnOcKkf075kMmYxJPWgA=",
       "name": "src",
     },
     HashedFile {
@@ -385,7 +385,7 @@ HashedFolder {
       "name": "tsconfig.json",
     },
   ],
-  "hash": "wkP3Gv39ORN0IUyWSgfWxJ6l8G4=",
+  "hash": "usie+mZ34CZSAYO9Q5n3vJ3muOs=",
   "name": "no-args",
 }
 `;

--- a/packages/ui/atomic/health-check/src/e2e/__snapshots__/test.spec.ts.snap
+++ b/packages/ui/atomic/health-check/src/e2e/__snapshots__/test.spec.ts.snap
@@ -18,7 +18,7 @@ HashedFolder {
             HashedFolder {
               "children": [
                 HashedFile {
-                  "hash": "P1U+h7kWRdRWyfQhQQveQZa3hI4=",
+                  "hash": "35WQZxNG+v2Eq1+yiY8nfuthAvU=",
                   "name": "package.json",
                 },
                 HashedFolder {
@@ -44,11 +44,11 @@ HashedFolder {
                   "name": "tsconfig.json",
                 },
               ],
-              "hash": "uEz4uMQM0pev7VexNb7uvDHbZVU=",
+              "hash": "BzX+UvVK0zUXkLpsCntzfDazolI=",
               "name": "valid-component-name",
             },
           ],
-          "hash": "bsm7if1Hbegu2sIb0zHctci30vk=",
+          "hash": "sIF+huZEh1B0fntHmUWhbEYpKCg=",
           "name": "components",
         },
         HashedFile {
@@ -74,7 +74,7 @@ HashedFolder {
           "name": "pages",
         },
       ],
-      "hash": "VEf68N3iY/e2+EdbUkz9cU+9zeg=",
+      "hash": "zY9pQwGiDMQNU8rO5dIQi0PfqMM=",
       "name": "src",
     },
     HashedFile {
@@ -86,7 +86,7 @@ HashedFolder {
       "name": "tsconfig.json",
     },
   ],
-  "hash": "4HI/NtMDtJ5KecPhwVvbBlNvli4=",
+  "hash": "TnIk1rs0LHXQFSt46Q4Bob8zLdM=",
   "name": "create-atomic-component",
 }
 `;
@@ -109,7 +109,7 @@ HashedFolder {
             HashedFolder {
               "children": [
                 HashedFile {
-                  "hash": "9wUm7J748WMHhj3HJWuVDXVB6SE=",
+                  "hash": "/ndnQkZFDpjscDW7FBHU2SbJ7MY=",
                   "name": "package.json",
                 },
                 HashedFolder {
@@ -135,11 +135,11 @@ HashedFolder {
                   "name": "tsconfig.json",
                 },
               ],
-              "hash": "wkILSkb35SNYL4UAK3MtV2gLqzo=",
+              "hash": "b+caCoj6Zi9gZLuEx6UbJE8iAnM=",
               "name": "valid-component-name",
             },
           ],
-          "hash": "RXkrkBrtle8mA9QaCptr84qhr0I=",
+          "hash": "M7BjKNRd2P/mpuut4lC42qLJoTo=",
           "name": "components",
         },
         HashedFile {
@@ -165,7 +165,7 @@ HashedFolder {
           "name": "pages",
         },
       ],
-      "hash": "Fz8rzmJ8worrkOvTZAMDDxoY9yE=",
+      "hash": "06vImAC+vG8IEHp+2QUG9ixhR28=",
       "name": "src",
     },
     HashedFile {
@@ -177,7 +177,7 @@ HashedFolder {
       "name": "tsconfig.json",
     },
   ],
-  "hash": "lFrsi7m8wV6FtOBjuOH2enqXDZo=",
+  "hash": "XKsAa9uYbJDPSyYPLyLiA5OKNXk=",
   "name": "create-atomic-result-component",
 }
 `;


### PR DESCRIPTION
<!-- For Coveo Employees only. Fill this section.

CDX-1454

-->

## Proposed changes

When in a CI, you cannot use confirm. This add the possibility of using a default value when in a CI for confirm.

## Testing

- [x] Unit Tests:
<!-- Did you write unit tests for your feature? If not, explains why?  -->
- [x] Functionnal Tests: existing (ish)
