### PR TITLE
feat(cli): deprecate config:set region and environment

### DIFF
--- a/packages/cli-e2e/__tests__/__snapshots__/atomic.specs.ts.snap
+++ b/packages/cli-e2e/__tests__/__snapshots__/atomic.specs.ts.snap
@@ -27,11 +27,11 @@ HashedFolder {
                   "name": "results-manager.tsx",
                 },
                 HashedFile {
-                  "hash": "2WXM24xZscVOUHVUti5Z8stWW2A=",
+                  "hash": "aylWHwQHlU7F0KpZuJopvDi6u/4=",
                   "name": "template-1.html",
                 },
               ],
-              "hash": "HghfGR6Ktv9oQs8WZP2zA+IjlgE=",
+              "hash": "t9fG5B9toXvcybK/ypFbrMJDTao=",
               "name": "results-manager",
             },
             HashedFolder {
@@ -63,7 +63,7 @@ HashedFolder {
               "name": "sample-result-component",
             },
           ],
-          "hash": "ApFF74n5JpLwWNDx/OdGzyfLNlg=",
+          "hash": "pIrl+qNoENInjtVxeEnRQC5X+s4=",
           "name": "components",
         },
         HashedFile {
@@ -104,7 +104,7 @@ HashedFolder {
           "name": "utils",
         },
       ],
-      "hash": "PBxgg8jprlbpGrP2ZWP+y/7lP8A=",
+      "hash": "pBlrdRw5yuMk/S0mFDAUBGrEvMs=",
       "name": "src",
     },
     HashedFile {
@@ -112,7 +112,7 @@ HashedFolder {
       "name": "tsconfig.json",
     },
   ],
-  "hash": "Osl3T0kqmA46szXnCn90VXTERFY=",
+  "hash": "MX8XJmhwXYKcItyHsBvb0tWTjlM=",
   "name": "normalizedDir",
 }
 `;
@@ -153,11 +153,11 @@ HashedFolder {
                   "name": "results-manager.tsx",
                 },
                 HashedFile {
-                  "hash": "xrt7puz0ZnvNnC32f8nDYJHvCcQ=",
+                  "hash": "M9F3lIlTmnV3mnsbtZgfpkfA7fc=",
                   "name": "template-1.html",
                 },
               ],
-              "hash": "kHLkOJ9S2RmK9QsYV4H3vFWRSOY=",
+              "hash": "07o/Hx3M8Lf/E88LFkbIQBseMYA=",
               "name": "results-manager",
             },
             HashedFolder {
@@ -189,7 +189,7 @@ HashedFolder {
               "name": "sample-result-component",
             },
           ],
-          "hash": "wLPpWj43ALvIz9yZsp4BFoMBbow=",
+          "hash": "cLJy/0XAUwc0A3avxtG5LmqNsfo=",
           "name": "components",
         },
         HashedFile {
@@ -230,7 +230,7 @@ HashedFolder {
           "name": "utils",
         },
       ],
-      "hash": "Ef7/8/tJBJSWIiFfltYXzGL2Imw=",
+      "hash": "FJTdsvHKymcS4bWGsVDxdv5+xI0=",
       "name": "src",
     },
     HashedFile {
@@ -238,7 +238,7 @@ HashedFolder {
       "name": "tsconfig.json",
     },
   ],
-  "hash": "ZzuGBPBUSyPMtIrjdtQn/NoDZOE=",
+  "hash": "fXSss5dlkGuizSP8OXlIF3OvP2Q=",
   "name": "normalizedDir",
 }
 `;

--- a/packages/cli/core/src/commands/config/set.ts
+++ b/packages/cli/core/src/commands/config/set.ts
@@ -1,30 +1,18 @@
 import {CLICommand} from '@coveo/cli-commons/command/cliCommand';
-import {CliUx, Flags} from '@oclif/core';
 import {Config} from '@coveo/cli-commons/config/config';
-import {AuthenticatedClient} from '@coveo/cli-commons/platform/authenticatedClient';
-import {
-  IsAuthenticated,
-  Preconditions,
-} from '@coveo/cli-commons/preconditions/index';
-import {Trackable} from '@coveo/cli-commons/preconditions/trackable';
-import {InvalidCommandError} from '../../lib/errors/InvalidCommandError';
 import {ConfigRenderer} from '@coveo/cli-commons/config/configRenderer';
+import {Before} from '@coveo/cli-commons/decorators/before';
+import {AuthenticatedClient} from '@coveo/cli-commons/platform/authenticatedClient';
+import {IsAuthenticated} from '@coveo/cli-commons/preconditions/index';
+import {Trackable} from '@coveo/cli-commons/preconditions/trackable';
+import {Flags} from '@oclif/core';
 import type {Example} from '@oclif/core/lib/interfaces';
+import {InvalidCommandError} from '../../lib/errors/InvalidCommandError';
 
 export default class Set extends CLICommand {
   public static description = 'Modify the current Coveo CLI configuration.';
 
   public static flags = {
-    // TODO CDX-1246
-    environment: Flags.string({
-      char: 'e',
-      hidden: true,
-    }),
-    // TODO CDX-1246
-    region: Flags.string({
-      char: 'r',
-      hidden: true,
-    }),
     organization: Flags.string({
       char: 'o',
       description:
@@ -41,15 +29,9 @@ export default class Set extends CLICommand {
   ];
 
   @Trackable()
-  @Preconditions(IsAuthenticated())
+  @Before(IsAuthenticated())
   public async run() {
     const {flags} = await this.parse(Set);
-    // TODO CDX-1246
-    if (flags.environment || flags.region) {
-      CliUx.ux.error(
-        'To connect to a different region or environment, use the `auth:login` command'
-      );
-    }
     if (Object.entries(flags).length === 0) {
       throw new InvalidCommandError('Command should contain at least 1 flag');
     }


### PR DESCRIPTION
https://coveord.atlassian.net/browse/CDX-1246

## Proposed changes

deprecate config:set command flags for region and environment
 
## Breaking changes

BREAKING CHANGE: those flags are no longer supported by the cli and the alternative is to re-execute a login flow with auth:login

This change is part of the effort for the next major release of the CLI (v3)

## Testing

Nop, deleting code.
