### PR TITLE
fix(snapshot): ensure git author is known when committing

### DIFF
--- a/packages/cli-e2e/utils/loginSelectors.ts
+++ b/packages/cli-e2e/utils/loginSelectors.ts
@@ -1,6 +1,6 @@
 export class LoginSelectors {
   public static readonly loginWithOfficeButton =
-    'button[formaction^="/auth/office365"]';
+    'button[formaction^="/auth/oauth2/authorization/microsoft"]';
   public static readonly passwordView = 'div[data-viewid="2"]';
   public static readonly emailView = 'div[data-viewid="1"]';
   public static readonly emailInput = 'input[type="email"]';

--- a/packages/cli/core/src/lib/snapshot/expandedPreviewer/expandedPreviewer.spec.ts
+++ b/packages/cli/core/src/lib/snapshot/expandedPreviewer/expandedPreviewer.spec.ts
@@ -276,7 +276,7 @@ describe('ExpandedPreviewer', () => {
       expect(mockedSpawnProcess).toHaveBeenNthCalledWith(
         2,
         'git',
-        ['add', '.'],
+        ['config', 'user.email', '"cli@coveo.com"'],
         {
           cwd: previewPath,
           stdio: 'ignore',
@@ -285,7 +285,25 @@ describe('ExpandedPreviewer', () => {
       expect(mockedSpawnProcess).toHaveBeenNthCalledWith(
         3,
         'git',
-        ['commit', '--message=someorg currently'],
+        ['config', 'user.name', '"Coveo CLI"'],
+        {
+          cwd: previewPath,
+          stdio: 'ignore',
+        }
+      );
+      expect(mockedSpawnProcess).toHaveBeenNthCalledWith(
+        4,
+        'git',
+        ['add', '.'],
+        {
+          cwd: previewPath,
+          stdio: 'ignore',
+        }
+      );
+      expect(mockedSpawnProcess).toHaveBeenNthCalledWith(
+        5,
+        'git',
+        ['commit', '--message="someorg currently"'],
         {
           cwd: previewPath,
           stdio: 'ignore',

--- a/packages/cli/core/src/lib/snapshot/expandedPreviewer/expandedPreviewer.ts
+++ b/packages/cli/core/src/lib/snapshot/expandedPreviewer/expandedPreviewer.ts
@@ -106,6 +106,14 @@ export class ExpandedPreviewer {
 
   private async initialPreviewCommit(dirPath: string) {
     await spawnProcess('git', ['init'], {cwd: dirPath, stdio: 'ignore'});
+    await spawnProcess('git', ['config', 'user.email', 'cli@coveo.com'], {
+      cwd: dirPath,
+      stdio: 'ignore',
+    });
+    await spawnProcess('git', ['config', 'user.name', 'Coveo CLI'], {
+      cwd: dirPath,
+      stdio: 'ignore',
+    });
     await spawnProcess('git', ['add', '.'], {cwd: dirPath, stdio: 'ignore'});
     await spawnProcess('git', ['commit', `--message=${this.orgId} currently`], {
       cwd: dirPath,


### PR DESCRIPTION
https://coveord.atlassian.net/browse/CDX-1505

## Proposed changes

Use a local git user when doing a commit for the expanded preview.



## Breaking changes

<!--
    Remove this section if the PR does not include any breaking change

    If your changes includes some breaking changes in the code, thoroughly explains:
        - What are the breaking changes programmatically speaking.
        - What is the impact on the end-user (e.g. user cannot do X anymore).
        - What motivates those changes.
-->

## Testing

- [x] Unit Tests:
- [x] Manual Tests:
  - Setup a containerized enviro with Ubuntu 22 LTS.
  - Install Node 20 LTS
  - Install the CLI with `npm`: `npm i -g @coveo/cli`
  - Run this:
  ```coveo auth:login or whatever to auth
  coveo org:create foobar
  mkdir testdir
  cd testdir
  coveo org:resources:pull
  coveo org:resources:push
  ```
  
  - Assert error
  - Modify `~/.nvm/versions/node/v20.10.0/lib/node_modules/@coveo/cli/lib/lib/snapshot/expandedPreviewer/expandedPreviewer.js`
  or wherever is the `expandedPreviewer.js` file to 🐒 patch the `initialPreviewCommit` method:
```patch
    async initialPreviewCommit(dirPath) {
        await (0, process_1.spawnProcess)('git', ['init'], { cwd: dirPath, stdio: 'ignore' });
+       await (0, process_1.spawnProcess)('git', ['config', 'user.email', '"cli@coveo.com"'], {cwd: dirPath, stdio: 'ignore'});
+       await (0, process_1.spawnProcess)('git', ['config', 'user.name', '"Coveo CLI"'], {cwd: dirPath, stdio: 'ignore'});
        await (0, process_1.spawnProcess)('git', ['add', '.'], { cwd: dirPath, stdio: 'ignore' });
        await (0, process_1.spawnProcess)('git', ['commit', `--message=${this.orgId} currently`], {
            cwd: dirPath,
            stdio: 'ignore',
        });
    }
```
  
  - Rerun `coveo org:resources:push`, assert proper execution. 