### PR TITLE
chore(tests): try to fix failing e2e tests by increasing beforeAll timeout

### DIFF
--- a/packages/cli-e2e/__tests__/atomic.specs.ts
+++ b/packages/cli-e2e/__tests__/atomic.specs.ts
@@ -276,7 +276,7 @@ describe('ui:create:atomic', () => {
               'atomic-server-valid'
             );
             await waitForAppRunning(appTerminal);
-          }, 5 * 60e3);
+          }, 10 * 60e3);
 
           beforeEach(async () => {
             consoleInterceptor = new BrowserConsoleInterceptor(


### PR DESCRIPTION
<!-- For Coveo Employees only. Fill this section.

KIT-2972

-->

## Proposed changes

There are a couple of e2e tests in the atomic spec that keep failing at the same spot, namely in the `beforeAll` at `when using an existing pageId (--pageId flag specified)` > `when the project is configured correctly`.

I’ve already verified that running the same command locally against the stg org / pageId used in the test works, so that should not be the issue.

The test fails with a timeout, so maybe increasing it will solve the issue.