### PR TITLE
chore: update matcher w/ lazy

### DIFF
--- a/scripts/oclifArtifactMatchers.mjs
+++ b/scripts/oclifArtifactMatchers.mjs
@@ -1,6 +1,6 @@
 export const binariesMatcher =
-  /^coveo[_-]{1}(?<version>v?\d+\.\d+\.\d+(-\d+)?)[_.-]{1}(?<commitSHA>\w+)[_-]?(\d+_)?(?<longExt>.*\.(exe|deb|pkg))$/;
+  /^coveo[_-]{1}(?<version>v?\d+\.\d+\.\d+(-\d+)*?)[_.-]{1}(?<commitSHA>\w+)[_-]?(\d+_)?(?<longExt>.*\.(exe|deb|pkg))$/;
 export const manifestMatcher =
-  /^coveo-(?<version>v?\d+\.\d+\.\d+(-\d+)?)-(?<commitSHA>\w+)-(?<targetSignature>.*-buildmanifest)$/;
+  /^coveo-(?<version>v?\d+\.\d+\.\d+(-\d+)*?)-(?<commitSHA>\w+)-(?<targetSignature>.*-buildmanifest)$/;
 export const tarballMatcher =
-  /^coveo-v?(?<version>\d+\.\d+\.\d+(-\d+)?)-(?<commitSHA>\w+)-(?<targetSignature>[\w-]+).tar\.[gx]z$/;
+  /^coveo-v?(?<version>\d+\.\d+\.\d+(-\d+)*?)-(?<commitSHA>\w+)-(?<targetSignature>[\w-]+).tar\.[gx]z$/;


### PR DESCRIPTION
<!-- For Coveo Employees only. Fill this section.

CDX-764

-->

## Proposed changes

`coveo-v3.2.0-94146122-arm64.pkg` will not match properly:
the commitSHA (9416122) will be gobbled by the version matcher.
This solves that by making the prerelease part of the version matcher 'lazy' so that the semver take priority over.