### PR TITLE
chore: enforce bash for `get-cli-version` step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -323,6 +323,7 @@ jobs:
               printf "CLI_VERSION="
               cat packages/cli/core/package.json | jq -r '.version'
           }  >> "$GITHUB_ENV"
+        shell: bash
       - name: Build
         run: npm run build
       - name: Setup Temporary Keychain


### PR DESCRIPTION
<!-- For Coveo Employees only. Fill this section.

CDX-764

-->

## Proposed changes

Windows seems to not manage to run the script anymore (or it didn't work for a while and we missed it).
This fixes that by ensuring/enforcing the execution of the step on `bash`.