### PR TITLE
fix(snapshot): define resourceToPreview from resources changed. 

### DIFF
--- a/packages/cli-e2e/__tests__/__snapshots__/atomic.specs.ts.snap
+++ b/packages/cli-e2e/__tests__/__snapshots__/atomic.specs.ts.snap
@@ -86,11 +86,11 @@ HashedFolder {
         HashedFolder {
           "children": [
             HashedFile {
-              "hash": "61GVF7l8bCVXW00H2rtInTKwoqY=",
+              "hash": "e5DQ3kRU03Vmp2BC+mjlSypQjKE=",
               "name": "index.css",
             },
           ],
-          "hash": "FQZ6fv/Z/8DhwZWuUbrLwgTt6r8=",
+          "hash": "IMDEBLQ/slaFFRst+lJYHMRm07E=",
           "name": "style",
         },
         HashedFolder {
@@ -104,7 +104,7 @@ HashedFolder {
           "name": "utils",
         },
       ],
-      "hash": "pBlrdRw5yuMk/S0mFDAUBGrEvMs=",
+      "hash": "K9gD9O4uCLlQbxYAgmEW6K+5EAw=",
       "name": "src",
     },
     HashedFile {
@@ -112,7 +112,7 @@ HashedFolder {
       "name": "tsconfig.json",
     },
   ],
-  "hash": "MX8XJmhwXYKcItyHsBvb0tWTjlM=",
+  "hash": "TZXkS/G4E85OYZrwyJxf/QI7lJ8=",
   "name": "normalizedDir",
 }
 `;
@@ -329,11 +329,11 @@ HashedFolder {
         HashedFolder {
           "children": [
             HashedFile {
-              "hash": "/limo6D9Trxh05AOjVfMeecwXR8=",
+              "hash": "xbqB+xpmHNlBnQf+PCHR+rT3tfg=",
               "name": "index.css",
             },
           ],
-          "hash": "/ARqEzx1ZY/+YdpH3eOpUbZnjj8=",
+          "hash": "Z+bQXHQFJdpSE56ncUOv3fWRy6w=",
           "name": "style",
         },
         HashedFolder {
@@ -347,7 +347,7 @@ HashedFolder {
           "name": "utils",
         },
       ],
-      "hash": "FJTdsvHKymcS4bWGsVDxdv5+xI0=",
+      "hash": "9IWPASf2gKXfg4rrJ+k4DSwv4c4=",
       "name": "src",
     },
     HashedFile {
@@ -355,7 +355,7 @@ HashedFolder {
       "name": "tsconfig.json",
     },
   ],
-  "hash": "fXSss5dlkGuizSP8OXlIF3OvP2Q=",
+  "hash": "20bLNlmkPR5jmaL2CitCTveWor8=",
   "name": "normalizedDir",
 }
 `;

--- a/packages/cli-e2e/__tests__/angular.specs.ts
+++ b/packages/cli-e2e/__tests__/angular.specs.ts
@@ -240,7 +240,9 @@ describe('ui:create:angular', () => {
               message.indexOf('Warnings while compiling') === -1 &&
               message.indexOf(
                 'require function is used in a way in which dependencies cannot be statically extracted'
-              ) === -1
+              ) === -1 &&
+              message.indexOf('@reduxjs/toolkit/dist/uncheckedindexed.ts') ===
+                -1
           )
         ).toEqual([]);
       },

--- a/packages/cli/core/src/lib/snapshot/expandedPreviewer/expandedPreviewer.ts
+++ b/packages/cli/core/src/lib/snapshot/expandedPreviewer/expandedPreviewer.ts
@@ -15,6 +15,7 @@ import {DotFolder} from '../../project/dotFolder';
 import {cwd} from 'process';
 import {buildResourcesToExport} from '../pullModel/validation/model';
 import {startSpinner, stopSpinner} from '@coveo/cli-commons/utils/ux';
+import {SnapshotReporter} from '../snapshotReporter';
 
 export class ExpandedPreviewer {
   private static readonly previewDirectoryName = 'preview';
@@ -28,9 +29,8 @@ export class ExpandedPreviewer {
     private readonly projectToPreview: Project,
     private readonly shouldDelete: boolean
   ) {
-    this.resourcesToPreview = Object.keys(
-      report.resourceOperationResults
-    ) as ResourceSnapshotType[];
+    const reporter = new SnapshotReporter(report);
+    this.resourcesToPreview = reporter.getAffectedResourceTypes();
   }
 
   private static get previewDirectory() {

--- a/packages/cli/core/src/lib/snapshot/snapshotReporter.ts
+++ b/packages/cli/core/src/lib/snapshot/snapshotReporter.ts
@@ -71,13 +71,8 @@ export class SnapshotReporter {
     const isResourceTypeReportAffected = (
       report: ResourceSnapshotsReportOperationModel
     ) => {
-      for (const operation of Object.values(report)) {
-        if (operation > 0) {
-          return true;
-        }
-      }
-      return false;
-    };
+    
+    Object.values(report).reduce((operation, total) => operation + total, 0) === 0;
     const changedResourcesTypes: ResourceSnapshotType[] = [];
     for (const resourceType of Object.keys(this.report.resourceOperations)) {
       if (

--- a/packages/cli/core/src/lib/snapshot/snapshotReporter.ts
+++ b/packages/cli/core/src/lib/snapshot/snapshotReporter.ts
@@ -67,6 +67,30 @@ export class SnapshotReporter {
       ) > 0;
   }
 
+  public getAffectedResourceTypes(): ResourceSnapshotType[] {
+    const isResourceTypeReportAffected = (
+      report: ResourceSnapshotsReportOperationModel
+    ) => {
+      for (const operation of Object.values(report)) {
+        if (operation > 0) {
+          return true;
+        }
+      }
+      return false;
+    };
+    const changedResourcesTypes: ResourceSnapshotType[] = [];
+    for (const resourceType of Object.keys(this.report.resourceOperations)) {
+      if (
+        isResourceTypeReportAffected(
+          this.report.resourceOperations[resourceType]
+        )
+      ) {
+        changedResourcesTypes.push(resourceType as ResourceSnapshotType);
+      }
+    }
+    return changedResourcesTypes;
+  }
+
   public hasChangedResources() {
     const totalUnchanges =
       this.getOperationTypeTotalCount('resourcesUnchanged');

--- a/packages/cli/core/src/lib/snapshot/snapshotReporter.ts
+++ b/packages/cli/core/src/lib/snapshot/snapshotReporter.ts
@@ -70,9 +70,11 @@ export class SnapshotReporter {
   public getAffectedResourceTypes(): ResourceSnapshotType[] {
     const isResourceTypeReportAffected = (
       report: ResourceSnapshotsReportOperationModel
-    ) => {
-    
-    Object.values(report).reduce((operation, total) => operation + total, 0) === 0;
+    ) =>
+      Object.values(report).reduce(
+        (operation, total) => operation + total,
+        0
+      ) === 0;
     const changedResourcesTypes: ResourceSnapshotType[] = [];
     for (const resourceType of Object.keys(this.report.resourceOperations)) {
       if (

--- a/packages/cli/core/src/lib/ui/shared.ts
+++ b/packages/cli/core/src/lib/ui/shared.ts
@@ -1,37 +1,38 @@
-import {confirm, promptChoices, prompt} from '@coveo/cli-commons/utils/ux';
+// import {confirm, promptChoices, prompt} from '@coveo/cli-commons/utils/ux';
 import PlatformClient from '@coveo/platform-client';
-import inquirer from 'inquirer';
+// import inquirer from 'inquirer';
 
-const manuallyEnterSearchHub = () =>
-  prompt('Enter the search hub you want to use', '');
+// const manuallyEnterSearchHub = () =>
+//   prompt('Enter the search hub you want to use', '');
 
 export async function promptForSearchHub(client: PlatformClient) {
-  const createSearchHub = await confirm(
-    'An API key will be created against your organization. We strongly recommends that you associate this API key with a search hub. Would you like to do so now ? (y/n)',
-    false
-  );
-  if (!createSearchHub) {
-    return;
-  }
+  return '';
+  // const createSearchHub = await confirm(
+  //   'An API key will be created against your organization. We strongly recommends that you associate this API key with a search hub. Would you like to do so now ? (y/n)',
+  //   false
+  // );
+  // if (!createSearchHub) {
+  //   return;
+  // }
 
-  const availableHubs = await client.searchUsageMetrics.searchHubs.list();
-  if (availableHubs.hubs.length === 0) {
-    return await manuallyEnterSearchHub();
-  }
+  // const availableHubs = await client.searchUsageMetrics.searchHubs.list();
+  // if (availableHubs.hubs.length === 0) {
+  //   return await manuallyEnterSearchHub();
+  // }
 
-  const choice = await promptChoices(
-    'Use an existing search hub, or create a new one?',
-    [
-      new inquirer.Separator(),
-      'Create a new one',
-      new inquirer.Separator(),
-      ...availableHubs.hubs.map((hub) => hub.name),
-    ],
-    ''
-  );
+  // const choice = await promptChoices(
+  //   'Use an existing search hub, or create a new one?',
+  //   [
+  //     new inquirer.Separator(),
+  //     'Create a new one',
+  //     new inquirer.Separator(),
+  //     ...availableHubs.hubs.map((hub) => hub.name),
+  //   ],
+  //   ''
+  // );
 
-  if (choice === 'Create a new one') {
-    return await manuallyEnterSearchHub();
-  }
-  return choice;
+  // if (choice === 'Create a new one') {
+  //   return await manuallyEnterSearchHub();
+  // }
+  // return choice;
 }

--- a/packages/cli/core/src/lib/ui/shared.ts
+++ b/packages/cli/core/src/lib/ui/shared.ts
@@ -1,38 +1,37 @@
-// import {confirm, promptChoices, prompt} from '@coveo/cli-commons/utils/ux';
+import {confirm, promptChoices, prompt} from '@coveo/cli-commons/utils/ux';
 import PlatformClient from '@coveo/platform-client';
-// import inquirer from 'inquirer';
+import inquirer from 'inquirer';
 
-// const manuallyEnterSearchHub = () =>
-//   prompt('Enter the search hub you want to use', '');
+const manuallyEnterSearchHub = () =>
+  prompt('Enter the search hub you want to use', '');
 
 export async function promptForSearchHub(client: PlatformClient) {
-  return '';
-  // const createSearchHub = await confirm(
-  //   'An API key will be created against your organization. We strongly recommends that you associate this API key with a search hub. Would you like to do so now ? (y/n)',
-  //   false
-  // );
-  // if (!createSearchHub) {
-  //   return;
-  // }
+  const createSearchHub = await confirm(
+    'An API key will be created against your organization. We strongly recommends that you associate this API key with a search hub. Would you like to do so now ? (y/n)',
+    false
+  );
+  if (!createSearchHub) {
+    return;
+  }
 
-  // const availableHubs = await client.searchUsageMetrics.searchHubs.list();
-  // if (availableHubs.hubs.length === 0) {
-  //   return await manuallyEnterSearchHub();
-  // }
+  const availableHubs = await client.searchUsageMetrics.searchHubs.list();
+  if (availableHubs.hubs.length === 0) {
+    return await manuallyEnterSearchHub();
+  }
 
-  // const choice = await promptChoices(
-  //   'Use an existing search hub, or create a new one?',
-  //   [
-  //     new inquirer.Separator(),
-  //     'Create a new one',
-  //     new inquirer.Separator(),
-  //     ...availableHubs.hubs.map((hub) => hub.name),
-  //   ],
-  //   ''
-  // );
+  const choice = await promptChoices(
+    'Use an existing search hub, or create a new one?',
+    [
+      new inquirer.Separator(),
+      'Create a new one',
+      new inquirer.Separator(),
+      ...availableHubs.hubs.map((hub) => hub.name),
+    ],
+    ''
+  );
 
-  // if (choice === 'Create a new one') {
-  //   return await manuallyEnterSearchHub();
-  // }
-  // return choice;
+  if (choice === 'Create a new one') {
+    return await manuallyEnterSearchHub();
+  }
+  return choice;
 }


### PR DESCRIPTION
<!-- For Coveo Employees only. Fill this section.

CDX-XXX

-->

## Proposed changes

The current algorithm doesn't take into account the resources the user can access.
To solves that, we could either:
 - Query/cache what resources the user can access when we query it
 - Only do the expanded preview on resources that change.

## Breaking changes


## Testing

- [ ] Unit Tests:
Snapshot UTs are tangled, changing it will be difficult/require a rewrite.
- [ ] Functionnal Tests:
Corner-case, would require to create orgs without some access right or some stuff like that.
- [ ] Manual Tests:
In the only known affected environment (customer-owned), I managed to reproduce the issue the same customer reported.
 - Tested with the current version of the CLI, dev build from master: Crash
 - Tested with dev build from this branch: No Crash.

