### PR TITLE
feat(cli): support apikey for ui:deploy

### DIFF
--- a/packages/cli/core/src/commands/ui/deploy.spec.ts
+++ b/packages/cli/core/src/commands/ui/deploy.spec.ts
@@ -197,18 +197,6 @@ describe('ui:deploy', () => {
   describe('when preconditions are not respected', () => {
     test
       .do(() => {
-        preconditionStatus.apiKey = false;
-      })
-      .stdout()
-      .stderr()
-      .command(['ui:deploy'])
-      .catch(/apiKey Precondition Error/)
-      .it(
-        'should not execute the command if the API key preconditions are not respected'
-      );
-
-    test
-      .do(() => {
         preconditionStatus.authentication = false;
       })
       .stdout()

--- a/packages/cli/core/src/commands/ui/deploy.ts
+++ b/packages/cli/core/src/commands/ui/deploy.ts
@@ -156,7 +156,7 @@ export default class Deploy extends CLICommand {
 
   @Trackable()
   @Preconditions(
-    IsAuthenticated([AuthenticationType.OAuth]),
+    IsAuthenticated([AuthenticationType.OAuth, AuthenticationType.ApiKey]),
     HasNecessaryCoveoPrivileges(createSearchPagesPrivilege)
   )
   public async run() {


### PR DESCRIPTION
<!-- For Coveo Employees only. Fill this section.

CDX-1449
-->

## Proposed changes

- Allow users to authenticate using API key to deploy their pages.

## Testing

- [x] Unit Tests: existing tests was testing for failure.
<!-- Did you write unit tests for your feature? If not, explains why?  -->
- [ ] Functionnal Tests:
<!-- Did you write functionnal tests for your feature? If not, explains why?  -->
- [x] Manual Tests: `@coveo/cli@3.3.4-baguette.0` was tested in both a local terminal and a CI by @jfallaire.