### PR TITLE
fix(cli): org:search:dump issues when dump is fetched across multiple queries

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "@actions/github": "5.1.1",
         "@commitlint/config-conventional": "17.6.1",
         "@commitlint/lint": "17.6.1",
-        "@coveo/platform-client": "52.1.0",
+        "@coveo/platform-client": "54.9.3",
         "@coveo/semantic-monorepo-tools": "2.4.28",
         "@coveord/release": "1.0.0",
         "@npmcli/arborist": "6.2.8",
@@ -2711,13 +2711,24 @@
       "integrity": "sha512-7jiRWgN4/8IdvCxbIwnwg2W0bbYFBH6BxFqBjMKk442t7+liF2Z1H6AUCcl8e/pD93GjPru+axeiJwFmRww1WQ=="
     },
     "node_modules/@coveo/platform-client": {
-      "version": "52.1.0",
-      "resolved": "https://registry.npmjs.org/@coveo/platform-client/-/platform-client-52.1.0.tgz",
-      "integrity": "sha512-uLmfUvVYUfD7m4prTmC7ZgXnSXULqMq8gw2LCo/d+KiYU3tuHkdZsiienttLGjFrbcUw05AiNiMaZOzi5Va4lA==",
+      "version": "54.9.3",
+      "resolved": "https://registry.npmjs.org/@coveo/platform-client/-/platform-client-54.9.3.tgz",
+      "integrity": "sha512-cKt1VyVSAidCiRHtQ8kA9JCny3571J2jNbovA5vfHnnROxiHcDngHpwmRhdTtKNPckTvpbCgMnCfjU/YthaBxA==",
       "dependencies": {
+        "core-js": "^3.37.1",
         "exponential-backoff": "^3.1.0",
         "query-string-cjs": "npm:query-string@^7.0.0",
-        "query-string-esm": "npm:query-string@^8.0.0"
+        "query-string-esm": "npm:query-string@^9.0.0"
+      }
+    },
+    "node_modules/@coveo/platform-client/node_modules/core-js": {
+      "version": "3.37.1",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.37.1.tgz",
+      "integrity": "sha512-Xn6qmxrQZyB0FFY8E3bgRXei3lWDJHhvI+u0q9TKIYM49G8pAr0FgnnrFRAmsbptZL1yxRADVXn+x5AGsbBfyw==",
+      "hasInstallScript": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
       }
     },
     "node_modules/@coveo/process-helpers": {
@@ -2748,6 +2759,63 @@
       "version": "0.45.6",
       "resolved": "https://registry.npmjs.org/@coveo/bueno/-/bueno-0.45.6.tgz",
       "integrity": "sha512-OPYN3pqw6ON7X1EYbCxRWcGBt9gjeOHDj9VVnL8YtD/nzozphTw2nYV9yf7OxfgUOYCiV2IvSXLHSA+tftQW2Q=="
+    },
+    "node_modules/@coveo/push-api-client/node_modules/@coveo/platform-client": {
+      "version": "52.6.1",
+      "resolved": "https://registry.npmjs.org/@coveo/platform-client/-/platform-client-52.6.1.tgz",
+      "integrity": "sha512-AyuoypQalnqQQMaqc7P2TgjWGCxHGAqU1NSh7UQNdFaqqjxg3ZEe2qo1hTcAB4atONcMlpijLf1OLyzkY3fdpA==",
+      "dependencies": {
+        "exponential-backoff": "^3.1.0",
+        "query-string-cjs": "npm:query-string@^7.0.0",
+        "query-string-esm": "npm:query-string@^8.0.0"
+      }
+    },
+    "node_modules/@coveo/push-api-client/node_modules/decode-uri-component": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.4.1.tgz",
+      "integrity": "sha512-+8VxcR21HhTy8nOt6jf20w0c9CADrw1O8d+VZ/YzzCt4bJ3uBjw+D1q2osAB8RnpwwaeYBxy0HyKQxD5JBMuuQ==",
+      "engines": {
+        "node": ">=14.16"
+      }
+    },
+    "node_modules/@coveo/push-api-client/node_modules/filter-obj": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/filter-obj/-/filter-obj-5.1.0.tgz",
+      "integrity": "sha512-qWeTREPoT7I0bifpPUXtxkZJ1XJzxWtfoWWkdVGqa+eCr3SHW/Ocp89o8vLvbUuQnadybJpjOKu4V+RwO6sGng==",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@coveo/push-api-client/node_modules/query-string-esm": {
+      "name": "query-string",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-8.2.0.tgz",
+      "integrity": "sha512-tUZIw8J0CawM5wyGBiDOAp7ObdRQh4uBor/fUR9ZjmbZVvw95OD9If4w3MQxr99rg0DJZ/9CIORcpEqU5hQG7g==",
+      "dependencies": {
+        "decode-uri-component": "^0.4.1",
+        "filter-obj": "^5.1.0",
+        "split-on-first": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@coveo/push-api-client/node_modules/split-on-first": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/split-on-first/-/split-on-first-3.0.0.tgz",
+      "integrity": "sha512-qxQJTx2ryR0Dw0ITYyekNQWpz6f8dGd7vffGNflQQ3Iqj9NJ6qiZ7ELpZsJ/QBhIVAiDfXdag3+Gp8RvWa62AA==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/@coveo/relay": {
       "version": "0.7.4",
@@ -24734,16 +24802,16 @@
     },
     "node_modules/query-string-esm": {
       "name": "query-string",
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/query-string/-/query-string-8.1.0.tgz",
-      "integrity": "sha512-BFQeWxJOZxZGix7y+SByG3F36dA0AbTy9o6pSmKFcFz7DAj0re9Frkty3saBn3nHo3D0oZJ/+rx3r8H8r8Jbpw==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-9.0.0.tgz",
+      "integrity": "sha512-4EWwcRGsO2H+yzq6ddHcVqkCQ2EFUSfDMEjF8ryp8ReymyZhIuaFRGLomeOQLkrzacMHoyky2HW0Qe30UbzkKw==",
       "dependencies": {
         "decode-uri-component": "^0.4.1",
         "filter-obj": "^5.1.0",
         "split-on-first": "^3.0.0"
       },
       "engines": {
-        "node": ">=14.16"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -30410,7 +30478,7 @@
         "@babel/preset-env": "7.21.5",
         "@babel/preset-typescript": "7.21.5",
         "@coveo/cli": "3.2.6",
-        "@coveo/platform-client": "52.1.0",
+        "@coveo/platform-client": "54.9.3",
         "abortcontroller-polyfill": "1.7.5",
         "async-retry": "1.3.3",
         "babel-jest": "29.5.0",
@@ -30457,7 +30525,7 @@
       "dependencies": {
         "@amplitude/analytics-node": "^1.3.3",
         "@amplitude/analytics-types": "^2.1.2",
-        "@coveo/platform-client": "52.1.0",
+        "@coveo/platform-client": "54.9.3",
         "@oclif/core": "1.24.0",
         "abortcontroller-polyfill": "1.7.5",
         "chalk": "4.1.2",
@@ -30518,7 +30586,7 @@
         "@amplitude/identify": "^1.9.0",
         "@coveo/cli-commons": "2.9.3",
         "@coveo/cli-plugin-source": "2.3.3",
-        "@coveo/platform-client": "52.1.0",
+        "@coveo/platform-client": "54.9.3",
         "@oclif/core": "1.24.0",
         "@oclif/plugin-help": "5.1.23",
         "@oclif/plugin-plugins": "2.1.12",
@@ -30621,7 +30689,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@coveo/cli-commons": "2.9.3",
-        "@coveo/platform-client": "52.1.0",
+        "@coveo/platform-client": "54.9.3",
         "@coveo/push-api-client": "4.0.1",
         "@oclif/core": "1.24.0",
         "@oclif/plugin-help": "5.1.23",
@@ -30687,7 +30755,7 @@
       "version": "1.40.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@coveo/platform-client": "52.1.0",
+        "@coveo/platform-client": "54.9.3",
         "abortcontroller-polyfill": "1.7.5",
         "detect-indent": "7.0.1",
         "https-proxy-agent": "5.0.1",
@@ -31542,6 +31610,63 @@
         "ts-jest": "29.1.0"
       }
     },
+    "packages/ui/search-token-server/node_modules/@coveo/platform-client": {
+      "version": "52.1.0",
+      "resolved": "https://registry.npmjs.org/@coveo/platform-client/-/platform-client-52.1.0.tgz",
+      "integrity": "sha512-uLmfUvVYUfD7m4prTmC7ZgXnSXULqMq8gw2LCo/d+KiYU3tuHkdZsiienttLGjFrbcUw05AiNiMaZOzi5Va4lA==",
+      "dependencies": {
+        "exponential-backoff": "^3.1.0",
+        "query-string-cjs": "npm:query-string@^7.0.0",
+        "query-string-esm": "npm:query-string@^8.0.0"
+      }
+    },
+    "packages/ui/search-token-server/node_modules/decode-uri-component": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.4.1.tgz",
+      "integrity": "sha512-+8VxcR21HhTy8nOt6jf20w0c9CADrw1O8d+VZ/YzzCt4bJ3uBjw+D1q2osAB8RnpwwaeYBxy0HyKQxD5JBMuuQ==",
+      "engines": {
+        "node": ">=14.16"
+      }
+    },
+    "packages/ui/search-token-server/node_modules/filter-obj": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/filter-obj/-/filter-obj-5.1.0.tgz",
+      "integrity": "sha512-qWeTREPoT7I0bifpPUXtxkZJ1XJzxWtfoWWkdVGqa+eCr3SHW/Ocp89o8vLvbUuQnadybJpjOKu4V+RwO6sGng==",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/ui/search-token-server/node_modules/query-string-esm": {
+      "name": "query-string",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-8.2.0.tgz",
+      "integrity": "sha512-tUZIw8J0CawM5wyGBiDOAp7ObdRQh4uBor/fUR9ZjmbZVvw95OD9If4w3MQxr99rg0DJZ/9CIORcpEqU5hQG7g==",
+      "dependencies": {
+        "decode-uri-component": "^0.4.1",
+        "filter-obj": "^5.1.0",
+        "split-on-first": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/ui/search-token-server/node_modules/split-on-first": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/split-on-first/-/split-on-first-3.0.0.tgz",
+      "integrity": "sha512-qxQJTx2ryR0Dw0ITYyekNQWpz6f8dGd7vffGNflQQ3Iqj9NJ6qiZ7ELpZsJ/QBhIVAiDfXdag3+Gp8RvWa62AA==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "packages/ui/vue/create-headless-vue": {
       "name": "@coveo/create-headless-vue",
       "version": "1.4.0",
@@ -31576,7 +31701,7 @@
         "zod": "^3.19.1"
       },
       "devDependencies": {
-        "@coveo/platform-client": "^52.1.0",
+        "@coveo/platform-client": "54.9.3",
         "@rushstack/eslint-patch": "^1.1.4",
         "@types/node": "18.16.3",
         "@vitejs/plugin-vue": "^4.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -30461,6 +30461,7 @@
         "@oclif/core": "1.24.0",
         "abortcontroller-polyfill": "1.7.5",
         "chalk": "4.1.2",
+        "core-js": "^3.37.1",
         "fs-extra": "11.1.1",
         "https-proxy-agent": "5.0.1",
         "is-ci": "3.0.1",
@@ -30498,6 +30499,16 @@
       "resolved": "https://registry.npmjs.org/@amplitude/analytics-types/-/analytics-types-2.1.2.tgz",
       "integrity": "sha512-ASKwH9g+5gglTHr7h7miK8J/ofIzuEtGRDCjnZAtRbE6+laoOfCLYPPJXMYz0k1x+rIhLO/6I6WWjT7zchmpyA=="
     },
+    "packages/cli/commons/node_modules/core-js": {
+      "version": "3.37.1",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.37.1.tgz",
+      "integrity": "sha512-Xn6qmxrQZyB0FFY8E3bgRXei3lWDJHhvI+u0q9TKIYM49G8pAr0FgnnrFRAmsbptZL1yxRADVXn+x5AGsbBfyw==",
+      "hasInstallScript": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
     "packages/cli/commons/node_modules/is-ci": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-3.0.1.tgz",
@@ -30507,6 +30518,19 @@
       },
       "bin": {
         "is-ci": "bin.js"
+      }
+    },
+    "packages/cli/commons/node_modules/typescript": {
+      "version": "5.4.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
+      "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "packages/cli/core": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -30461,7 +30461,6 @@
         "@oclif/core": "1.24.0",
         "abortcontroller-polyfill": "1.7.5",
         "chalk": "4.1.2",
-        "core-js": "^3.37.1",
         "fs-extra": "11.1.1",
         "https-proxy-agent": "5.0.1",
         "is-ci": "3.0.1",
@@ -30499,16 +30498,6 @@
       "resolved": "https://registry.npmjs.org/@amplitude/analytics-types/-/analytics-types-2.1.2.tgz",
       "integrity": "sha512-ASKwH9g+5gglTHr7h7miK8J/ofIzuEtGRDCjnZAtRbE6+laoOfCLYPPJXMYz0k1x+rIhLO/6I6WWjT7zchmpyA=="
     },
-    "packages/cli/commons/node_modules/core-js": {
-      "version": "3.37.1",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.37.1.tgz",
-      "integrity": "sha512-Xn6qmxrQZyB0FFY8E3bgRXei3lWDJHhvI+u0q9TKIYM49G8pAr0FgnnrFRAmsbptZL1yxRADVXn+x5AGsbBfyw==",
-      "hasInstallScript": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/core-js"
-      }
-    },
     "packages/cli/commons/node_modules/is-ci": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-3.0.1.tgz",
@@ -30518,19 +30507,6 @@
       },
       "bin": {
         "is-ci": "bin.js"
-      }
-    },
-    "packages/cli/commons/node_modules/typescript": {
-      "version": "5.4.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
-      "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
-      "dev": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
       }
     },
     "packages/cli/core": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "@actions/github": "5.1.1",
     "@commitlint/config-conventional": "17.6.1",
     "@commitlint/lint": "17.6.1",
-    "@coveo/platform-client": "52.1.0",
+    "@coveo/platform-client": "54.9.3",
     "@coveo/semantic-monorepo-tools": "2.4.28",
     "@coveord/release": "1.0.0",
     "@npmcli/arborist": "6.2.8",

--- a/packages/cli-e2e/package.json
+++ b/packages/cli-e2e/package.json
@@ -62,7 +62,7 @@
     "@babel/preset-env": "7.21.5",
     "@babel/preset-typescript": "7.21.5",
     "@coveo/cli": "3.2.6",
-    "@coveo/platform-client": "52.1.0",
+    "@coveo/platform-client": "54.9.3",
     "abortcontroller-polyfill": "1.7.5",
     "async-retry": "1.3.3",
     "babel-jest": "29.5.0",

--- a/packages/cli/commons/package.json
+++ b/packages/cli/commons/package.json
@@ -30,7 +30,6 @@
     "@oclif/core": "1.24.0",
     "abortcontroller-polyfill": "1.7.5",
     "chalk": "4.1.2",
-    "core-js": "^3.37.1",
     "fs-extra": "11.1.1",
     "https-proxy-agent": "5.0.1",
     "is-ci": "3.0.1",

--- a/packages/cli/commons/package.json
+++ b/packages/cli/commons/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "@amplitude/analytics-node": "^1.3.3",
     "@amplitude/analytics-types": "^2.1.2",
-    "@coveo/platform-client": "52.1.0",
+    "@coveo/platform-client": "54.9.3",
     "@oclif/core": "1.24.0",
     "abortcontroller-polyfill": "1.7.5",
     "chalk": "4.1.2",

--- a/packages/cli/commons/package.json
+++ b/packages/cli/commons/package.json
@@ -30,6 +30,7 @@
     "@oclif/core": "1.24.0",
     "abortcontroller-polyfill": "1.7.5",
     "chalk": "4.1.2",
+    "core-js": "^3.37.1",
     "fs-extra": "11.1.1",
     "https-proxy-agent": "5.0.1",
     "is-ci": "3.0.1",

--- a/packages/cli/commons/src/platform/authenticatedClient.ts
+++ b/packages/cli/commons/src/platform/authenticatedClient.ts
@@ -66,8 +66,8 @@ export class AuthenticatedClient {
               ) => any
             )(content, (key, value, context) => {
               if (
+                key === 'rowid' &&
                 typeof value === 'number' &&
-                Number.isInteger(value) &&
                 !Number.isSafeInteger(value)
               ) {
                 return context.source;

--- a/packages/cli/commons/src/platform/authenticatedClient.ts
+++ b/packages/cli/commons/src/platform/authenticatedClient.ts
@@ -1,11 +1,9 @@
-import 'core-js/actual/json/parse';
 import {setGlobalDispatcher, ProxyAgent, FormData, fetch} from 'undici';
-import PlatformClient, {ResponseHandlers} from '@coveo/platform-client';
+import PlatformClient from '@coveo/platform-client';
 import {Config, Configuration} from '../config/config';
 import {castEnvironmentToPlatformClient} from './environment';
 import globalConfig from '../config/globalConfig';
 import 'fetch-undici-polyfill';
-import {Response} from 'node-fetch';
 
 export class AuthenticatedClient {
   public cfg: Config;
@@ -41,47 +39,12 @@ export class AuthenticatedClient {
     if (!Object.keys(global).includes('FormData')) {
       Object.assign(global, {FormData});
     }
-
     return new PlatformClient({
       globalRequestSettings,
       environment: castEnvironmentToPlatformClient(resolvedConfig.environment),
       region: resolvedConfig.region,
       organizationId: resolvedConfig.organization,
       accessToken: resolvedConfig.accessToken!,
-      responseHandlers: [
-        {
-          canProcess: (response: Response): boolean => {
-            return response.ok;
-          },
-          process: async <T>(response: Response) => {
-            const content = await response.text();
-            return (
-              JSON.parse as (
-                text: string,
-                reviver?: (
-                  key: string,
-                  value: any,
-                  context: {source: any}
-                ) => any | undefined
-              ) => any
-            )(content, (key, value, context) => {
-              if (
-                key === 'rowid' &&
-                typeof value === 'number' &&
-                !Number.isSafeInteger(value)
-              ) {
-                return context.source;
-              }
-              return value;
-            });
-          },
-        },
-        ResponseHandlers.badGateway,
-        ResponseHandlers.blockedByWAF,
-        ResponseHandlers.error,
-        ResponseHandlers.htmlError,
-        ResponseHandlers.noContent,
-      ],
     });
   }
 

--- a/packages/cli/commons/src/platform/authenticatedClient.ts
+++ b/packages/cli/commons/src/platform/authenticatedClient.ts
@@ -42,6 +42,10 @@ export class AuthenticatedClient {
       Object.assign(global, {FormData});
     }
 
+    const {success, ...restOfDefaultResponseHandlers} = ResponseHandlers;
+    const defaultResponseHandlers = Object.values(
+      restOfDefaultResponseHandlers
+    ).map((handler) => handler);
     return new PlatformClient({
       globalRequestSettings,
       environment: castEnvironmentToPlatformClient(resolvedConfig.environment),
@@ -76,11 +80,7 @@ export class AuthenticatedClient {
             });
           },
         },
-        ResponseHandlers.badGateway,
-        ResponseHandlers.blockedByWAF,
-        ResponseHandlers.error,
-        ResponseHandlers.htmlError,
-        ResponseHandlers.noContent,
+        ...defaultResponseHandlers,
       ],
     });
   }

--- a/packages/cli/commons/src/platform/authenticatedClient.ts
+++ b/packages/cli/commons/src/platform/authenticatedClient.ts
@@ -42,10 +42,6 @@ export class AuthenticatedClient {
       Object.assign(global, {FormData});
     }
 
-    const {success, ...restOfDefaultResponseHandlers} = ResponseHandlers;
-    const defaultResponseHandlers = Object.values(
-      restOfDefaultResponseHandlers
-    ).map((handler) => handler);
     return new PlatformClient({
       globalRequestSettings,
       environment: castEnvironmentToPlatformClient(resolvedConfig.environment),
@@ -80,7 +76,11 @@ export class AuthenticatedClient {
             });
           },
         },
-        ...defaultResponseHandlers,
+        ResponseHandlers.badGateway,
+        ResponseHandlers.blockedByWAF,
+        ResponseHandlers.error,
+        ResponseHandlers.htmlError,
+        ResponseHandlers.noContent,
       ],
     });
   }

--- a/packages/cli/commons/src/platform/authenticatedClient.ts
+++ b/packages/cli/commons/src/platform/authenticatedClient.ts
@@ -66,8 +66,8 @@ export class AuthenticatedClient {
               ) => any
             )(content, (key, value, context) => {
               if (
-                key === 'rowid' &&
                 typeof value === 'number' &&
+                Number.isInteger(value) &&
                 !Number.isSafeInteger(value)
               ) {
                 return context.source;

--- a/packages/cli/core/package.json
+++ b/packages/cli/core/package.json
@@ -11,7 +11,7 @@
     "@amplitude/identify": "^1.9.0",
     "@coveo/cli-commons": "2.9.3",
     "@coveo/cli-plugin-source": "2.3.3",
-    "@coveo/platform-client": "52.1.0",
+    "@coveo/platform-client": "54.9.3",
     "@oclif/core": "1.24.0",
     "@oclif/plugin-help": "5.1.23",
     "@oclif/plugin-plugins": "2.1.12",

--- a/packages/cli/core/src/commands/org/search/dump.spec.ts
+++ b/packages/cli/core/src/commands/org/search/dump.spec.ts
@@ -82,6 +82,21 @@ describe('org:search:dump', () => {
     })
     .stdout()
     .stderr()
+    .command(['org:search:dump', '-s', 'the_source_1'])
+    .it('should pass maximumAge 0 as a search parameter', () =>
+      expect(mockedSearch).toHaveBeenCalledWith(
+        expect.objectContaining({
+          maximumAge: 0,
+        })
+      )
+    );
+
+  test
+    .do(() => {
+      mockReturnNumberOfResults(0);
+    })
+    .stdout()
+    .stderr()
     .command(['org:search:dump', '-s', 'the_source'])
     .it('should pass the source as a search filter', () =>
       expect(mockedSearch).toHaveBeenCalledWith(

--- a/packages/cli/core/src/commands/org/search/dump.ts
+++ b/packages/cli/core/src/commands/org/search/dump.ts
@@ -260,6 +260,7 @@ export default class Dump extends CLICommand {
       try {
         const results = (await params.client.search.query({
           aq: this.getFilter(params, rowId),
+          maximumAge: 0,
           debug: true,
           organizationId: params.organizationId,
           numberOfResults: this.numberOfResultPerQuery,

--- a/packages/cli/core/src/commands/org/search/dump.ts
+++ b/packages/cli/core/src/commands/org/search/dump.ts
@@ -260,7 +260,6 @@ export default class Dump extends CLICommand {
       try {
         const results = (await params.client.search.query({
           aq: this.getFilter(params, rowId),
-          maximumAge: 0,
           debug: true,
           organizationId: params.organizationId,
           numberOfResults: this.numberOfResultPerQuery,

--- a/packages/cli/core/src/commands/org/search/dump.ts
+++ b/packages/cli/core/src/commands/org/search/dump.ts
@@ -261,6 +261,7 @@ export default class Dump extends CLICommand {
         const results = (await params.client.search.query({
           aq: this.getFilter(params, rowId),
           debug: true,
+          maximumAge: 0,
           organizationId: params.organizationId,
           numberOfResults: this.numberOfResultPerQuery,
           sortCriteria: '@rowid ascending',

--- a/packages/cli/source/package.json
+++ b/packages/cli/source/package.json
@@ -15,7 +15,7 @@
   ],
   "dependencies": {
     "@coveo/cli-commons": "2.9.3",
-    "@coveo/platform-client": "52.1.0",
+    "@coveo/platform-client": "54.9.3",
     "@coveo/push-api-client": "4.0.1",
     "@oclif/core": "1.24.0",
     "@oclif/plugin-help": "5.1.23",

--- a/packages/ui/atomic/create-atomic/package.json
+++ b/packages/ui/atomic/create-atomic/package.json
@@ -30,7 +30,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@coveo/platform-client": "52.1.0",
+    "@coveo/platform-client": "54.9.3",
     "abortcontroller-polyfill": "1.7.5",
     "detect-indent": "7.0.1",
     "https-proxy-agent": "5.0.1",

--- a/packages/ui/vue/create-headless-vue/template/package.json
+++ b/packages/ui/vue/create-headless-vue/template/package.json
@@ -21,7 +21,7 @@
     "zod": "^3.19.1"
   },
   "devDependencies": {
-    "@coveo/platform-client": "^52.1.0",
+    "@coveo/platform-client": "54.9.3",
     "@rushstack/eslint-patch": "^1.1.4",
     "@types/node": "18.16.3",
     "@vitejs/plugin-vue": "^4.0.0",


### PR DESCRIPTION
<!-- For Coveo Employees only. Fill this section.

KIT-3321

-->

## Proposed changes

**Context:**

The `org:search:dump command` executes queries under the hood. When we execute this command, it's possible that we hit the Search API maximum response size. The likelihood of hitting that limit is increased in the HIPAA environment, as the HIPAA maximum response size is 4x smaller than in PROD.

When the dump is executed across multiple queries, we ensure that results are fetched from the same index by passing the `indexToken` of the initial query to each subsequent queries. This is, by definition, incompatible with using the index cache, as stated in the `indexToken` parameter documentation:

> The Base64 encoded identifier of the index mirror to forward the request to. See also the index parameter.
> If you do not specify an indexToken (or index) value, any index mirror could be used.
> Note: Passing an indexToken (or index) value has no effect when the results of a specific request can be returned from cache (see the maximumAge parameter).

Another issue is that in order to know what result to start from in each subsequent query after the first, we request results to be ordered by ascending `rowid` value, and we request only results whose `rowid` is greater than the `rowid` of the last result returned in the previous query. However, the `rowid` value is returned as a very large integer (greater than the maximum safe integer size JavaScript can handle without losing precision). Therefore, the expression `rowid>ROW_ID_OF_LAST_RESULT` typically behaves like `rowid>=ROW_ID_OF_LAST_RESULT` because JavaScript rounds the `rowid` during the JSON.parse conversion of the response body.

Fix:

- Setting `maximumAge: 0` on every query performed for fetching source dumps trivially addresses the index cache issue.

- Using response handler to the platform client that uses the new `context` parameter of the `JSON.parse` reviver (see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse#parameters) allows us to avoid losing precision when converting rowid values. However, this new parameter is only available from Node 21, so we have to polyfill it for now. **EDIT:** After discussion with the DX team, this change was made directly in the platform-client project. See https://github.com/coveo/platform-client/pull/834.

## Breaking changes

None

## Testing

- [x] Unit Tests: Yes
- [x] Functionnal Tests: No, unit tests are sufficient to ensure that maximumAge is set to 0
- [x] Manual Tests: Tested the `org:search:dump` command locally before / after platform-client update against problematic HIPAA test organization. The duplicate / inconsistent dump result issue is no longer present after the fix.
