### PR TITLE
chore: fallback git-message on empty str

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -288,16 +288,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: macos-latest
-            pack-command: ' macos'
-            for: 'macos install kit'
-          - os: windows-latest
-            pack-command: ' win'
-            for: 'windows install kit'
           - os: ubuntu-20.04
             pack-command: ' deb'
             for: 'linux install kit'
-
     steps:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3
         with:

--- a/utils/release/git-publish-all.mjs
+++ b/utils/release/git-publish-all.mjs
@@ -30,7 +30,7 @@ import {createAppAuth} from '@octokit/auth-app';
 // @ts-ignore no dts is ok.
 import angularChangelogConvention from 'conventional-changelog-angular';
 import {dedent} from 'ts-dedent';
-import {readFileSync, writeFileSync} from 'fs';
+import {readFileSync, writeFileSync, existsSync} from 'fs';
 import {removeWriteAccessRestrictions} from './lock-master.mjs';
 import {spawnSync} from 'child_process';
 
@@ -196,9 +196,11 @@ if (commits.length > 0) {
 updateRootReadme();
 
 // Find all packages that have been released in this release.
-const packagesReleased = readFileSync('.git-message', {
-  encoding: 'utf-8',
-}).trim();
+const packagesReleased = existsSync('.git-message')
+  ? readFileSync('.git-message', {
+      encoding: 'utf-8',
+    }).trim()
+  : '';
 
 // Compile git commit message
 const commitMessage = dedent`


### PR DESCRIPTION
CDX-764
Sometimes we don't have a git-message, this can be an issue.

Moreover, we have issues with macos deployments (and concurrent environment), so let's keep it minimal (we are only interested in the tarball command result)