### PR TITLE
fix: update SourcePushAdd.description

### DIFF
--- a/packages/cli/source/src/commands/source/push/add.ts
+++ b/packages/cli/source/src/commands/source/push/add.ts
@@ -29,7 +29,7 @@ import {AddDisplay} from '../../../lib/addDisplay';
 
 export default class SourcePushAdd extends CLICommand {
   public static description =
-    'Index a JSON document into a Coveo Push source. See https://github.com/coveo/cli/wiki/Pushing-JSON-Files-with-the-Coveo-CLI for more information.';
+    'Index a JSON document into a Coveo Push source. See [Pushing JSON Files with the Coveo CLI](https://github.com/coveo/cli/wiki/Pushing-JSON-Files-with-the-Coveo-CLI) for more information.';
 
   public static flags = {
     ...withFiles(),


### PR DESCRIPTION
Updated string used in https://docs.coveo.com/en/cli/#coveo-sourcepushadd-sourceid and not being rendered properly. See https://github.com/coveo/doc_jekyll-public-site/pull/14390/files#r2439063203