### PR TITLE
fix(cli): update deployment Slack notifications to ops-dxui-deployments

### DIFF
--- a/.deployment.config.json
+++ b/.deployment.config.json
@@ -4,7 +4,7 @@
   "general": {
     "team_jenkins": "searchuibuilds",
     "notifications": {
-      "slack_channels": ["#searchuibuilds"]
+      "slack_channels": ["#ops-dxui-deployments"]
     },
     "environments_order": {
       "sequential": [


### PR DESCRIPTION
## Proposed changes

See [conversation](https://coveo.slack.com/archives/G7HD9P48H/p1783457878841689) and [guidance](https://coveord.atlassian.net/wiki/spaces/IT/pages/6629031971/Slack+Channels#%F0%9F%8F%B7-Channel-naming-conventions)
